### PR TITLE
btree: virtualize page allocation methods

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -428,6 +428,7 @@ TESTSRC = \
   $(TOP)/src/test_thread.c \
   $(TOP)/src/test_vdbecov.c \
   $(TOP)/src/test_vfs.c \
+  $(TOP)/src/test_vfs_custom_page_alloc.c \
   $(TOP)/src/test_windirent.c \
   $(TOP)/src/test_window.c \
   $(TOP)/src/test_wsd.c       \

--- a/Makefile.msc
+++ b/Makefile.msc
@@ -1546,6 +1546,7 @@ TESTSRC = \
   $(TOP)\src\test_thread.c \
   $(TOP)\src\test_vdbecov.c \
   $(TOP)\src\test_vfs.c \
+  $(TOP)\src\test_vfs_custom_page_alloc.c \
   $(TOP)\src\test_windirent.c \
   $(TOP)\src\test_window.c \
   $(TOP)\src\test_wsd.c \

--- a/main.mk
+++ b/main.mk
@@ -354,6 +354,7 @@ TESTSRC = \
   $(TOP)/src/test_thread.c \
   $(TOP)/src/test_vdbecov.c \
   $(TOP)/src/test_vfs.c \
+  $(TOP)/src/test_vfs_custom_page_alloc.c \
   $(TOP)/src/test_windirent.c \
   $(TOP)/src/test_window.c \
   $(TOP)/src/test_wsd.c

--- a/src/btree.c
+++ b/src/btree.c
@@ -2653,6 +2653,11 @@ int sqlite3BtreeOpen(
       sqlite3_mutex_leave(mutexShared);
     }
 #endif
+
+    if ((pVfs->xAllocatePage && !pVfs->xFreePage) || (pVfs->xFreePage && !pVfs->xAllocatePage)) {
+      rc = SQLITE_MISUSE;
+      goto btree_open_out;
+    }
   }
 
 #if !defined(SQLITE_OMIT_SHARED_CACHE) && !defined(SQLITE_OMIT_DISKIO)
@@ -6237,7 +6242,7 @@ int sqlite3BtreePrevious(BtCursor *pCur, int flags){
 ** to nearby if any such page exists.  If eMode is BTALLOC_ANY then there
 ** are no restrictions on which page is returned.
 */
-static int allocateBtreePage(
+static int allocateBtreePageDefaultImpl(
   BtShared *pBt,         /* The btree */
   MemPage **ppPage,      /* Store pointer to the allocated page here */
   Pgno *pPgno,           /* Store the page number here */
@@ -6547,6 +6552,28 @@ end_allocate_page:
   return rc;
 }
 
+static int allocateBtreePage(
+  BtShared *pBt,         /* The btree */
+  MemPage **ppPage,      /* Store pointer to the allocated page here */
+  Pgno *pPgno,           /* Store the page number here */
+  Pgno nearby,           /* Search for a page near this one */
+  u8 eMode               /* BTALLOC_EXACT, BTALLOC_LT, or BTALLOC_ANY */
+){
+  if (pBt->pPager->pVfs->xAllocatePage) {
+    int rc = pBt->pPager->pVfs->xAllocatePage(pBt->pPager->fd, pPgno, eMode);
+    if (rc) return rc;
+    rc = btreeGetUnusedPage(pBt, *pPgno, ppPage, 0);
+    if (rc) return rc;
+    rc = sqlite3PagerWrite((*ppPage)->pDbPage);
+    releasePage(*ppPage);
+    if( rc!=SQLITE_OK ){
+      *ppPage = 0;
+      return rc;
+    }
+  }
+  return allocateBtreePageDefaultImpl(pBt, ppPage, pPgno, nearby, eMode);
+}
+
 /*
 ** This function is used to add page iPage to the database file free-list. 
 ** It is assumed that the page is not already a part of the free-list.
@@ -6559,7 +6586,7 @@ end_allocate_page:
 ** If a pointer to a MemPage object is passed as the second argument,
 ** its reference count is not altered by this function.
 */
-static int freePage2(BtShared *pBt, MemPage *pMemPage, Pgno iPage){
+static int freePageDefaultImpl(BtShared *pBt, MemPage *pMemPage, Pgno iPage){
   MemPage *pTrunk = 0;                /* Free-list trunk page */
   Pgno iTrunk = 0;                    /* Page number of free-list trunk page */ 
   MemPage *pPage1 = pBt->pPage1;      /* Local reference to page 1 */
@@ -6693,6 +6720,14 @@ freepage_out:
   releasePage(pTrunk);
   return rc;
 }
+
+static int freePage2(BtShared *pBt, MemPage *pMemPage, Pgno iPage){
+  if (pBt->pPager->pVfs->xFreePage) {
+    return pBt->pPager->pVfs->xFreePage(pBt->pPager->fd, iPage);
+  }
+  return freePageDefaultImpl(pBt, pMemPage, iPage);
+}
+
 static void freePage(MemPage *pPage, int *pRC){
   if( (*pRC)==SQLITE_OK ){
     *pRC = freePage2(pPage->pBt, pPage, pPage->pgno);
@@ -10726,6 +10761,8 @@ char *sqlite3BtreeIntegrityCheck(
   if( i<=sCheck.nPage ) setPageReferenced(&sCheck, i);
 
   /* Check the integrity of the freelist
+  *  libSQL: makes no sense if xAllocatePage is used, but does no harm,
+  *  and instead just reports that there are no free pages
   */
   if( bCkFreelist ){
     sCheck.zPfx = "Main freelist: ";

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -1435,7 +1435,7 @@ typedef struct sqlite3_api_routines sqlite3_api_routines;
 typedef struct sqlite3_vfs sqlite3_vfs;
 typedef void (*sqlite3_syscall_ptr)(void);
 struct sqlite3_vfs {
-  int iVersion;            /* Structure version number (currently 3) */
+  int iVersion;            /* Structure version number (currently 700 (libSQL)) */
   int szOsFile;            /* Size of subclassed sqlite3_file */
   int mxPathname;          /* Maximum file pathname length */
   sqlite3_vfs *pNext;      /* Next registered VFS */
@@ -1471,6 +1471,23 @@ struct sqlite3_vfs {
   ** New fields may be appended in future versions.  The iVersion
   ** value will increment whenever this happens. 
   */
+
+  /* libSQL extensions:
+  **  - Virtual page allocation
+  **    for use cases where the default freelist becomes a contention point.
+  **    While this is not directly a file system routine, it's logically tightly coupled with VFS
+  **    and is expected to be modified along with providing a custom VFS implementation.
+  **    The new implementations are assumed to not touch the internal page structure, and need to
+  **    implement their own logic for persisting the state (which pages are free, how many of them, etc).
+  **    For improved backward compatibility, these entries can be NULL, in which case the default
+  **    freelist implementation is used to manage free pages.
+  **    Overriding xAllocatePage implies that xFreePage needs to be overridden as well.
+  **
+  **      xAllocatePage:     allocate a new page (default: freelist based on offsets 32, 36)
+  **      xFreePage:         deallocate a page   (default: freelist based on offsets 32, 36)
+  */
+  int (*xAllocatePage)(sqlite3_file* fd, unsigned *pgno, unsigned char mode);
+  int (*xFreePage)(sqlite3_file* fd, unsigned pgno);
 };
 
 /*

--- a/src/test_vfs_custom_page_alloc.c
+++ b/src/test_vfs_custom_page_alloc.c
@@ -1,0 +1,92 @@
+/* libSQL extension
+******************************************************************************
+**
+** This file contains an implementation of a VFS shim which overwrites
+** the page allocation/deallocation mechanisms.
+**
+** USAGE:
+**
+** This source file exports a single symbol which is the name of a
+** function:
+**
+**   int vfsCustomPageAlloc_register(
+**     const char *zTraceName,                                         // Name of the newly constructed VFS
+**     const char *zOldVfsName,                                        // Name of the underlying VFS
+**     int (*xAllocatePage)(sqlite3_file*, unsigned *, unsigned char), // Custom page allocator
+**     int (*xFreePage)(sqlite3_file* fd, unsigned pgno),              // Custom page deallocator
+**     int makeDefault                                                 // Make the new VFS the default
+**   );
+**
+** It can be later used to test whether the custom page allocation/deallocation
+** works properly.
+**
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include "sqlite3.h"
+
+typedef struct vfs_custom_page_alloc_file {
+  sqlite3_file base;        /* Base class.  Must be first */
+  sqlite3_vfs *pRootVfs;    /* The real underlying filesystem */
+  sqlite3_file *pReal;      /* The real underlying file */
+} vfs_custom_page_alloc_file;
+
+/*
+** Return SQLITE_OK on success.  
+**
+** SQLITE_NOMEM is returned in the case of a memory allocation error.
+** SQLITE_NOTFOUND is returned if zOldVfsName does not exist.
+*/
+
+int vfsCustomPageAlloc_register(
+   const char *zName,                                              /* Name of the newly constructed VFS */
+   const char *zOldVfsName,                                        /* Name of the underlying VFS */
+   int (*xAllocatePage)(sqlite3_file*, unsigned *, unsigned char), /* Custom page allocator */
+   int (*xFreePage)(sqlite3_file* fd, unsigned pgno),              /* Custom page deallocator */
+   int makeDefault                                                 /* True to make the new VFS the default */
+){
+  sqlite3_vfs *pNew;
+  sqlite3_vfs *pRoot;
+  int nName;
+  int nByte;
+
+  pRoot = sqlite3_vfs_find(zOldVfsName);
+  if( pRoot==0 ) return SQLITE_NOTFOUND;
+  nName = strlen(zName);
+  nByte = sizeof(*pNew) + sizeof(pRoot) + nName + 1;
+  pNew = sqlite3_malloc( nByte );
+  if( pNew==0 ) return SQLITE_NOMEM;
+  memset(pNew, 0, nByte);
+  pNew->zName = (char*)&pNew[1];
+  memcpy((char*)&pNew[1], zName, nName+1);
+  pNew->iVersion = pRoot->iVersion;
+  pNew->szOsFile = pRoot->szOsFile;
+  pNew->mxPathname = pRoot->mxPathname;
+  pNew->zName = zName;
+  pNew->pAppData = pRoot->pAppData;
+  pNew->xOpen = pRoot->xOpen;
+  pNew->xDelete = pRoot->xDelete;
+  pNew->xAccess = pRoot->xAccess;
+  pNew->xFullPathname = pRoot->xFullPathname;
+  pNew->xDlOpen = pRoot->xDlOpen;
+  pNew->xDlError = pRoot->xDlError;
+  pNew->xDlSym = pRoot->xDlSym;
+  pNew->xDlClose = pRoot->xDlClose;
+  pNew->xRandomness = pRoot->xRandomness;
+  pNew->xSleep = pRoot->xSleep;
+  pNew->xCurrentTime = pRoot->xCurrentTime;
+  pNew->xGetLastError = pRoot->xGetLastError;
+  if( pNew->iVersion>=2 ){
+    pNew->xCurrentTimeInt64 = pRoot->xCurrentTimeInt64;
+    if( pNew->iVersion>=3 ){
+      pNew->xSetSystemCall = pRoot->xSetSystemCall;
+      pNew->xGetSystemCall = pRoot->xGetSystemCall;
+      pNew->xNextSystemCall = pRoot->xNextSystemCall;
+    }
+  }
+  pNew->xAllocatePage = xAllocatePage;
+  pNew->xFreePage = xFreePage;
+
+  return sqlite3_vfs_register(pNew, makeDefault);
+}


### PR DESCRIPTION
This commit abstracts away page allocation methods, originally based on a
simple freelist persisted at offset 32 with its size stored at offset 36 in the
page header. The new code allows redefining the allocation methods. The target
use case is mitigating contention when using an optimistic lock-free storage
layer.

The overridden allocation methods do not assume access to internal SQLite
structures, and should instead implement their own persistence mechanisms.

Fixes #11

TODO:
- [ ] tests based on a custom VFS implementation, making sure that all code assumptions about the contents of offsets 32, 36 still hold
- [ ] tests checking that the interface is foolproof enough, e.g. that it requires both page allocation and deallocation to be overridden, and not just one