### PR TITLE
Virtualize WAL methods

### DIFF
--- a/ext/vwal/vwal.c
+++ b/ext/vwal/vwal.c
@@ -151,6 +151,7 @@ void libsql_register_vwal() {
     .xDb = v_db,
     .xPathnameLen = v_pathname_len,
     .xGetWalPathname = v_get_wal_pathname,
+    .xPreMainDbOpen = NULL,
     .zName = "vwal"
   };
   libsql_wal_methods_register(&methods);

--- a/ext/vwal/vwal.c
+++ b/ext/vwal/vwal.c
@@ -116,6 +116,7 @@ static void v_get_wal_pathname(char *buf, const char *orig, int orig_len) {
 __attribute__((__visibility__("default")))
 void libsql_register_vwal() {
   static libsql_wal_methods methods = {
+    .iVersion = 1,
     .xOpen = v_open,
     .xClose = v_close,
     .xLimit = v_limit,

--- a/ext/vwal/vwal.c
+++ b/ext/vwal/vwal.c
@@ -1,0 +1,157 @@
+#include "sqliteInt.h"
+#include "wal.h"
+
+/*
+** This file contains a stub for implementing one's own WAL routines.
+** Registering a new set of WAL methods can be done through
+** libsql_wal_methods_register(). Later, a registered set can
+** be used by passing its name as a parameter to libsql_open().
+*/
+
+extern int libsql_wal_methods_register(libsql_wal_methods*);
+
+static int v_open(sqlite3_vfs *pVfs, sqlite3_file *pDbFd, const char *zWalName, int bNoShm, i64 mxWalSize, libsql_wal_methods *pMethods, Wal **ppWal) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_close(Wal *wal, sqlite3 *db, int sync_flags, int nBuf, u8 *zBuf) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static void v_limit(Wal *wal, i64 limit) {
+  //TODO: implement
+}
+
+static int v_begin_read_transaction(Wal *wal, int *) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static void v_end_read_transaction(Wal *wal) {
+  //TODO: implement
+}
+
+static int v_find_frame(Wal *wal, Pgno pgno, u32 *frame) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_read_frame(Wal *wal, u32 frame, int nOut, u8 *pOut) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static Pgno v_dbsize(Wal *wal) {
+  //TODO: implement
+  return 0;
+}
+
+static int v_begin_write_transaction(Wal *wal) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_end_write_transaction(Wal *wal) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_undo(Wal *wal, int (*xUndo)(void *, Pgno), void *pUndoCtx) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static void v_savepoint(Wal *wal, u32 *wal_data) {
+  //TODO: implement
+}
+
+static int v_savepoint_undo(Wal *wal, u32 *wal_data) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_frames(Wal *pWal, int szPage, PgHdr *pList, Pgno nTruncate, int isCommit, int sync_flags) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_checkpoint(Wal *wal, sqlite3 *db, int eMode, int (xBusy)(void *), void *pBusyArg, int sync_flags, int nBuf, u8 *zBuf, int *pnLog, int *pnCkpt) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_callback(Wal *wal) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static int v_exclusive_mode(Wal *wal, int op) {
+  //TODO: implement
+  return SQLITE_MISUSE;;
+}
+
+static int v_heap_memory(Wal *wal) {
+  //TODO: implement
+  return SQLITE_MISUSE;
+}
+
+static sqlite3_file *v_file(Wal *wal) {
+  //TODO: implement
+  return NULL;
+}
+
+static void v_db(Wal *wal, sqlite3 *db) {
+  //TODO: implement
+}
+
+static int v_pathname_len(int n) {
+  return 0;
+}
+
+static void v_get_wal_pathname(char *buf, const char *orig, int orig_len) {
+}
+
+__attribute__((__visibility__("default")))
+void libsql_register_vwal() {
+  static libsql_wal_methods methods = {
+    .xOpen = v_open,
+    .xClose = v_close,
+    .xLimit = v_limit,
+    .xBeginReadTransaction = v_begin_read_transaction,
+    .xEndReadTransaction = v_end_read_transaction,
+    .xFindFrame = v_find_frame,
+    .xReadFrame = v_read_frame,
+    .xDbsize = v_dbsize,
+    .xBeginWriteTransaction = v_begin_write_transaction,
+    .xEndWriteTransaction = v_end_write_transaction,
+    .xUndo = v_undo,
+    .xSavepoint = v_savepoint,
+    .xSavepointUndo = v_savepoint_undo,
+    .xFrames = v_frames,
+    .xCheckpoint = v_checkpoint,
+    .xCallback = v_callback,
+    .xExclusiveMode = v_exclusive_mode,
+    .xHeapMemory = v_heap_memory,
+#ifdef SQLITE_ENABLE_SNAPSHOT
+    .xSnapshotGet = NULL,
+    .xSnapshotOpen = NULL,
+    .xSnapshotRecover = NULL,
+    .xSnapshotCheck = NULL,
+    .xSnapshotUnlock = NULL,
+#endif
+#ifdef SQLITE_ENABLE_ZIPVFS
+    .xFramesize = NULL,
+#endif
+    .xFile = v_file,
+#ifdef SQLITE_ENABLE_SETLK_TIMEOUT
+    .xWriteLock = NULL,
+#endif
+    .xDb = v_db,
+    .xPathnameLen = v_pathname_len,
+    .xGetWalPathname = v_get_wal_pathname,
+    .zName = "vwal"
+  };
+  libsql_wal_methods_register(&methods);
+}

--- a/src/attach.c
+++ b/src/attach.c
@@ -12,6 +12,7 @@
 ** This file contains code used to implement the ATTACH and DETACH commands.
 */
 #include "sqliteInt.h"
+#include "wal.h"
 
 #ifndef SQLITE_OMIT_ATTACH
 /*

--- a/src/btree.c
+++ b/src/btree.c
@@ -2433,12 +2433,13 @@ static int btreeInvokeBusyHandler(void *pArg){
 ** to problems with locking.
 */
 int sqlite3BtreeOpen(
-  sqlite3_vfs *pVfs,      /* VFS to use for this b-tree */
-  const char *zFilename,  /* Name of the file containing the BTree database */
-  sqlite3 *db,            /* Associated database handle */
-  Btree **ppBtree,        /* Pointer to new Btree object written here */
-  int flags,              /* Options */
-  int vfsFlags            /* Flags passed through to sqlite3_vfs.xOpen() */
+  sqlite3_vfs *pVfs,       /* VFS to use for this b-tree */
+  libsql_wal_methods *pWal,/* WAL methods to use for this b-tree */
+  const char *zFilename,   /* Name of the file containing the BTree database */
+  sqlite3 *db,             /* Associated database handle */
+  Btree **ppBtree,         /* Pointer to new Btree object written here */
+  int flags,               /* Options */
+  int vfsFlags             /* Flags passed through to sqlite3_vfs.xOpen() */
 ){
   BtShared *pBt = 0;             /* Shared part of btree structure */
   Btree *p;                      /* Handle to return */
@@ -2579,7 +2580,7 @@ int sqlite3BtreeOpen(
       rc = SQLITE_NOMEM_BKPT;
       goto btree_open_out;
     }
-    rc = sqlite3PagerOpen(pVfs, &pBt->pPager, zFilename,
+    rc = sqlite3PagerOpen(pVfs, pWal, &pBt->pPager, zFilename,
                           sizeof(MemPage), flags, vfsFlags, pageReinit);
     if( rc==SQLITE_OK ){
       sqlite3PagerSetMmapLimit(pBt->pPager, db->szMmap);

--- a/src/btree.h
+++ b/src/btree.h
@@ -41,9 +41,11 @@ typedef struct BtCursor BtCursor;
 typedef struct BtShared BtShared;
 typedef struct BtreePayload BtreePayload;
 
+typedef struct libsql_wal_methods libsql_wal_methods;
 
 int sqlite3BtreeOpen(
   sqlite3_vfs *pVfs,       /* VFS to use with this b-tree */
+  libsql_wal_methods *pWal,/* WAL methods to use with this b-tree */
   const char *zFilename,   /* Name of database file to open */
   sqlite3 *db,             /* Associated database connection */
   Btree **ppBtree,         /* Return open Btree* here */

--- a/src/build.c
+++ b/src/build.c
@@ -5207,7 +5207,7 @@ int sqlite3OpenTempDatabase(Parse *pParse){
           SQLITE_OPEN_DELETEONCLOSE |
           SQLITE_OPEN_TEMP_DB;
 
-    rc = sqlite3BtreeOpen(db->pVfs, 0, db, &pBt, 0, flags);
+    rc = sqlite3BtreeOpen(db->pVfs, db->pWalMethods, 0, db, &pBt, 0, flags);
     if( rc!=SQLITE_OK ){
       sqlite3ErrorMsg(pParse, "unable to open a temporary database "
         "file for storing temporary tables");

--- a/src/loadext.c
+++ b/src/loadext.c
@@ -514,7 +514,8 @@ static const sqlite3_api_routines sqlite3Apis = {
 
   /* libSQL 0.1.1 */
   libsql_wal_methods_find,
-  libsql_wal_methods_register
+  libsql_wal_methods_register,
+  libsql_wal_methods_unregister
 };
 
 /* True if x is the directory separator character

--- a/src/loadext.c
+++ b/src/loadext.c
@@ -510,7 +510,11 @@ static const sqlite3_api_routines sqlite3Apis = {
 #endif
   sqlite3_db_name,
   /* Version 3.40.0 and later */
-  sqlite3_value_encoding
+  sqlite3_value_encoding,
+
+  /* libSQL 0.1.1 */
+  libsql_wal_methods_find,
+  libsql_wal_methods_register
 };
 
 /* True if x is the directory separator character

--- a/src/main.c
+++ b/src/main.c
@@ -3975,6 +3975,11 @@ int sqlite3_file_control(sqlite3 *db, const char *zDbName, int op, void *pArg){
     }else if( op==SQLITE_FCNTL_DATA_VERSION ){
       *(unsigned int*)pArg = sqlite3PagerDataVersion(pPager);
       rc = SQLITE_OK;
+#ifndef SQLITE_OMIT_WAL
+    }else if( op==SQLITE_FCNTL_WAL_METHODS_POINTER ){
+      *(libsql_wal_methods**)pArg = sqlite3PagerWalMethods(pPager);
+      rc = SQLITE_OK;
+#endif
     }else if( op==SQLITE_FCNTL_RESERVE_BYTES ){
       int iNew = *(int*)pArg;
       *(int*)pArg = sqlite3BtreeGetRequestedReserve(pBtree);

--- a/src/pager.c
+++ b/src/pager.c
@@ -225,7 +225,7 @@ int sqlite3PagerTrace=1;  /* True to enable tracing */
 **    * If the connection is open in rollback-mode, a RESERVED or greater 
 **      lock is held on the database file.
 **    * If the connection is open in WAL-mode, a WAL write transaction
-**      is open (i.e. sqlite3WalBeginWriteTransaction() has been successfully
+**      is open (i.e. pPager->pWalMethods->xBeginWriteTransaction() has been successfully
 **      called).
 **    * The dbSize, dbOrigSize and dbFileSize variables are all valid.
 **    * The contents of the pager cache have not been modified.
@@ -697,8 +697,9 @@ struct Pager {
   char *pTmpSpace;            /* Pager.pageSize bytes of space for tmp use */
   PCache *pPCache;            /* Pointer to page cache object */
 #ifndef SQLITE_OMIT_WAL
-  Wal *pWal;                  /* Write-ahead log used by "journal_mode=wal" */
-  char *zWal;                 /* File name for write-ahead log */
+  Wal *pWal;                       /* Write-ahead log used by "journal_mode=wal" */
+  libsql_wal_methods *pWalMethods; /* Virtual methods for interacting with WAL */
+  char *zWal;                      /* File name for write-ahead log */
 #endif
 };
 
@@ -819,7 +820,7 @@ int sqlite3PagerDirectReadOk(Pager *pPager, Pgno pgno){
   if( pPager->pWal ){
     u32 iRead = 0;
     int rc;
-    rc = sqlite3WalFindFrame(pPager->pWal, pgno, &iRead);
+    rc = pPager->pWalMethods->xFindFrame(pPager->pWal, pgno, &iRead);
     return (rc==SQLITE_OK && iRead==0);
   }
 #endif
@@ -1830,7 +1831,9 @@ static void pager_unlock(Pager *pPager){
 
   if( pagerUseWal(pPager) ){
     assert( !isOpen(pPager->jfd) );
-    sqlite3WalEndReadTransaction(pPager->pWal);
+#ifndef SQLITE_OMIT_WAL
+    pPager->pWalMethods->xEndReadTransaction(pPager->pWal);
+#endif
     pPager->eState = PAGER_OPEN;
   }else if( !pPager->exclusiveMode ){
     int rc;                       /* Error code returned by pagerUnlockDb() */
@@ -2109,7 +2112,9 @@ static int pager_end_transaction(Pager *pPager, int hasSuper, int bCommit){
     ** locking_mode=exclusive mode but is no longer, drop the EXCLUSIVE 
     ** lock held on the database file.
     */
-    rc2 = sqlite3WalEndWriteTransaction(pPager->pWal);
+#ifndef SQLITE_OMIT_WAL
+    rc2 = pPager->pWalMethods->xEndWriteTransaction(pPager->pWal);
+#endif
     assert( rc2==SQLITE_OK );
   }else if( rc==SQLITE_OK && bCommit && pPager->dbFileSize>pPager->dbSize ){
     /* This branch is taken when committing a transaction in rollback-journal
@@ -2127,9 +2132,13 @@ static int pager_end_transaction(Pager *pPager, int hasSuper, int bCommit){
     if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
   }
 
-  if( !pPager->exclusiveMode 
-   && (!pagerUseWal(pPager) || sqlite3WalExclusiveMode(pPager->pWal, 0))
-  ){
+  int should_unlock = !pPager->exclusiveMode;
+#ifndef SQLITE_OMIT_WAL
+  if (should_unlock && pagerUseWal(pPager)) {
+    should_unlock &= pPager->pWalMethods->xExclusiveMode(pPager->pWal, 0);
+  }
+#endif
+  if( should_unlock ){
     rc2 = pagerUnlockDb(pPager, SHARED_LOCK);
   }
   pPager->eState = PAGER_READER;
@@ -2976,11 +2985,11 @@ static int readDbPage(PgHdr *pPg){
   assert( isOpen(pPager->fd) );
 
   if( pagerUseWal(pPager) ){
-    rc = sqlite3WalFindFrame(pPager->pWal, pPg->pgno, &iFrame);
+    rc = pPager->pWalMethods->xFindFrame(pPager->pWal, pPg->pgno, &iFrame);
     if( rc ) return rc;
   }
   if( iFrame ){
-    rc = sqlite3WalReadFrame(pPager->pWal, iFrame,pPager->pageSize,pPg->pData);
+    rc = pPager->pWalMethods->xReadFrame(pPager->pWal, iFrame,pPager->pageSize,pPg->pData);
   }else
 #endif
   {
@@ -3103,7 +3112,7 @@ static int pagerRollbackWal(Pager *pPager){
   **   + Reload page content from the database (if refcount>0).
   */
   pPager->dbSize = pPager->dbOrigSize;
-  rc = sqlite3WalUndo(pPager->pWal, pagerUndoCallback, (void *)pPager);
+  rc = pPager->pWalMethods->xUndo(pPager->pWal, pagerUndoCallback, (void *)pPager);
   pList = sqlite3PcacheDirtyList(pPager->pPCache);
   while( pList && rc==SQLITE_OK ){
     PgHdr *pNext = pList->pDirty;
@@ -3115,7 +3124,7 @@ static int pagerRollbackWal(Pager *pPager){
 }
 
 /*
-** This function is a wrapper around sqlite3WalFrames(). As well as logging
+** This function is a wrapper around pPager->pWalMethods->xFrames(). As well as logging
 ** the contents of the list of pages headed by pList (connected by pDirty),
 ** this function notifies any active backup processes that the pages have
 ** changed. 
@@ -3163,7 +3172,7 @@ static int pagerWalFrames(
   pPager->aStat[PAGER_STAT_WRITE] += nList;
 
   if( pList->pgno==1 ) pager_write_changecounter(pList);
-  rc = sqlite3WalFrames(pPager->pWal, 
+  rc = pPager->pWalMethods->xFrames(pPager->pWal,
       pPager->pageSize, pList, nTruncate, isCommit, pPager->walSyncFlags
   );
   if( rc==SQLITE_OK && pPager->pBackup ){
@@ -3197,14 +3206,14 @@ static int pagerBeginReadTransaction(Pager *pPager){
   assert( pagerUseWal(pPager) );
   assert( pPager->eState==PAGER_OPEN || pPager->eState==PAGER_READER );
 
-  /* sqlite3WalEndReadTransaction() was not called for the previous
+  /* pPager->pWalMethods->xEndReadTransaction() was not called for the previous
   ** transaction in locking_mode=EXCLUSIVE.  So call it now.  If we
   ** are in locking_mode=NORMAL and EndRead() was previously called,
   ** the duplicate call is harmless.
   */
-  sqlite3WalEndReadTransaction(pPager->pWal);
+  pPager->pWalMethods->xEndReadTransaction(pPager->pWal);
 
-  rc = sqlite3WalBeginReadTransaction(pPager->pWal, &changed);
+  rc = pPager->pWalMethods->xBeginReadTransaction(pPager->pWal, &changed);
   if( rc!=SQLITE_OK || changed ){
     pager_reset(pPager);
     if( USEFETCH(pPager) ) sqlite3OsUnfetch(pPager->fd, 0, 0);
@@ -3236,7 +3245,11 @@ static int pagerPagecount(Pager *pPager, Pgno *pnPage){
   assert( pPager->eLock>=SHARED_LOCK );
   assert( isOpen(pPager->fd) );
   assert( pPager->tempFile==0 );
-  nPage = sqlite3WalDbsize(pPager->pWal);
+#ifndef SQLITE_OMIT_WAL
+  nPage = pagerUseWal(pPager) ? pPager->pWalMethods->xDbsize(pPager->pWal) : 0;
+#else
+  nPage = 0;
+#endif
 
   /* If the number of pages in the database is not available from the
   ** WAL sub-system, determine the page count based on the size of
@@ -3440,9 +3453,11 @@ static int pagerPlaybackSavepoint(Pager *pPager, PagerSavepoint *pSavepoint){
     u32 ii;            /* Loop counter */
     i64 offset = (i64)pSavepoint->iSubRec*(4+pPager->pageSize);
 
+#ifndef SQLITE_OMIT_WAL
     if( pagerUseWal(pPager) ){
-      rc = sqlite3WalSavepointUndo(pPager->pWal, pSavepoint->aWalData);
+      rc = pPager->pWalMethods->xSavepointUndo(pPager->pWal, pSavepoint->aWalData);
     }
+#endif
     for(ii=pSavepoint->iSubRec; rc==SQLITE_OK && ii<pPager->nSubRec; ii++){
       assert( offset==(i64)ii*(4+pPager->pageSize) );
       rc = pager_playback_one_page(pPager, &offset, pDone, 0, 1);
@@ -4126,7 +4141,9 @@ int sqlite3PagerClose(Pager *pPager, sqlite3 *db){
     ){
       a = pTmp;
     }
-    sqlite3WalClose(pPager->pWal, db, pPager->walSyncFlags, pPager->pageSize,a);
+    if (pagerUseWal(pPager)) {
+      pPager->pWalMethods->xClose(pPager->pWal, db, pPager->walSyncFlags, pPager->pageSize,a);
+    }
     pPager->pWal = 0;
   }
 #endif
@@ -4667,6 +4684,7 @@ int sqlite3PagerFlush(Pager *pPager){
 */
 int sqlite3PagerOpen(
   sqlite3_vfs *pVfs,       /* The virtual file system to use */
+  libsql_wal_methods *pWalMethods, /* WAL methods to use */
   Pager **ppPager,         /* OUT: Return the Pager structure here */
   const char *zFilename,   /* Name of the database file to open */
   int nExtra,              /* Extra bytes append to each in-memory page */
@@ -4859,6 +4877,7 @@ int sqlite3PagerOpen(
   }
 
 #ifndef SQLITE_OMIT_WAL
+  pPager->pWalMethods = pWalMethods;
   /* Fill in Pager.zWal */
   if( nPathname>0 ){
     pPager->zWal = (char*)pPtr;
@@ -5614,11 +5633,13 @@ static int getPageMMap(
   assert( pPager->errCode==SQLITE_OK );
 
   if( bMmapOk && pagerUseWal(pPager) ){
-    rc = sqlite3WalFindFrame(pPager->pWal, pgno, &iFrame);
+#ifndef SQLITE_OMIT_WAL
+    rc = pPager->pWalMethods->xFindFrame(pPager->pWal, pgno, &iFrame);
     if( rc!=SQLITE_OK ){
       *ppPage = 0;
       return rc;
     }
+#endif
   }
   if( bMmapOk && iFrame==0 ){
     void *pData = 0;
@@ -5859,15 +5880,16 @@ int sqlite3PagerBegin(Pager *pPager, int exFlag, int subjInMemory){
     assert( pPager->pInJournal==0 );
 
     if( pagerUseWal(pPager) ){
+#ifndef SQLITE_OMIT_WAL
       /* If the pager is configured to use locking_mode=exclusive, and an
       ** exclusive lock on the database is not already held, obtain it now.
       */
-      if( pPager->exclusiveMode && sqlite3WalExclusiveMode(pPager->pWal, -1) ){
+      if( pPager->exclusiveMode && pPager->pWalMethods->xExclusiveMode(pPager->pWal, -1) ){
         rc = pagerLockDb(pPager, EXCLUSIVE_LOCK);
         if( rc!=SQLITE_OK ){
           return rc;
         }
-        (void)sqlite3WalExclusiveMode(pPager->pWal, 1);
+        (void)pPager->pWalMethods->xExclusiveMode(pPager->pWal, 1);
       }
 
       /* Grab the write lock on the log file. If successful, upgrade to
@@ -5875,7 +5897,8 @@ int sqlite3PagerBegin(Pager *pPager, int exFlag, int subjInMemory){
       ** The busy-handler is not invoked if another connection already
       ** holds the write-lock. If possible, the upper layer will call it.
       */
-      rc = sqlite3WalBeginWriteTransaction(pPager->pWal);
+      rc = pPager->pWalMethods->xBeginWriteTransaction(pPager->pWal);
+#endif
     }else{
       /* Obtain a RESERVED lock on the database file. If the exFlag parameter
       ** is true, then immediately upgrade this to an EXCLUSIVE lock. The
@@ -6876,7 +6899,9 @@ static SQLITE_NOINLINE int pagerOpenSavepoint(Pager *pPager, int nSavepoint){
       return SQLITE_NOMEM_BKPT;
     }
     if( pagerUseWal(pPager) ){
-      sqlite3WalSavepoint(pPager->pWal, aNew[ii].aWalData);
+#ifndef SQLITE_OMIT_WAL
+      pPager->pWalMethods->xSavepoint(pPager->pWal, aNew[ii].aWalData);
+#endif
     }
     pPager->nSavepoint = ii+1;
   }
@@ -7040,7 +7065,7 @@ sqlite3_file *sqlite3PagerJrnlFile(Pager *pPager){
 #if SQLITE_OMIT_WAL
   return pPager->jfd;
 #else
-  return pPager->pWal ? sqlite3WalFile(pPager->pWal) : pPager->jfd;
+  return pPager->pWal ? pPager->pWalMethods->xFile(pPager->pWal) : pPager->jfd;
 #endif
 }
 
@@ -7237,6 +7262,15 @@ void *sqlite3PagerGetExtra(DbPage *pPg){
   return pPg->pExtra;
 }
 
+static int pagerWalHeapMemory(Pager *pPager) {
+#ifndef SQLITE_OMIT_WAL
+  if (pagerUseWal(pPager)) {
+    return pPager->pWalMethods->xHeapMemory(pPager->pWal);
+  }
+#endif
+  return 0;
+}
+
 /*
 ** Get/set the locking-mode for this pager. Parameter eMode must be one
 ** of PAGER_LOCKINGMODE_QUERY, PAGER_LOCKINGMODE_NORMAL or 
@@ -7253,8 +7287,8 @@ int sqlite3PagerLockingMode(Pager *pPager, int eMode){
             || eMode==PAGER_LOCKINGMODE_EXCLUSIVE );
   assert( PAGER_LOCKINGMODE_QUERY<0 );
   assert( PAGER_LOCKINGMODE_NORMAL>=0 && PAGER_LOCKINGMODE_EXCLUSIVE>=0 );
-  assert( pPager->exclusiveMode || 0==sqlite3WalHeapMemory(pPager->pWal) );
-  if( eMode>=0 && !pPager->tempFile && !sqlite3WalHeapMemory(pPager->pWal) ){
+  assert( pPager->exclusiveMode || 0==pagerWalHeapMemory(pPager) );
+  if( eMode>=0 && !pPager->tempFile && !pagerWalHeapMemory(pPager) ){
     pPager->exclusiveMode = (u8)eMode;
   }
   return (int)pPager->exclusiveMode;
@@ -7395,7 +7429,9 @@ int sqlite3PagerOkToChangeJournalMode(Pager *pPager){
 i64 sqlite3PagerJournalSizeLimit(Pager *pPager, i64 iLimit){
   if( iLimit>=-1 ){
     pPager->journalSizeLimit = iLimit;
-    sqlite3WalLimit(pPager->pWal, iLimit);
+#ifndef SQLITE_OMIT_WAL
+    pPager->pWalMethods->xLimit(pPager->pWal, iLimit);
+#endif
   }
   return pPager->journalSizeLimit;
 }
@@ -7450,7 +7486,7 @@ int sqlite3PagerCheckpoint(
     sqlite3_exec(db, "PRAGMA table_list",0,0,0);
   }
   if( pPager->pWal ){
-    rc = sqlite3WalCheckpoint(pPager->pWal, db, eMode,
+    rc = pPager->pWalMethods->xCheckpoint(pPager->pWal, db, eMode,
         (eMode==SQLITE_CHECKPOINT_PASSIVE ? 0 : pPager->xBusyHandler),
         pPager->pBusyHandlerArg,
         pPager->walSyncFlags, pPager->pageSize, (u8 *)pPager->pTmpSpace,
@@ -7461,7 +7497,10 @@ int sqlite3PagerCheckpoint(
 }
 
 int sqlite3PagerWalCallback(Pager *pPager){
-  return sqlite3WalCallback(pPager->pWal);
+  if (pagerUseWal(pPager)) {
+    return pPager->pWalMethods->xCallback(pPager->pWal);
+  }
+  return SQLITE_OK;
 }
 
 /*
@@ -7493,7 +7532,7 @@ static int pagerExclusiveLock(Pager *pPager){
 }
 
 /*
-** Call sqlite3WalOpen() to open the WAL handle. If the pager is in 
+** Call pPager->pWalMethods->xOpen() to open the WAL handle. If the pager is in 
 ** exclusive-locking mode when this function is called, take an EXCLUSIVE
 ** lock on the database file and use heap-memory to store the wal-index
 ** in. Otherwise, use the normal shared-memory.
@@ -7517,9 +7556,9 @@ static int pagerOpenWal(Pager *pPager){
   ** (e.g. due to malloc() failure), return an error code.
   */
   if( rc==SQLITE_OK ){
-    rc = sqlite3WalOpen(pPager->pVfs,
+    rc = pPager->pWalMethods->xOpen(pPager->pVfs,
         pPager->fd, pPager->zWal, pPager->exclusiveMode,
-        pPager->journalSizeLimit, &pPager->pWal
+        pPager->journalSizeLimit, pPager->pWalMethods, &pPager->pWal
     );
   }
   pagerFixMaplimit(pPager);
@@ -7610,7 +7649,7 @@ int sqlite3PagerCloseWal(Pager *pPager, sqlite3 *db){
   if( rc==SQLITE_OK && pPager->pWal ){
     rc = pagerExclusiveLock(pPager);
     if( rc==SQLITE_OK ){
-      rc = sqlite3WalClose(pPager->pWal, db, pPager->walSyncFlags,
+      rc = pPager->pWalMethods->xClose(pPager->pWal, db, pPager->walSyncFlags,
                            pPager->pageSize, (u8*)pPager->pTmpSpace);
       pPager->pWal = 0;
       pagerFixMaplimit(pPager);
@@ -7623,14 +7662,14 @@ int sqlite3PagerCloseWal(Pager *pPager, sqlite3 *db){
 #ifdef SQLITE_ENABLE_SETLK_TIMEOUT
 /*
 ** If pager pPager is a wal-mode database not in exclusive locking mode,
-** invoke the sqlite3WalWriteLock() function on the associated Wal object 
+** invoke the pPager->pWalMethods->xWriteLock() function on the associated Wal object 
 ** with the same db and bLock parameters as were passed to this function.
 ** Return an SQLite error code if an error occurs, or SQLITE_OK otherwise.
 */
 int sqlite3PagerWalWriteLock(Pager *pPager, int bLock){
   int rc = SQLITE_OK;
   if( pagerUseWal(pPager) && pPager->exclusiveMode==0 ){
-    rc = sqlite3WalWriteLock(pPager->pWal, bLock);
+    rc = pPager->pWalMethods->xWriteLock(pPager->pWal, bLock);
   }
   return rc;
 }
@@ -7641,7 +7680,7 @@ int sqlite3PagerWalWriteLock(Pager *pPager, int bLock){
 */
 void sqlite3PagerWalDb(Pager *pPager, sqlite3 *db){
   if( pagerUseWal(pPager) ){
-    sqlite3WalDb(pPager->pWal, db);
+    pPager->pWalMethods->xDb(pPager->pWal, db);
   }
 }
 #endif
@@ -7654,7 +7693,7 @@ void sqlite3PagerWalDb(Pager *pPager, sqlite3 *db){
 int sqlite3PagerSnapshotGet(Pager *pPager, sqlite3_snapshot **ppSnapshot){
   int rc = SQLITE_ERROR;
   if( pPager->pWal ){
-    rc = sqlite3WalSnapshotGet(pPager->pWal, ppSnapshot);
+    rc = pPager->pWalMethods->xSnapshotGet(pPager->pWal, ppSnapshot);
   }
   return rc;
 }
@@ -7670,7 +7709,7 @@ int sqlite3PagerSnapshotOpen(
 ){
   int rc = SQLITE_OK;
   if( pPager->pWal ){
-    sqlite3WalSnapshotOpen(pPager->pWal, pSnapshot);
+    pPager->pWalMethods->xSnapshotOpen(pPager->pWal, pSnapshot);
   }else{
     rc = SQLITE_ERROR;
   }
@@ -7678,13 +7717,13 @@ int sqlite3PagerSnapshotOpen(
 }
 
 /*
-** If this is a WAL database, call sqlite3WalSnapshotRecover(). If this 
+** If this is a WAL database, call pPager->pWalMethods->xSnapshotRecover(). If this 
 ** is not a WAL database, return an error.
 */
 int sqlite3PagerSnapshotRecover(Pager *pPager){
   int rc;
   if( pPager->pWal ){
-    rc = sqlite3WalSnapshotRecover(pPager->pWal);
+    rc = pPager->pWalMethods->xSnapshotRecover(pPager->pWal);
   }else{
     rc = SQLITE_ERROR;
   }
@@ -7706,7 +7745,7 @@ int sqlite3PagerSnapshotRecover(Pager *pPager){
 int sqlite3PagerSnapshotCheck(Pager *pPager, sqlite3_snapshot *pSnapshot){
   int rc;
   if( pPager->pWal ){
-    rc = sqlite3WalSnapshotCheck(pPager->pWal, pSnapshot);
+    rc = pPager->pWalMethods->xSnapshotCheck(pPager->pWal, pSnapshot);
   }else{
     rc = SQLITE_ERROR;
   }
@@ -7719,7 +7758,7 @@ int sqlite3PagerSnapshotCheck(Pager *pPager, sqlite3_snapshot *pSnapshot){
 */
 void sqlite3PagerSnapshotUnlock(Pager *pPager){
   assert( pPager->pWal );
-  sqlite3WalSnapshotUnlock(pPager->pWal);
+  pPager->pWalMethods->xSnapshotUnlock(pPager->pWal);
 }
 
 #endif /* SQLITE_ENABLE_SNAPSHOT */
@@ -7735,7 +7774,7 @@ void sqlite3PagerSnapshotUnlock(Pager *pPager){
 */
 int sqlite3PagerWalFramesize(Pager *pPager){
   assert( pPager->eState>=PAGER_READER );
-  return sqlite3WalFramesize(pPager->pWal);
+  return pPager->pWalMethods->xFramesize(pPager->pWal);
 }
 #endif
 

--- a/src/pager.c
+++ b/src/pager.c
@@ -7510,7 +7510,7 @@ int sqlite3PagerWalCallback(Pager *pPager){
 int sqlite3PagerWalSupported(Pager *pPager){
   const sqlite3_io_methods *pMethods = pPager->fd->pMethods;
   if( pPager->noLock ) return 0;
-  return pPager->exclusiveMode || (pMethods->iVersion>=2 && pMethods->xShmMap);
+  return pPager->exclusiveMode || (pPager->pWalMethods->bUsesShm == 0) || (pMethods->iVersion>=2 && pMethods->xShmMap);
 }
 
 /*

--- a/src/pager.c
+++ b/src/pager.c
@@ -4893,6 +4893,14 @@ int sqlite3PagerOpen(
     sqlite3FileSuffix3(zFilename, pPager->zWal);
     pPtr = (u8*)(pPager->zWal + sqlite3Strlen30(pPager->zWal)+1);
 #endif
+
+  if (pWalMethods->xPreMainDbOpen) {
+    int rc = pWalMethods->xPreMainDbOpen(pWalMethods, zPathname);
+    if (rc != SQLITE_OK) {
+      return rc;
+    }
+  }
+
   }else{
     pPager->zWal = 0;
   }

--- a/src/pager.c
+++ b/src/pager.c
@@ -7054,6 +7054,15 @@ sqlite3_vfs *sqlite3PagerVfs(Pager *pPager){
   return pPager->pVfs;
 }
 
+#ifndef SQLITE_OMIT_WAL
+/*
+** Return the WAL methods structure for the pager.
+*/
+libsql_wal_methods *sqlite3PagerWalMethods(Pager *pPager){
+  return pPager->pWalMethods;
+}
+#endif
+
 /*
 ** Return the file handle for the database file associated
 ** with the pager.  This might return NULL if the file has

--- a/src/pager.h
+++ b/src/pager.h
@@ -113,9 +113,12 @@ typedef struct PgHdr DbPage;
 ** a detailed description of each routine.
 */
 
+typedef struct libsql_wal_methods libsql_wal_methods;
+
 /* Open and close a Pager connection. */ 
 int sqlite3PagerOpen(
   sqlite3_vfs*,
+  libsql_wal_methods*,
   Pager **ppPager,
   const char*,
   int,

--- a/src/pager.h
+++ b/src/pager.h
@@ -214,6 +214,9 @@ u32 sqlite3PagerDataVersion(Pager*);
 int sqlite3PagerMemUsed(Pager*);
 const char *sqlite3PagerFilename(const Pager*, int);
 sqlite3_vfs *sqlite3PagerVfs(Pager*);
+#ifndef SQLITE_OMIT_WAL
+libsql_wal_methods *sqlite3PagerWalMethods(Pager*);
+#endif
 sqlite3_file *sqlite3PagerFile(Pager*);
 sqlite3_file *sqlite3PagerJrnlFile(Pager*);
 const char *sqlite3PagerJournalname(Pager*);

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -10871,6 +10871,24 @@ static int do_meta_command(char *zLine, ShellState *p){
     }
   }else
 
+#ifndef SQLITE_OMIT_WAL
+  if( c=='w' && cli_strncmp(azArg[0], "walmethodslist", n)==0 ){
+    libsql_wal_methods *pWal;
+    libsql_wal_methods *pCurrent = 0;
+    if( p->db ){
+      sqlite3_file_control(p->db, "main", SQLITE_FCNTL_WAL_METHODS_POINTER, &pCurrent);
+    }
+    for(pWal=libsql_wal_methods_find(0); pWal; pWal=libsql_wal_methods_next(pWal)){
+      
+      utf8_printf(p->out, "wal.zName      = \"%s\"%s\n", libsql_wal_methods_name(pWal),
+           pWal==pCurrent ? "  <--- CURRENT" : "");
+      if( libsql_wal_methods_next(pWal) ){
+        raw_printf(p->out, "-----------------------------------\n");
+      }
+    }
+  }else
+#endif
+
   if( c=='w' && cli_strncmp(azArg[0], "wheretrace", n)==0 ){
     unsigned int x = nArg>=2 ? (unsigned int)integerValue(azArg[1]) : 0xffffffff;
     sqlite3_test_control(SQLITE_TESTCTRL_TRACEFLAGS, 3, &x);

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -1012,6 +1012,13 @@ struct sqlite3_io_methods {
 ** ^When there are multiple VFS shims in the stack, this opcode finds the
 ** upper-most shim only.
 **
+** <li>[[SQLITE_FCNTL_WAL_METHODS_POINTER]]
+** ^The [SQLITE_FCNTL_WAL_METHODS_POINTER] opcode finds a pointer to the top-level
+** WAL methods currently in use.  ^(The argument X in
+** sqlite3_file_control(db,SQLITE_FCNTL_WAL_METHODS_POINTER,X) must be
+** of type "[libsql_wal_methods] **".  This opcodes will set *X
+** to a pointer to the top-level WAL methods.)^
+**
 ** <li>[[SQLITE_FCNTL_PRAGMA]]
 ** ^Whenever a [PRAGMA] statement is parsed, an [SQLITE_FCNTL_PRAGMA] 
 ** file control is sent to the open [sqlite3_file] object corresponding
@@ -1248,6 +1255,9 @@ struct sqlite3_io_methods {
 #define SQLITE_FCNTL_EXTERNAL_READER        40
 #define SQLITE_FCNTL_CKSM_FILE              41
 #define SQLITE_FCNTL_RESET_CACHE            42
+
+// libSQL extension
+#define SQLITE_FCNTL_WAL_METHODS_POINTER   129
 
 /* deprecated names */
 #define SQLITE_GET_LOCKPROXYFILE      SQLITE_FCNTL_GET_LOCKPROXYFILE
@@ -7750,6 +7760,9 @@ typedef struct libsql_wal_methods libsql_wal_methods;
 libsql_wal_methods *libsql_wal_methods_find(const char *zName);
 int libsql_wal_methods_register(libsql_wal_methods*);
 int libsql_wal_methods_unregister(libsql_wal_methods*);
+
+libsql_wal_methods *libsql_wal_methods_next(libsql_wal_methods *w);
+const char *libsql_wal_methods_name(libsql_wal_methods *w);
 
 /*
 ** CAPI3REF: Mutexes

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -3679,6 +3679,13 @@ int sqlite3_open_v2(
   int flags,              /* Flags */
   const char *zVfs        /* Name of VFS module to use */
 );
+int libsql_open(
+  const char *filename,   /* Database filename (UTF-8) */
+  sqlite3 **ppDb,         /* OUT: SQLite db handle */
+  int flags,              /* Flags */
+  const char *zVfs,       /* Name of VFS module to use, NULL for default */
+  const char *zWal        /* Name of WAL module to use */
+);
 
 #ifdef LIBSQL_ENABLE_WASM_RUNTIME
 LIBSQL_API int libsql_try_initialize_wasm_func_table(sqlite3 *db);
@@ -7718,6 +7725,31 @@ int sqlite3_blob_write(sqlite3_blob *, const void *z, int n, int iOffset);
 sqlite3_vfs *sqlite3_vfs_find(const char *zVfsName);
 int sqlite3_vfs_register(sqlite3_vfs*, int makeDflt);
 int sqlite3_vfs_unregister(sqlite3_vfs*);
+
+/*
+** CAPI3REF: Virtual WAL Methods
+**
+** Virtual WAL methods can be redefined in order to change the default
+** behavior of the write-ahead log.
+** Methods can be registered and unregistered.
+** The following interfaces are provided.
+**
+** ^The libsql_wal_methods_find() interface returns a pointer
+** to the methods given their identifier.
+** ^Names are case sensitive.
+** ^Names are zero-terminated UTF-8 strings.
+** ^If there is no match, a NULL pointer is returned.
+** ^If zName is NULL then the default implementation is returned.
+**
+** ^New WAL methods are registered with libsql_wal_methods_register().
+** ^Same methods can be registered multiple times without injury.
+**
+** ^Unregister WAL methods with the libsql_wal_methods_unregister() interface.
+*/
+typedef struct libsql_wal_methods libsql_wal_methods;
+libsql_wal_methods *libsql_wal_methods_find(const char *zName);
+int libsql_wal_methods_register(libsql_wal_methods*);
+int libsql_wal_methods_unregister(libsql_wal_methods*);
 
 /*
 ** CAPI3REF: Mutexes

--- a/src/sqlite3ext.h
+++ b/src/sqlite3ext.h
@@ -359,6 +359,10 @@ struct sqlite3_api_routines {
   const char *(*db_name)(sqlite3*,int);
   /* Version 3.40.0 and later */
   int (*value_encoding)(sqlite3_value*);
+
+  /* libSQL 0.1.1 */
+  struct libsql_wal_methods *(*wal_methods_find)(const char *);
+  int (*wal_methods_register)(struct libsql_wal_methods*);
 };
 
 /*
@@ -685,6 +689,9 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_db_name                sqlite3_api->db_name
 /* Version 3.40.0 and later */
 #define sqlite3_value_encoding         sqlite3_api->value_encoding
+/* libSQL 0.1.1 */
+#define libsql_wal_methods_find        sqlite3_api->wal_methods_find
+#define libsql_wal_methods_register    sqlite3_api->wal_methods_register
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)

--- a/src/sqlite3ext.h
+++ b/src/sqlite3ext.h
@@ -363,6 +363,7 @@ struct sqlite3_api_routines {
   /* libSQL 0.1.1 */
   struct libsql_wal_methods *(*wal_methods_find)(const char *);
   int (*wal_methods_register)(struct libsql_wal_methods*);
+  int (*wal_methods_unregister)(struct libsql_wal_methods*);
 };
 
 /*
@@ -692,6 +693,7 @@ typedef int (*sqlite3_loadext_entry)(
 /* libSQL 0.1.1 */
 #define libsql_wal_methods_find        sqlite3_api->wal_methods_find
 #define libsql_wal_methods_register    sqlite3_api->wal_methods_register
+#define libsql_wal_methods_unregister  sqlite3_api->wal_methods_unregister
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -1595,6 +1595,8 @@ typedef struct libsql_wasm_ctx {
 } libsql_wasm_ctx;
 #endif
 
+typedef struct libsql_wal_methods libsql_wal_methods;
+
 /*
 ** Each database connection is an instance of the following structure.
 */
@@ -1741,6 +1743,7 @@ struct sqlite3 {
 #ifdef LIBSQL_ENABLE_WASM_RUNTIME
   libsql_wasm_ctx wasm;        /* WebAssembly runtime context */
 #endif
+  libsql_wal_methods* pWalMethods; /* Custom WAL methods */
 };
 
 /*
@@ -4722,8 +4725,8 @@ void sqlite3AddCollateType(Parse*, Token*);
 void sqlite3AddGenerated(Parse*,Expr*,Token*);
 void sqlite3EndTable(Parse*,Token*,Token*,u32,Select*);
 void sqlite3AddReturning(Parse*,ExprList*);
-int sqlite3ParseUri(const char*,const char*,unsigned int*,
-                    sqlite3_vfs**,char**,char **);
+int sqlite3ParseUri(const char*,const char*,const char*,unsigned int*,
+                    sqlite3_vfs**,libsql_wal_methods**,char**,char **);
 #define sqlite3CodecQueryParameters(A,B,C) 0
 Btree *sqlite3DbNameToBtree(sqlite3*,const char*);
 

--- a/src/test2.c
+++ b/src/test2.c
@@ -37,6 +37,8 @@ static void pager_test_reiniter(DbPage *pNotUsed){
   return;
 }
 
+extern libsql_wal_methods *libsql_wal_methods_find(const char*);
+
 /*
 ** Usage:   pager_open FILENAME N-PAGE
 **
@@ -50,6 +52,7 @@ static int SQLITE_TCLAPI pager_open(
 ){
   u32 pageSize;
   Pager *pPager;
+  libsql_wal_methods *pWalMethods = NULL;
   int nPage;
   int rc;
   char zBuf[100];
@@ -59,7 +62,10 @@ static int SQLITE_TCLAPI pager_open(
     return TCL_ERROR;
   }
   if( Tcl_GetInt(interp, argv[2], &nPage) ) return TCL_ERROR;
-  rc = sqlite3PagerOpen(sqlite3_vfs_find(0), &pPager, argv[1], 0, 0,
+#ifndef SQLITE_OMIT_WAL
+  pWalMethods = libsql_wal_methods_find(NULL);
+#endif
+  rc = sqlite3PagerOpen(sqlite3_vfs_find(0), pWalMethods, &pPager, argv[1], 0, 0,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB,
       pager_test_reiniter);
   if( rc!=SQLITE_OK ){

--- a/src/test3.c
+++ b/src/test3.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 extern const char *sqlite3ErrName(int);
+extern libsql_wal_methods *libsql_wal_methods_find(const char*);
 
 /*
 ** A bogus sqlite3 connection structure for use in the btree
@@ -57,6 +58,9 @@ static int SQLITE_TCLAPI btree_open(
   nRefSqlite3++;
   if( nRefSqlite3==1 ){
     sDb.pVfs = sqlite3_vfs_find(0);
+  #ifndef SQLITE_OMIT_WAL
+    sDb.pWalMethods = libsql_wal_methods_find(NULL);
+  #endif
     sDb.mutex = sqlite3MutexAlloc(SQLITE_MUTEX_RECURSIVE);
     sqlite3_mutex_enter(sDb.mutex);
   }
@@ -65,7 +69,7 @@ static int SQLITE_TCLAPI btree_open(
   if( zFilename==0 ) return TCL_ERROR;
   memcpy(zFilename, argv[1], n+1);
   zFilename[n+1] = 0;
-  rc = sqlite3BtreeOpen(sDb.pVfs, zFilename, &sDb, &pBt, 0, 
+  rc = sqlite3BtreeOpen(sDb.pVfs, sDb.pWalMethods, zFilename, &sDb, &pBt, 0, 
      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
   sqlite3_free(zFilename);
   if( rc!=SQLITE_OK ){

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -4350,7 +4350,7 @@ case OP_OpenEphemeral: {
     pCx = allocateCursor(p, pOp->p1, pOp->p2, CURTYPE_BTREE);
     if( pCx==0 ) goto no_mem;
     pCx->isEphemeral = 1;
-    rc = sqlite3BtreeOpen(db->pVfs, 0, db, &pCx->ub.pBtx, 
+    rc = sqlite3BtreeOpen(db->pVfs, db->pWalMethods, 0, db, &pCx->ub.pBtx, 
                           BTREE_OMIT_JOURNAL | BTREE_SINGLE | pOp->p5,
                           vfsFlags);
     if( rc==SQLITE_OK ){

--- a/src/wal.c
+++ b/src/wal.c
@@ -4200,6 +4200,7 @@ int libsql_wal_methods_register(libsql_wal_methods* pWalMethods) {
   sqlite3_mutex_leave(mutex);
   return SQLITE_OK;
 }
+
 int libsql_wal_methods_unregister(libsql_wal_methods *pWalMethods) {
   if (strncmp(pWalMethods->zName, "default", 7) == 0) {
     return SQLITE_MISUSE;

--- a/src/wal.c
+++ b/src/wal.c
@@ -4111,6 +4111,7 @@ libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
     zName = "default";
   }
   if (methods_head == NULL && strncmp(zName, "default", 7) == 0) {
+    methods.iVersion = 1;
     methods.xOpen = sqlite3WalOpen;
     methods.xClose = sqlite3WalClose;
     methods.xLimit = sqlite3WalLimit;

--- a/src/wal.c
+++ b/src/wal.c
@@ -4092,6 +4092,10 @@ static void libsqlGetWalPathname(char *buf, const char *orig, int orig_len) {
   memcpy(buf + orig_len, "-wal", 4);
 }
 
+static int libsqlPreMainDbOpen(struct libsql_wal_methods*, const char *) {
+  return SQLITE_OK;
+}
+
 libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
   static libsql_wal_methods methods;
   static libsql_wal_methods *methods_head = NULL; 
@@ -4146,6 +4150,7 @@ libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
     methods.xDb = sqlite3WalDb;
     methods.xPathnameLen = libsqlWalPathnameLen;
     methods.xGetWalPathname = libsqlGetWalPathname;
+    methods.xPreMainDbOpen = libsqlPreMainDbOpen;
 
     methods.bUsesShm = 1;
     methods.zName = "default";

--- a/src/wal.c
+++ b/src/wal.c
@@ -4209,4 +4209,12 @@ int libsql_wal_methods_unregister(libsql_wal_methods *pWalMethods) {
   return SQLITE_OK;
 }
 
+libsql_wal_methods *libsql_wal_methods_next(libsql_wal_methods *w) {
+  return w->pNext;
+}
+
+const char *libsql_wal_methods_name(libsql_wal_methods *w) {
+  return w->zName;
+}
+
 #endif /* #ifndef SQLITE_OMIT_WAL */

--- a/src/wal.c
+++ b/src/wal.c
@@ -4083,6 +4083,15 @@ static sqlite3_file *sqlite3WalFile(Wal *pWal){
   return pWal->pWalFd;
 }
 
+static int libsqlWalPathnameLen(int n) {
+  return n ? n + 4 : 0;
+}
+
+static void libsqlGetWalPathname(char *buf, const char *orig, int orig_len) {
+  memcpy(buf, orig, orig_len);
+  memcpy(buf + orig_len, "-wal", 4);
+}
+
 libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
   static libsql_wal_methods methods;
   static libsql_wal_methods *methods_head = NULL; 
@@ -4128,6 +4137,8 @@ libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
     methods.xWriteLock = sqlite3WalWriteLock;
 #endif
     methods.xDb = sqlite3WalDb;
+    methods.xPathnameLen = libsqlWalPathnameLen;
+    methods.xGetWalPathname = libsqlGetWalPathname;
 
     methods.bUsesShm = 1;
     methods.zName = "default";

--- a/src/wal.c
+++ b/src/wal.c
@@ -4129,6 +4129,7 @@ libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
 #endif
     methods.xDb = sqlite3WalDb;
 
+    methods.bUsesShm = 1;
     methods.zName = "default";
     methods.pNext = NULL;
     methods_head = &methods;

--- a/src/wal.c
+++ b/src/wal.c
@@ -247,6 +247,7 @@
 ** that correspond to frames greater than the new K value are removed
 ** from the hash table at this point.
 */
+#include "sqliteInt.h"
 #ifndef SQLITE_OMIT_WAL
 
 #include "wal.h"
@@ -297,40 +298,6 @@ int sqlite3WalTrace = 0;
 #define WAL_RECOVER_LOCK       2
 #define WAL_READ_LOCK(I)       (3+(I))
 #define WAL_NREADER            (SQLITE_SHM_NLOCK-3)
-
-
-/* Object declarations */
-typedef struct WalIndexHdr WalIndexHdr;
-typedef struct WalIterator WalIterator;
-typedef struct WalCkptInfo WalCkptInfo;
-
-
-/*
-** The following object holds a copy of the wal-index header content.
-**
-** The actual header in the wal-index consists of two copies of this
-** object followed by one instance of the WalCkptInfo object.
-** For all versions of SQLite through 3.10.0 and probably beyond,
-** the locking bytes (WalCkptInfo.aLock) start at offset 120 and
-** the total header size is 136 bytes.
-**
-** The szPage value can be any power of 2 between 512 and 32768, inclusive.
-** Or it can be 1 to represent a 65536-byte page.  The latter case was
-** added in 3.7.1 when support for 64K pages was added.  
-*/
-struct WalIndexHdr {
-  u32 iVersion;                   /* Wal-index version */
-  u32 unused;                     /* Unused (padding) field */
-  u32 iChange;                    /* Counter incremented each transaction */
-  u8 isInit;                      /* 1 when initialized */
-  u8 bigEndCksum;                 /* True if checksums in WAL are big-endian */
-  u16 szPage;                     /* Database page size in bytes. 1==64K */
-  u32 mxFrame;                    /* Index of last valid frame in the WAL */
-  u32 nPage;                      /* Size of database in pages */
-  u32 aFrameCksum[2];             /* Checksum of last frame in log */
-  u32 aSalt[2];                   /* Two salt values copied from WAL header */
-  u32 aCksum[2];                  /* Checksum over all prior fields */
-};
 
 /*
 ** A copy of the following object occurs in the wal-index immediately
@@ -498,46 +465,6 @@ struct WalCkptInfo {
 #define walFrameOffset(iFrame, szPage) (                               \
   WAL_HDRSIZE + ((iFrame)-1)*(i64)((szPage)+WAL_FRAME_HDRSIZE)         \
 )
-
-/*
-** An open write-ahead log file is represented by an instance of the
-** following object.
-*/
-struct Wal {
-  sqlite3_vfs *pVfs;         /* The VFS used to create pDbFd */
-  sqlite3_file *pDbFd;       /* File handle for the database file */
-  sqlite3_file *pWalFd;      /* File handle for WAL file */
-  u32 iCallback;             /* Value to pass to log callback (or 0) */
-  i64 mxWalSize;             /* Truncate WAL to this size upon reset */
-  int nWiData;               /* Size of array apWiData */
-  int szFirstBlock;          /* Size of first block written to WAL file */
-  volatile u32 **apWiData;   /* Pointer to wal-index content in memory */
-  u32 szPage;                /* Database page size */
-  i16 readLock;              /* Which read lock is being held.  -1 for none */
-  u8 syncFlags;              /* Flags to use to sync header writes */
-  u8 exclusiveMode;          /* Non-zero if connection is in exclusive mode */
-  u8 writeLock;              /* True if in a write transaction */
-  u8 ckptLock;               /* True if holding a checkpoint lock */
-  u8 readOnly;               /* WAL_RDWR, WAL_RDONLY, or WAL_SHM_RDONLY */
-  u8 truncateOnCommit;       /* True to truncate WAL file on commit */
-  u8 syncHeader;             /* Fsync the WAL header if true */
-  u8 padToSectorBoundary;    /* Pad transactions out to the next sector */
-  u8 bShmUnreliable;         /* SHM content is read-only and unreliable */
-  WalIndexHdr hdr;           /* Wal-index header for current transaction */
-  u32 minFrame;              /* Ignore wal frames before this one */
-  u32 iReCksum;              /* On commit, recalculate checksums from here */
-  const char *zWalName;      /* Name of WAL file */
-  u32 nCkpt;                 /* Checkpoint sequence counter in the wal-header */
-#ifdef SQLITE_DEBUG
-  u8 lockError;              /* True if a locking error has occurred */
-#endif
-#ifdef SQLITE_ENABLE_SNAPSHOT
-  WalIndexHdr *pSnapshot;    /* Start transaction here if not NULL */
-#endif
-#ifdef SQLITE_ENABLE_SETLK_TIMEOUT
-  sqlite3 *db;
-#endif
-};
 
 /*
 ** Candidate values for Wal.exclusiveMode.
@@ -1460,6 +1387,8 @@ static void walIndexClose(Wal *pWal, int isDelete){
 ** already be opened on connection pDbFd. The buffer that zWalName points
 ** to must remain valid for the lifetime of the returned Wal* handle.
 **
+** Custom virtual methods may be provided via the pMethods parameter.
+**
 ** A SHARED lock should be held on the database file when this function
 ** is called. The purpose of this SHARED lock is to prevent any other
 ** client from unlinking the WAL or wal-index file. If another process
@@ -1470,12 +1399,13 @@ static void walIndexClose(Wal *pWal, int isDelete){
 ** *ppWal is set to point to a new WAL handle. If an error occurs,
 ** an SQLite error code is returned and *ppWal is left unmodified.
 */
-int sqlite3WalOpen(
+static int sqlite3WalOpen(
   sqlite3_vfs *pVfs,              /* vfs module to open wal and wal-index */
   sqlite3_file *pDbFd,            /* The open database file */
   const char *zWalName,           /* Name of the WAL file */
   int bNoShm,                     /* True to run in heap-memory mode */
   i64 mxWalSize,                  /* Truncate WAL to this size on reset */
+  libsql_wal_methods* pMethods,   /* Virtual methods for interacting with WAL */
   Wal **ppWal                     /* OUT: Allocated Wal handle */
 ){
   int rc;                         /* Return Code */
@@ -1567,13 +1497,14 @@ int sqlite3WalOpen(
     *ppWal = pRet;
     WALTRACE(("WAL%d: opened\n", pRet));
   }
+  pRet->pMethods = pMethods;
   return rc;
 }
 
 /*
 ** Change the size to which the WAL file is trucated on each reset.
 */
-void sqlite3WalLimit(Wal *pWal, i64 iLimit){
+static void sqlite3WalLimit(Wal *pWal, i64 iLimit){
   if( pWal ) pWal->mxWalSize = iLimit;
 }
 
@@ -1890,7 +1821,7 @@ static void walDisableBlocking(Wal *pWal){
 **
 ** If the bLock parameter is false and the WRITER lock is held, release it.
 */
-int sqlite3WalWriteLock(Wal *pWal, int bLock){
+static int sqlite3WalWriteLock(Wal *pWal, int bLock){
   int rc = SQLITE_OK;
   assert( pWal->readLock<0 || bLock==0 );
   if( bLock ){
@@ -1910,13 +1841,6 @@ int sqlite3WalWriteLock(Wal *pWal, int bLock){
 }
 
 /*
-** Set the database handle used to determine if blocking locks are required.
-*/
-void sqlite3WalDb(Wal *pWal, sqlite3 *db){
-  pWal->db = db;
-}
-
-/*
 ** Take an exclusive WRITE lock. Blocking if so configured.
 */
 static int walLockWriter(Wal *pWal){
@@ -1930,9 +1854,16 @@ static int walLockWriter(Wal *pWal){
 # define walEnableBlocking(x) 0
 # define walDisableBlocking(x)
 # define walLockWriter(pWal) walLockExclusive((pWal), WAL_WRITE_LOCK, 1)
-# define sqlite3WalDb(pWal, db)
 #endif   /* ifdef SQLITE_ENABLE_SETLK_TIMEOUT */
 
+/*
+** Set the database handle used to determine if blocking locks are required.
+*/
+static void sqlite3WalDb(Wal *pWal, sqlite3 *db){
+#ifdef SQLITE_ENABLE_SETLK_TIMEOUT
+  pWal->db = db;
+#endif
+}
 
 /*
 ** Attempt to obtain the exclusive WAL lock defined by parameters lockIdx and
@@ -2235,7 +2166,7 @@ static void walLimitSize(Wal *pWal, i64 nMax){
 /*
 ** Close a connection to a log file.
 */
-int sqlite3WalClose(
+static int sqlite3WalClose(
   Wal *pWal,                      /* Wal to close */
   sqlite3 *db,                    /* For interrupt flag */
   int sync_flags,                 /* Flags to pass to OsSync() (or 0) */
@@ -2260,7 +2191,7 @@ int sqlite3WalClose(
       if( pWal->exclusiveMode==WAL_NORMAL_MODE ){
         pWal->exclusiveMode = WAL_EXCLUSIVE_MODE;
       }
-      rc = sqlite3WalCheckpoint(pWal, db, 
+      rc = pWal->pMethods->xCheckpoint(pWal, db, 
           SQLITE_CHECKPOINT_PASSIVE, 0, 0, sync_flags, nBuf, zBuf, 0, 0
       );
       if( rc==SQLITE_OK ){
@@ -2651,7 +2582,7 @@ static int walBeginShmUnreliable(Wal *pWal, int *pChanged){
       pWal->apWiData[i] = 0;
     }
     pWal->bShmUnreliable = 0;
-    sqlite3WalEndReadTransaction(pWal);
+    pWal->pMethods->xEndReadTransaction(pWal);
     *pChanged = 1;
   }
   return rc;
@@ -2937,7 +2868,7 @@ static int walTryBeginRead(Wal *pWal, int *pChanged, int useWal, int cnt){
 ** error occurs. It is not an error if nBackfillAttempted cannot be
 ** decreased at all.
 */
-int sqlite3WalSnapshotRecover(Wal *pWal){
+static int sqlite3WalSnapshotRecover(Wal *pWal){
   int rc;
 
   assert( pWal->readLock>=0 );
@@ -3008,7 +2939,7 @@ int sqlite3WalSnapshotRecover(Wal *pWal){
 ** Pager layer will use this to know that its cache is stale and
 ** needs to be flushed.
 */
-int sqlite3WalBeginReadTransaction(Wal *pWal, int *pChanged){
+static int sqlite3WalBeginReadTransaction(Wal *pWal, int *pChanged){
   int rc;                         /* Return code */
   int cnt = 0;                    /* Number of TryBeginRead attempts */
 #ifdef SQLITE_ENABLE_SNAPSHOT
@@ -3097,7 +3028,7 @@ int sqlite3WalBeginReadTransaction(Wal *pWal, int *pChanged){
       pWal->minFrame = 1;
 
       if( rc!=SQLITE_OK ){
-        sqlite3WalEndReadTransaction(pWal);
+        pWal->pMethods->xEndReadTransaction(pWal);
       }
     }
   }
@@ -3116,8 +3047,8 @@ int sqlite3WalBeginReadTransaction(Wal *pWal, int *pChanged){
 ** Finish with a read transaction.  All this does is release the
 ** read-lock.
 */
-void sqlite3WalEndReadTransaction(Wal *pWal){
-  sqlite3WalEndWriteTransaction(pWal);
+static void sqlite3WalEndReadTransaction(Wal *pWal){
+  pWal->pMethods->xEndWriteTransaction(pWal);
   if( pWal->readLock>=0 ){
     walUnlockShared(pWal, WAL_READ_LOCK(pWal->readLock));
     pWal->readLock = -1;
@@ -3132,7 +3063,7 @@ void sqlite3WalEndReadTransaction(Wal *pWal){
 ** Return SQLITE_OK if successful, or an error code if an error occurs. If an
 ** error does occur, the final value of *piRead is undefined.
 */
-int sqlite3WalFindFrame(
+static int sqlite3WalFindFrame(
   Wal *pWal,                      /* WAL handle */
   Pgno pgno,                      /* Database page number to read data for */
   u32 *piRead                     /* OUT: Frame number (or zero) */
@@ -3236,7 +3167,7 @@ int sqlite3WalFindFrame(
 ** (which is nOut bytes in size). Return SQLITE_OK if successful, or an
 ** error code otherwise.
 */
-int sqlite3WalReadFrame(
+static int sqlite3WalReadFrame(
   Wal *pWal,                      /* WAL handle */
   u32 iRead,                      /* Frame to read */
   int nOut,                       /* Size of buffer pOut in bytes */
@@ -3256,7 +3187,7 @@ int sqlite3WalReadFrame(
 /* 
 ** Return the size of the database in pages (or zero, if unknown).
 */
-Pgno sqlite3WalDbsize(Wal *pWal){
+static Pgno sqlite3WalDbsize(Wal *pWal){
   if( pWal && ALWAYS(pWal->readLock>=0) ){
     return pWal->hdr.nPage;
   }
@@ -3277,7 +3208,7 @@ Pgno sqlite3WalDbsize(Wal *pWal){
 **
 ** There can only be a single writer active at a time.
 */
-int sqlite3WalBeginWriteTransaction(Wal *pWal){
+static int sqlite3WalBeginWriteTransaction(Wal *pWal){
   int rc;
 
 #ifdef SQLITE_ENABLE_SETLK_TIMEOUT
@@ -3325,7 +3256,7 @@ int sqlite3WalBeginWriteTransaction(Wal *pWal){
 ** End a write transaction.  The commit has already been done.  This
 ** routine merely releases the lock.
 */
-int sqlite3WalEndWriteTransaction(Wal *pWal){
+static int sqlite3WalEndWriteTransaction(Wal *pWal){
   if( pWal->writeLock ){
     walUnlockExclusive(pWal, WAL_WRITE_LOCK, 1);
     pWal->writeLock = 0;
@@ -3347,7 +3278,7 @@ int sqlite3WalEndWriteTransaction(Wal *pWal){
 ** Otherwise, if the callback function does not return an error, this
 ** function returns SQLITE_OK.
 */
-int sqlite3WalUndo(Wal *pWal, int (*xUndo)(void *, Pgno), void *pUndoCtx){
+static int sqlite3WalUndo(Wal *pWal, int (*xUndo)(void *, Pgno), void *pUndoCtx){
   int rc = SQLITE_OK;
   if( ALWAYS(pWal->writeLock) ){
     Pgno iMax = pWal->hdr.mxFrame;
@@ -3387,7 +3318,7 @@ int sqlite3WalUndo(Wal *pWal, int (*xUndo)(void *, Pgno), void *pUndoCtx){
 ** "rollback" the write position of the WAL handle back to the current 
 ** point in the event of a savepoint rollback (via WalSavepointUndo()).
 */
-void sqlite3WalSavepoint(Wal *pWal, u32 *aWalData){
+static void sqlite3WalSavepoint(Wal *pWal, u32 *aWalData){
   assert( pWal->writeLock );
   aWalData[0] = pWal->hdr.mxFrame;
   aWalData[1] = pWal->hdr.aFrameCksum[0];
@@ -3401,7 +3332,7 @@ void sqlite3WalSavepoint(Wal *pWal, u32 *aWalData){
 ** of WAL_SAVEPOINT_NDATA u32 values that has been previously populated
 ** by a call to WalSavepoint().
 */
-int sqlite3WalSavepointUndo(Wal *pWal, u32 *aWalData){
+static int sqlite3WalSavepointUndo(Wal *pWal, u32 *aWalData){
   int rc = SQLITE_OK;
 
   assert( pWal->writeLock );
@@ -3601,7 +3532,7 @@ static int walRewriteChecksums(Wal *pWal, u32 iLast){
 ** Write a set of frames to the log. The caller must hold the write-lock
 ** on the log file (obtained using sqlite3WalBeginWriteTransaction()).
 */
-int sqlite3WalFrames(
+static int sqlite3WalFrames(
   Wal *pWal,                      /* Wal handle to write to */
   int szPage,                     /* Database page-size in bytes */
   PgHdr *pList,                   /* List of dirty pages to write */
@@ -3710,7 +3641,7 @@ int sqlite3WalFrames(
     ** checksums must be recomputed when the transaction is committed.  */
     if( iFirst && (p->pDirty || isCommit==0) ){
       u32 iWrite = 0;
-      VVA_ONLY(rc =) sqlite3WalFindFrame(pWal, p->pgno, &iWrite);
+      VVA_ONLY(rc =) pWal->pMethods->xFindFrame(pWal, p->pgno, &iWrite);
       assert( rc==SQLITE_OK || iWrite==0 );
       if( iWrite>=iFirst ){
         i64 iOff = walFrameOffset(iWrite, szPage) + WAL_FRAME_HDRSIZE;
@@ -3839,7 +3770,7 @@ int sqlite3WalFrames(
 ** If parameter xBusy is not NULL, it is a pointer to a busy-handler
 ** callback. In this case this function runs a blocking checkpoint.
 */
-int sqlite3WalCheckpoint(
+static int sqlite3WalCheckpoint(
   Wal *pWal,                      /* Wal connection */
   sqlite3 *db,                    /* Check this handle's interrupt flag */
   int eMode,                      /* PASSIVE, FULL, RESTART, or TRUNCATE */
@@ -3868,7 +3799,7 @@ int sqlite3WalCheckpoint(
 
   /* Enable blocking locks, if possible. If blocking locks are successfully
   ** enabled, set xBusy2=0 so that the busy-handler is never invoked. */
-  sqlite3WalDb(pWal, db);
+  pWal->pMethods->xDb(pWal, db);
   (void)walEnableBlocking(pWal);
 
   /* IMPLEMENTATION-OF: R-62028-47212 All calls obtain an exclusive 
@@ -3944,10 +3875,10 @@ int sqlite3WalCheckpoint(
   }
 
   walDisableBlocking(pWal);
-  sqlite3WalDb(pWal, 0);
+  pWal->pMethods->xDb(pWal, 0);
 
   /* Release the locks. */
-  sqlite3WalEndWriteTransaction(pWal);
+  pWal->pMethods->xEndWriteTransaction(pWal);
   if( pWal->ckptLock ){
     walUnlockExclusive(pWal, WAL_CKPT_LOCK, 1);
     pWal->ckptLock = 0;
@@ -3964,7 +3895,7 @@ int sqlite3WalCheckpoint(
 ** sqlite3WalCallback() was called.  If no commits have occurred since
 ** the last call, then return 0.
 */
-int sqlite3WalCallback(Wal *pWal){
+static int sqlite3WalCallback(Wal *pWal){
   u32 ret = 0;
   if( pWal ){
     ret = pWal->iCallback;
@@ -3997,7 +3928,7 @@ int sqlite3WalCallback(Wal *pWal){
 ** should acquire the database exclusive lock prior to invoking
 ** the op==1 case.
 */
-int sqlite3WalExclusiveMode(Wal *pWal, int op){
+static int sqlite3WalExclusiveMode(Wal *pWal, int op){
   int rc;
   assert( pWal->writeLock==0 );
   assert( pWal->exclusiveMode!=WAL_HEAPMEMORY_MODE || op==-1 );
@@ -4039,7 +3970,7 @@ int sqlite3WalExclusiveMode(Wal *pWal, int op){
 ** heap-memory for the wal-index. Otherwise, if the argument is NULL or the
 ** WAL module is using shared-memory, return false. 
 */
-int sqlite3WalHeapMemory(Wal *pWal){
+static int sqlite3WalHeapMemory(Wal *pWal){
   return (pWal && pWal->exclusiveMode==WAL_HEAPMEMORY_MODE );
 }
 
@@ -4048,7 +3979,7 @@ int sqlite3WalHeapMemory(Wal *pWal){
 ** every other subsystem, so the WAL module can put whatever it needs
 ** in the object.
 */
-int sqlite3WalSnapshotGet(Wal *pWal, sqlite3_snapshot **ppSnapshot){
+static int sqlite3WalSnapshotGet(Wal *pWal, sqlite3_snapshot **ppSnapshot){
   int rc = SQLITE_OK;
   WalIndexHdr *pRet;
   static const u32 aZero[4] = { 0, 0, 0, 0 };
@@ -4072,7 +4003,7 @@ int sqlite3WalSnapshotGet(Wal *pWal, sqlite3_snapshot **ppSnapshot){
 
 /* Try to open on pSnapshot when the next read-transaction starts
 */
-void sqlite3WalSnapshotOpen(
+static void sqlite3WalSnapshotOpen(
   Wal *pWal, 
   sqlite3_snapshot *pSnapshot
 ){
@@ -4083,7 +4014,7 @@ void sqlite3WalSnapshotOpen(
 ** Return a +ve value if snapshot p1 is newer than p2. A -ve value if
 ** p1 is older than p2 and zero if p1 and p2 are the same snapshot.
 */
-int sqlite3_snapshot_cmp(sqlite3_snapshot *p1, sqlite3_snapshot *p2){
+static int sqlite3_snapshot_cmp(sqlite3_snapshot *p1, sqlite3_snapshot *p2){
   WalIndexHdr *pHdr1 = (WalIndexHdr*)p1;
   WalIndexHdr *pHdr2 = (WalIndexHdr*)p2;
 
@@ -4107,7 +4038,7 @@ int sqlite3_snapshot_cmp(sqlite3_snapshot *p1, sqlite3_snapshot *p2){
 ** occurs (any value other than SQLITE_OK is returned), the CHECKPOINTER
 ** lock is released before returning.
 */
-int sqlite3WalSnapshotCheck(Wal *pWal, sqlite3_snapshot *pSnapshot){
+static int sqlite3WalSnapshotCheck(Wal *pWal, sqlite3_snapshot *pSnapshot){
   int rc;
   rc = walLockShared(pWal, WAL_CKPT_LOCK);
   if( rc==SQLITE_OK ){
@@ -4126,7 +4057,7 @@ int sqlite3WalSnapshotCheck(Wal *pWal, sqlite3_snapshot *pSnapshot){
 ** Release a lock obtained by an earlier successful call to
 ** sqlite3WalSnapshotCheck().
 */
-void sqlite3WalSnapshotUnlock(Wal *pWal){
+static void sqlite3WalSnapshotUnlock(Wal *pWal){
   assert( pWal );
   walUnlockShared(pWal, WAL_CKPT_LOCK);
 }
@@ -4140,7 +4071,7 @@ void sqlite3WalSnapshotUnlock(Wal *pWal){
 ** read-lock. This function returns the database page-size if it is known,
 ** or zero if it is not (or if pWal is NULL).
 */
-int sqlite3WalFramesize(Wal *pWal){
+static int sqlite3WalFramesize(Wal *pWal){
   assert( pWal==0 || pWal->readLock>=0 );
   return (pWal ? pWal->szPage : 0);
 }
@@ -4148,8 +4079,122 @@ int sqlite3WalFramesize(Wal *pWal){
 
 /* Return the sqlite3_file object for the WAL file
 */
-sqlite3_file *sqlite3WalFile(Wal *pWal){
+static sqlite3_file *sqlite3WalFile(Wal *pWal){
   return pWal->pWalFd;
+}
+
+libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
+  static libsql_wal_methods methods;
+  static libsql_wal_methods *methods_head = NULL; 
+
+  if (!zName || *zName == '\0') {
+    zName = "default";
+  }
+  if (methods_head == NULL && strncmp(zName, "default", 7) == 0) {
+    methods.xOpen = sqlite3WalOpen;
+    methods.xClose = sqlite3WalClose;
+    methods.xLimit = sqlite3WalLimit;
+    methods.xBeginReadTransaction = sqlite3WalBeginReadTransaction;
+    methods.xEndReadTransaction = sqlite3WalEndReadTransaction;
+    methods.xFindFrame = sqlite3WalFindFrame;
+    methods.xReadFrame = sqlite3WalReadFrame;
+    methods.xDbsize = sqlite3WalDbsize;
+    methods.xBeginWriteTransaction = sqlite3WalBeginWriteTransaction;
+    methods.xEndWriteTransaction = sqlite3WalEndWriteTransaction;
+    methods.xUndo = sqlite3WalUndo;
+    methods.xSavepoint = sqlite3WalSavepoint;
+    methods.xSavepointUndo = sqlite3WalSavepointUndo;
+    methods.xFrames = sqlite3WalFrames;
+    methods.xCheckpoint = sqlite3WalCheckpoint;
+    methods.xCallback = sqlite3WalCallback;
+    methods.xExclusiveMode = sqlite3WalExclusiveMode;
+    methods.xHeapMemory = sqlite3WalHeapMemory;
+
+#ifdef SQLITE_ENABLE_SNAPSHOT
+    methods.xSnapshotGet = sqlite3WalSnapshotGet;
+    methods.xSnapshotOpen = sqlite3WalSnapshotOpen;
+    methods.xSnapshotRecover = sqlite3WalSnapshotRecover;
+    methods.xSnapshotCheck = sqlite3WalSnapshotCheck;
+    methods.xSnapshotUnlock = sqlite3WalSnapshotUnlock;
+#endif
+
+#ifdef SQLITE_ENABLE_ZIPVFS
+    methods.xFramesize = sqlite3WalFramesize;
+#endif
+
+    methods.xFile = sqlite3WalFile;
+
+#ifdef SQLITE_ENABLE_SETLK_TIMEOUT
+    methods.xWriteLock = sqlite3WalWriteLock;
+#endif
+    methods.xDb = sqlite3WalDb;
+
+    methods.zName = "default";
+    methods.pNext = NULL;
+    methods_head = &methods;
+
+    return methods_head;
+  }
+
+  // Look up in the methods table
+  for (libsql_wal_methods *m = methods_head; m != NULL; m = m->pNext) {
+    if (m && strcmp(zName, m->zName) == 0) {
+      return m;
+    }
+  }
+
+  return NULL;
+}
+
+int libsql_wal_methods_register(libsql_wal_methods* pWalMethods) {
+  if (strncmp(pWalMethods->zName, "default", 7) == 0) {
+    return SQLITE_MISUSE;
+  }
+  MUTEX_LOGIC(sqlite3_mutex *mutex;)
+  MUTEX_LOGIC( mutex = sqlite3MutexAlloc(SQLITE_MUTEX_STATIC_MAIN); )
+  sqlite3_mutex_enter(mutex);
+
+  libsql_wal_methods *prev = libsql_wal_methods_find("default");
+  libsql_wal_methods *m = prev->pNext;
+
+  while (1) {
+    if (m == NULL) {
+      prev->pNext = pWalMethods;
+      pWalMethods->pNext = NULL;
+      break;
+    }
+    if (strcmp(m->zName, pWalMethods->zName) == 0) {
+      prev->pNext = pWalMethods;
+      pWalMethods->pNext = m->pNext;
+      break;
+    }
+    prev = m;
+    m = m->pNext;
+  }
+  sqlite3_mutex_leave(mutex);
+  return SQLITE_OK;
+}
+int libsql_wal_methods_unregister(libsql_wal_methods *pWalMethods) {
+  if (strncmp(pWalMethods->zName, "default", 7) == 0) {
+    return SQLITE_MISUSE;
+  }
+  MUTEX_LOGIC(sqlite3_mutex *mutex;)
+  MUTEX_LOGIC( mutex = sqlite3MutexAlloc(SQLITE_MUTEX_STATIC_MAIN); )
+  sqlite3_mutex_enter(mutex);
+
+  libsql_wal_methods *prev = libsql_wal_methods_find("default");
+  libsql_wal_methods *m = prev->pNext;
+
+  while (m != NULL) {
+    if (strcmp(m->zName, pWalMethods->zName) == 0) {
+      prev->pNext = m->pNext;
+      break;
+    }
+    prev = m;
+    m = m->pNext;
+  }
+  sqlite3_mutex_leave(mutex);
+  return SQLITE_OK;
 }
 
 #endif /* #ifndef SQLITE_OMIT_WAL */

--- a/src/wal.c
+++ b/src/wal.c
@@ -4096,6 +4096,13 @@ libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
   static libsql_wal_methods methods;
   static libsql_wal_methods *methods_head = NULL; 
 
+#ifndef SQLITE_OMIT_AUTOINIT
+  int rc = sqlite3_initialize();
+  if (rc != SQLITE_OK) {
+    return NULL;
+  }
+#endif
+
   if (!zName || *zName == '\0') {
     zName = "default";
   }
@@ -4159,6 +4166,13 @@ libsql_wal_methods *libsql_wal_methods_find(const char *zName) {
 }
 
 int libsql_wal_methods_register(libsql_wal_methods* pWalMethods) {
+#ifndef SQLITE_OMIT_AUTOINIT
+  int rc = sqlite3_initialize();
+  if (rc != SQLITE_OK) {
+    return rc;
+  }
+#endif
+
   if (strncmp(pWalMethods->zName, "default", 7) == 0) {
     return SQLITE_MISUSE;
   }

--- a/src/wal.h
+++ b/src/wal.h
@@ -25,28 +25,6 @@
 #define WAL_SYNC_FLAGS(X)   ((X)&0x03)
 #define CKPT_SYNC_FLAGS(X)  (((X)>>2)&0x03)
 
-#ifdef SQLITE_OMIT_WAL
-# define sqlite3WalOpen(x,y,z)                   0
-# define sqlite3WalLimit(x,y)
-# define sqlite3WalClose(v,w,x,y,z)              0
-# define sqlite3WalBeginReadTransaction(y,z)     0
-# define sqlite3WalEndReadTransaction(z)
-# define sqlite3WalDbsize(y)                     0
-# define sqlite3WalBeginWriteTransaction(y)      0
-# define sqlite3WalEndWriteTransaction(x)        0
-# define sqlite3WalUndo(x,y,z)                   0
-# define sqlite3WalSavepoint(y,z)
-# define sqlite3WalSavepointUndo(y,z)            0
-# define sqlite3WalFrames(u,v,w,x,y,z)           0
-# define sqlite3WalCheckpoint(q,r,s,t,u,v,w,x,y,z) 0
-# define sqlite3WalCallback(z)                   0
-# define sqlite3WalExclusiveMode(y,z)            0
-# define sqlite3WalHeapMemory(z)                 0
-# define sqlite3WalFramesize(z)                  0
-# define sqlite3WalFindFrame(x,y,z)              0
-# define sqlite3WalFile(x)                       0
-#else
-
 #define WAL_SAVEPOINT_NDATA 4
 
 /* Connection to a write-ahead log (WAL) file. 
@@ -54,102 +32,183 @@
 */
 typedef struct Wal Wal;
 
-/* Open and close a connection to a write-ahead log. */
-int sqlite3WalOpen(sqlite3_vfs*, sqlite3_file*, const char *, int, i64, Wal**);
-int sqlite3WalClose(Wal *pWal, sqlite3*, int sync_flags, int, u8 *);
+typedef struct libsql_wal_methods {
+  /* Open and close a connection to a write-ahead log. */
+  int (*xOpen)(sqlite3_vfs*, sqlite3_file* , const char*, int no_shm_mode, i64 max_size, struct libsql_wal_methods*, Wal**);
+  int (*xClose)(Wal*, sqlite3* db, int sync_flags, int nBuf, u8 *zBuf);
 
-/* Set the limiting size of a WAL file. */
-void sqlite3WalLimit(Wal*, i64);
+  /* Set the limiting size of a WAL file. */
+  void (*xLimit)(Wal*, i64 limit);
 
-/* Used by readers to open (lock) and close (unlock) a snapshot.  A 
-** snapshot is like a read-transaction.  It is the state of the database
-** at an instant in time.  sqlite3WalOpenSnapshot gets a read lock and
-** preserves the current state even if the other threads or processes
-** write to or checkpoint the WAL.  sqlite3WalCloseSnapshot() closes the
-** transaction and releases the lock.
-*/
-int sqlite3WalBeginReadTransaction(Wal *pWal, int *);
-void sqlite3WalEndReadTransaction(Wal *pWal);
+  /* Used by readers to open (lock) and close (unlock) a snapshot.  A 
+  ** snapshot is like a read-transaction.  It is the state of the database
+  ** at an instant in time.  sqlite3WalOpenSnapshot gets a read lock and
+  ** preserves the current state even if the other threads or processes
+  ** write to or checkpoint the WAL.  sqlite3WalCloseSnapshot() closes the
+  ** transaction and releases the lock.
+  */
+  int (*xBeginReadTransaction)(Wal *, int *);
+  void (*xEndReadTransaction)(Wal *);
 
-/* Read a page from the write-ahead log, if it is present. */
-int sqlite3WalFindFrame(Wal *, Pgno, u32 *);
-int sqlite3WalReadFrame(Wal *, u32, int, u8 *);
+  /* Read a page from the write-ahead log, if it is present. */
+  int (*xFindFrame)(Wal *, Pgno, u32 *);
+  int (*xReadFrame)(Wal *, u32, int, u8 *);
 
-/* If the WAL is not empty, return the size of the database. */
-Pgno sqlite3WalDbsize(Wal *pWal);
+  /* If the WAL is not empty, return the size of the database. */
+  Pgno (*xDbsize)(Wal *pWal);
 
-/* Obtain or release the WRITER lock. */
-int sqlite3WalBeginWriteTransaction(Wal *pWal);
-int sqlite3WalEndWriteTransaction(Wal *pWal);
+  /* Obtain or release the WRITER lock. */
+  int (*xBeginWriteTransaction)(Wal *pWal);
+  int (*xEndWriteTransaction)(Wal *pWal);
 
-/* Undo any frames written (but not committed) to the log */
-int sqlite3WalUndo(Wal *pWal, int (*xUndo)(void *, Pgno), void *pUndoCtx);
+  /* Undo any frames written (but not committed) to the log */
+  int (*xUndo)(Wal *pWal, int (*xUndo)(void *, Pgno), void *pUndoCtx);
 
-/* Return an integer that records the current (uncommitted) write
-** position in the WAL */
-void sqlite3WalSavepoint(Wal *pWal, u32 *aWalData);
+  /* Return an integer that records the current (uncommitted) write
+  ** position in the WAL */
+  void (*xSavepoint)(Wal *pWal, u32 *aWalData);
 
-/* Move the write position of the WAL back to iFrame.  Called in
-** response to a ROLLBACK TO command. */
-int sqlite3WalSavepointUndo(Wal *pWal, u32 *aWalData);
+  /* Move the write position of the WAL back to iFrame.  Called in
+  ** response to a ROLLBACK TO command. */
+  int (*xSavepointUndo)(Wal *pWal, u32 *aWalData);
 
-/* Write a frame or frames to the log. */
-int sqlite3WalFrames(Wal *pWal, int, PgHdr *, Pgno, int, int);
+  /* Write a frame or frames to the log. */
+  int (*xFrames)(Wal *pWal, int, PgHdr *, Pgno, int, int);
 
-/* Copy pages from the log to the database file */ 
-int sqlite3WalCheckpoint(
-  Wal *pWal,                      /* Write-ahead log connection */
-  sqlite3 *db,                    /* Check this handle's interrupt flag */
-  int eMode,                      /* One of PASSIVE, FULL and RESTART */
-  int (*xBusy)(void*),            /* Function to call when busy */
-  void *pBusyArg,                 /* Context argument for xBusyHandler */
-  int sync_flags,                 /* Flags to sync db file with (or 0) */
-  int nBuf,                       /* Size of buffer nBuf */
-  u8 *zBuf,                       /* Temporary buffer to use */
-  int *pnLog,                     /* OUT: Number of frames in WAL */
-  int *pnCkpt                     /* OUT: Number of backfilled frames in WAL */
-);
+  /* Copy pages from the log to the database file */ 
+  int (*xCheckpoint)(
+    Wal *pWal,                      /* Write-ahead log connection */
+    sqlite3 *db,                    /* Check this handle's interrupt flag */
+    int eMode,                      /* One of PASSIVE, FULL and RESTART */
+    int (*xBusy)(void*),            /* Function to call when busy */
+    void *pBusyArg,                 /* Context argument for xBusyHandler */
+    int sync_flags,                 /* Flags to sync db file with (or 0) */
+    int nBuf,                       /* Size of buffer nBuf */
+    u8 *zBuf,                       /* Temporary buffer to use */
+    int *pnLog,                     /* OUT: Number of frames in WAL */
+    int *pnCkpt                     /* OUT: Number of backfilled frames in WAL */
+  );
 
-/* Return the value to pass to a sqlite3_wal_hook callback, the
-** number of frames in the WAL at the point of the last commit since
-** sqlite3WalCallback() was called.  If no commits have occurred since
-** the last call, then return 0.
-*/
-int sqlite3WalCallback(Wal *pWal);
+  /* Return the value to pass to a sqlite3_wal_hook callback, the
+  ** number of frames in the WAL at the point of the last commit since
+  ** sqlite3WalCallback() was called.  If no commits have occurred since
+  ** the last call, then return 0.
+  */
+  int (*xCallback)(Wal *pWal);
 
-/* Tell the wal layer that an EXCLUSIVE lock has been obtained (or released)
-** by the pager layer on the database file.
-*/
-int sqlite3WalExclusiveMode(Wal *pWal, int op);
+  /* Tell the wal layer that an EXCLUSIVE lock has been obtained (or released)
+  ** by the pager layer on the database file.
+  */
+  int (*xExclusiveMode)(Wal *pWal, int op);
 
-/* Return true if the argument is non-NULL and the WAL module is using
-** heap-memory for the wal-index. Otherwise, if the argument is NULL or the
-** WAL module is using shared-memory, return false. 
-*/
-int sqlite3WalHeapMemory(Wal *pWal);
+  /* Return true if the argument is non-NULL and the WAL module is using
+  ** heap-memory for the wal-index. Otherwise, if the argument is NULL or the
+  ** WAL module is using shared-memory, return false. 
+  */
+  int (*xHeapMemory)(Wal *pWal);
 
 #ifdef SQLITE_ENABLE_SNAPSHOT
-int sqlite3WalSnapshotGet(Wal *pWal, sqlite3_snapshot **ppSnapshot);
-void sqlite3WalSnapshotOpen(Wal *pWal, sqlite3_snapshot *pSnapshot);
-int sqlite3WalSnapshotRecover(Wal *pWal);
-int sqlite3WalSnapshotCheck(Wal *pWal, sqlite3_snapshot *pSnapshot);
-void sqlite3WalSnapshotUnlock(Wal *pWal);
+  int (*xSnapshotGet)(Wal *pWal, sqlite3_snapshot **ppSnapshot);
+  void (*xSnapshotOpen)(Wal *pWal, sqlite3_snapshot *pSnapshot);
+  int (*xSnapshotRecover)(Wal *pWal);
+  int (*xSnapshotCheck)(Wal *pWal, sqlite3_snapshot *pSnapshot);
+  void (*xSnapshotUnlock)(Wal *pWal);
 #endif
 
 #ifdef SQLITE_ENABLE_ZIPVFS
-/* If the WAL file is not empty, return the number of bytes of content
-** stored in each frame (i.e. the db page-size when the WAL was created).
-*/
-int sqlite3WalFramesize(Wal *pWal);
+  /* If the WAL file is not empty, return the number of bytes of content
+  ** stored in each frame (i.e. the db page-size when the WAL was created).
+  */
+  int (*xFramesize)(Wal *pWal);
 #endif
 
-/* Return the sqlite3_file object for the WAL file */
-sqlite3_file *sqlite3WalFile(Wal *pWal);
+  /* Return the sqlite3_file object for the WAL file */
+  sqlite3_file *(*xFile)(Wal *pWal);
 
 #ifdef SQLITE_ENABLE_SETLK_TIMEOUT
-int sqlite3WalWriteLock(Wal *pWal, int bLock);
-void sqlite3WalDb(Wal *pWal, sqlite3 *db);
+  int (*xWriteLock)(Wal *pWal, int bLock);
 #endif
 
-#endif /* ifndef SQLITE_OMIT_WAL */
+  void (*xDb)(Wal *pWal, sqlite3 *db);
+
+  const char *zName;
+  struct libsql_wal_methods *pNext;
+} libsql_wal_methods;
+
+libsql_wal_methods* libsql_wal_methods_find(const char *zName);
+
+/* Object declarations */
+typedef struct WalIndexHdr WalIndexHdr;
+typedef struct WalIterator WalIterator;
+typedef struct WalCkptInfo WalCkptInfo;
+
+
+/*
+** The following object holds a copy of the wal-index header content.
+**
+** The actual header in the wal-index consists of two copies of this
+** object followed by one instance of the WalCkptInfo object.
+** For all versions of SQLite through 3.10.0 and probably beyond,
+** the locking bytes (WalCkptInfo.aLock) start at offset 120 and
+** the total header size is 136 bytes.
+**
+** The szPage value can be any power of 2 between 512 and 32768, inclusive.
+** Or it can be 1 to represent a 65536-byte page.  The latter case was
+** added in 3.7.1 when support for 64K pages was added.  
+*/
+struct WalIndexHdr {
+  u32 iVersion;                   /* Wal-index version */
+  u32 unused;                     /* Unused (padding) field */
+  u32 iChange;                    /* Counter incremented each transaction */
+  u8 isInit;                      /* 1 when initialized */
+  u8 bigEndCksum;                 /* True if checksums in WAL are big-endian */
+  u16 szPage;                     /* Database page size in bytes. 1==64K */
+  u32 mxFrame;                    /* Index of last valid frame in the WAL */
+  u32 nPage;                      /* Size of database in pages */
+  u32 aFrameCksum[2];             /* Checksum of last frame in log */
+  u32 aSalt[2];                   /* Two salt values copied from WAL header */
+  u32 aCksum[2];                  /* Checksum over all prior fields */
+};
+
+/*
+** An open write-ahead log file is represented by an instance of the
+** following object.
+*/
+struct Wal {
+  sqlite3_vfs *pVfs;         /* The VFS used to create pDbFd */
+  sqlite3_file *pDbFd;       /* File handle for the database file */
+  sqlite3_file *pWalFd;      /* File handle for WAL file */
+  u32 iCallback;             /* Value to pass to log callback (or 0) */
+  i64 mxWalSize;             /* Truncate WAL to this size upon reset */
+  int nWiData;               /* Size of array apWiData */
+  int szFirstBlock;          /* Size of first block written to WAL file */
+  volatile u32 **apWiData;   /* Pointer to wal-index content in memory */
+  u32 szPage;                /* Database page size */
+  i16 readLock;              /* Which read lock is being held.  -1 for none */
+  u8 syncFlags;              /* Flags to use to sync header writes */
+  u8 exclusiveMode;          /* Non-zero if connection is in exclusive mode */
+  u8 writeLock;              /* True if in a write transaction */
+  u8 ckptLock;               /* True if holding a checkpoint lock */
+  u8 readOnly;               /* WAL_RDWR, WAL_RDONLY, or WAL_SHM_RDONLY */
+  u8 truncateOnCommit;       /* True to truncate WAL file on commit */
+  u8 syncHeader;             /* Fsync the WAL header if true */
+  u8 padToSectorBoundary;    /* Pad transactions out to the next sector */
+  u8 bShmUnreliable;         /* SHM content is read-only and unreliable */
+  WalIndexHdr hdr;           /* Wal-index header for current transaction */
+  u32 minFrame;              /* Ignore wal frames before this one */
+  u32 iReCksum;              /* On commit, recalculate checksums from here */
+  const char *zWalName;      /* Name of WAL file */
+  u32 nCkpt;                 /* Checkpoint sequence counter in the wal-header */
+#ifdef SQLITE_DEBUG
+  u8 lockError;              /* True if a locking error has occurred */
+#endif
+#ifdef SQLITE_ENABLE_SNAPSHOT
+  WalIndexHdr *pSnapshot;    /* Start transaction here if not NULL */
+#endif
+#ifdef SQLITE_ENABLE_SETLK_TIMEOUT
+  sqlite3 *db;
+#endif
+  libsql_wal_methods *pMethods; /* Virtual methods for interacting with WAL */;
+};
+
 #endif /* SQLITE_WAL_H */

--- a/src/wal.h
+++ b/src/wal.h
@@ -222,6 +222,7 @@ struct Wal {
   WalIndexHdr *pSnapshot;    /* Start transaction here if not NULL */
   sqlite3 *db;
   libsql_wal_methods *pMethods; /* Virtual methods for interacting with WAL */;
+  void *pMethodsData;           /* Optional context for private use of libsql_wal_methods */
 };
 
 #endif /* SQLITE_WAL_H */

--- a/src/wal.h
+++ b/src/wal.h
@@ -108,27 +108,25 @@ typedef struct libsql_wal_methods {
   */
   int (*xHeapMemory)(Wal *pWal);
 
-#ifdef SQLITE_ENABLE_SNAPSHOT
+  // Only needed with SQLITE_ENABLE_SNAPSHOT, but part of the ABI
   int (*xSnapshotGet)(Wal *pWal, sqlite3_snapshot **ppSnapshot);
   void (*xSnapshotOpen)(Wal *pWal, sqlite3_snapshot *pSnapshot);
   int (*xSnapshotRecover)(Wal *pWal);
   int (*xSnapshotCheck)(Wal *pWal, sqlite3_snapshot *pSnapshot);
   void (*xSnapshotUnlock)(Wal *pWal);
-#endif
 
-#ifdef SQLITE_ENABLE_ZIPVFS
+  // Only needed with SQLITE_ENABLE_ZIPVFS, but part of the ABI
   /* If the WAL file is not empty, return the number of bytes of content
   ** stored in each frame (i.e. the db page-size when the WAL was created).
   */
   int (*xFramesize)(Wal *pWal);
-#endif
+
 
   /* Return the sqlite3_file object for the WAL file */
   sqlite3_file *(*xFile)(Wal *pWal);
 
-#ifdef SQLITE_ENABLE_SETLK_TIMEOUT
+  // Only needed with  SQLITE_ENABLE_SETLK_TIMEOUT
   int (*xWriteLock)(Wal *pWal, int bLock);
-#endif
 
   void (*xDb)(Wal *pWal, sqlite3 *db);
 
@@ -220,15 +218,9 @@ struct Wal {
   u32 iReCksum;              /* On commit, recalculate checksums from here */
   const char *zWalName;      /* Name of WAL file */
   u32 nCkpt;                 /* Checkpoint sequence counter in the wal-header */
-#ifdef SQLITE_DEBUG
   u8 lockError;              /* True if a locking error has occurred */
-#endif
-#ifdef SQLITE_ENABLE_SNAPSHOT
   WalIndexHdr *pSnapshot;    /* Start transaction here if not NULL */
-#endif
-#ifdef SQLITE_ENABLE_SETLK_TIMEOUT
   sqlite3 *db;
-#endif
   libsql_wal_methods *pMethods; /* Virtual methods for interacting with WAL */;
 };
 

--- a/src/wal.h
+++ b/src/wal.h
@@ -131,6 +131,9 @@ typedef struct libsql_wal_methods {
 
   void (*xDb)(Wal *pWal, sqlite3 *db);
 
+  /* True if the implementation relies on shared memory routines (e.g. locks) */
+  int bUsesShm;
+
   const char *zName;
   struct libsql_wal_methods *pNext;
 } libsql_wal_methods;

--- a/src/wal.h
+++ b/src/wal.h
@@ -141,6 +141,13 @@ typedef struct libsql_wal_methods {
   ** */
   void (*xGetWalPathname)(char *buf, const char *orig, int orig_len);
 
+  /*
+  ** This optional callback gets called before the main database file which owns
+  ** the WAL file is open. It is a good place for initialization routines, as WAL
+  ** is otherwise open lazily.
+  */
+  int (*xPreMainDbOpen)(libsql_wal_methods *methods, const char *main_db_path);
+
   /* True if the implementation relies on shared memory routines (e.g. locks) */
   int bUsesShm;
 

--- a/src/wal.h
+++ b/src/wal.h
@@ -33,6 +33,7 @@
 typedef struct Wal Wal;
 
 typedef struct libsql_wal_methods {
+  int iVersion; /* Current version is 1, versioning is here for backward compatibility *.
   /* Open and close a connection to a write-ahead log. */
   int (*xOpen)(sqlite3_vfs*, sqlite3_file* , const char*, int no_shm_mode, i64 max_size, struct libsql_wal_methods*, Wal**);
   int (*xClose)(Wal*, sqlite3* db, int sync_flags, int nBuf, u8 *zBuf);

--- a/src/wal.h
+++ b/src/wal.h
@@ -131,6 +131,16 @@ typedef struct libsql_wal_methods {
 
   void (*xDb)(Wal *pWal, sqlite3 *db);
 
+  /* Return the WAL pathname length based on the owning pager's pathname len.
+  ** For WAL implementations not based on a single file, 0 should be returned. */
+  int (*xPathnameLen)(int origPathname);
+
+  /* Get the WAL pathname to given buffer. Assumes that the buffer can hold
+  ** at least xPathnameLen bytes. For WAL implementations not based on a single file,
+  ** this operation can safely be a no-op.
+  ** */
+  void (*xGetWalPathname)(char *buf, const char *orig, int orig_len);
+
   /* True if the implementation relies on shared memory routines (e.g. locks) */
   int bUsesShm;
 

--- a/test/rust_suite/Cargo.lock
+++ b/test/rust_suite/Cargo.lock
@@ -83,10 +83,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "getrandom"
-version = "0.2.7"
+name = "fastrand"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -118,6 +127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,15 +158,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -161,13 +179,14 @@ dependencies = [
  "itertools",
  "libsqlite3-sys",
  "rusqlite",
+ "tempfile",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "bindgen",
  "pkg-config",
@@ -198,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "peeking_take_while"
@@ -210,9 +229,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
@@ -233,19 +252,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.6.0"
+name = "redox_syscall"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rusqlite"
@@ -278,6 +315,20 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/test/rust_suite/Cargo.toml
+++ b/test/rust_suite/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 rusqlite = { version = "0.28", features = ["buildtime_bindgen"] }
 libsqlite3-sys = "0.25"
 itertools = "0.10"
+tempfile = "3.3"
 
 [features]
 default = []

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -1,4 +1,5 @@
 mod random_rowid;
+mod virtual_wal;
 
 #[cfg(all(test, feature = "udf"))]
 mod user_defined_functions;

--- a/test/rust_suite/src/random_rowid.rs
+++ b/test/rust_suite/src/random_rowid.rs
@@ -58,8 +58,11 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
 
         conn.execute("CREATE TABLE t(id) RANDOM ROWID", ()).unwrap();
-        conn.execute("INSERT INTO t(rowid) VALUES (42)", ()).unwrap();
-        let rowid: i64 = conn.query_row("SELECT rowid FROM t", [], |r| r.get(0)).unwrap();
+        conn.execute("INSERT INTO t(rowid) VALUES (42)", ())
+            .unwrap();
+        let rowid: i64 = conn
+            .query_row("SELECT rowid FROM t", [], |r| r.get(0))
+            .unwrap();
         assert_eq!(rowid, 42);
     }
 }

--- a/test/rust_suite/src/virtual_wal.rs
+++ b/test/rust_suite/src/virtual_wal.rs
@@ -31,9 +31,9 @@ mod tests {
         recalculate_checksums: u32,
         wal_name: *const u8,
         n_checkpoints: u32,
-        // debug: log_error
-        // snapshot: p_snapshot
-        // setlk: *db
+        lock_error: u8,
+        p_snapshot: *const c_void,
+        p_db: *const c_void,
         wal_methods: *mut libsql_wal_methods,
     }
 
@@ -107,9 +107,17 @@ mod tests {
         callback: extern "C" fn(wal: *mut Wal) -> i32,
         exclusive_mode: extern "C" fn(wal: *mut Wal) -> i32,
         heap_memory: extern "C" fn(wal: *mut Wal) -> i32,
-        // snapshot: get, open, recover, check, unlock
-        // enable_zipvfs: framesize
+        // stubs, only useful with snapshot support compiled-in
+        snapshot_get_stub: *const c_void,
+        snapshot_open_stub: *const c_void,
+        snapshot_recover_stub: *const c_void,
+        snapshot_check_stub: *const c_void,
+        snapshot_unlock_stub: *const c_void,
+        // stub, only useful with zipfs support compiled-in
+        framesize_stub: *const c_void,
         file: extern "C" fn(wal: *mut Wal) -> *const c_void,
+        // stub, only useful with setlk timeout compiled-in
+        write_lock_stub: *const c_void,
         db: extern "C" fn(wal: *mut Wal, db: *const c_void),
         pathname_len: extern "C" fn(orig_len: i32) -> i32,
         get_pathname: extern "C" fn(buf: *mut u8, orig: *const u8, orig_len: i32),
@@ -193,6 +201,9 @@ mod tests {
             recalculate_checksums: 0,
             wal_name: wal_name,
             n_checkpoints: 0,
+            lock_error: 0,
+            p_snapshot: std::ptr::null(),
+            p_db: std::ptr::null(),
             wal_methods: methods,
         });
         unsafe { *wal = &*new_wal }
@@ -363,7 +374,16 @@ mod tests {
                 callback,
                 exclusive_mode,
                 heap_memory,
+                snapshot_get_stub: std::ptr::null(),
+                snapshot_open_stub: std::ptr::null(),
+                snapshot_recover_stub: std::ptr::null(),
+                snapshot_check_stub: std::ptr::null(),
+                snapshot_unlock_stub: std::ptr::null(),
+                // stub, only useful with zipfs support compiled-in
+                framesize_stub: std::ptr::null(),
                 file,
+                // stub, only useful with setlk timeout compiled-in
+                write_lock_stub: std::ptr::null(),
                 db,
                 pathname_len,
                 get_pathname,

--- a/test/rust_suite/src/virtual_wal.rs
+++ b/test/rust_suite/src/virtual_wal.rs
@@ -1,0 +1,405 @@
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+    use std::ffi::c_void;
+
+    const ERR_MISUSE: i32 = 21;
+
+    #[repr(C)]
+    struct Wal {
+        vfs: *const c_void,
+        db_fd: *const c_void,
+        wal_fd: *const c_void,
+        callback_value: u32,
+        max_wal_size: i64,
+        wi_data: i32,
+        size_first_block: i32,
+        ap_wi_data: *const *mut u32,
+        page_size: u32,
+        read_lock: i16,
+        sync_flags: u8,
+        exclusive_mode: u8,
+        write_lock: u8,
+        checkpoint_lock: u8,
+        read_only: u8,
+        truncate_on_commit: u8,
+        sync_header: u8,
+        pad_to_section_boundary: u8,
+        b_shm_unreliable: u8,
+        hdr: WalIndexHdr,
+        min_frame: u32,
+        recalculate_checksums: u32,
+        wal_name: *const u8,
+        n_checkpoints: u32,
+        // debug: log_error
+        // snapshot: p_snapshot
+        // setlk: *db
+        wal_methods: *mut libsql_wal_methods,
+    }
+
+    #[repr(C)]
+    struct WalIndexHdr {
+        version: u32,
+        unused: u32,
+        change: u32,
+        is_init: u8,
+        big_endian_checksum: u8,
+        page_size: u16,
+        last_valid_frame: u32,
+        n_pages: u32,
+        frame_checksum: [u32; 2],
+        salt: [u32; 2],
+        checksum: [u32; 2],
+    }
+
+    #[repr(C)]
+    struct libsql_wal_methods {
+        open: extern "C" fn(
+            vfs: *const c_void,
+            file: *const c_void,
+            wal_name: *const u8,
+            no_shm_mode: i32,
+            max_size: i64,
+            methods: *mut libsql_wal_methods,
+            wal: *mut *const Wal,
+        ) -> i32,
+        close: extern "C" fn(
+            wal: *mut Wal,
+            db: *mut c_void,
+            sync_flags: i32,
+            n_buf: i32,
+            z_buf: *mut u8,
+        ) -> i32,
+        limit: extern "C" fn(wal: *mut Wal, limit: i64),
+        begin_read: extern "C" fn(wal: *mut Wal, changed: *mut i32) -> i32,
+        end_read: extern "C" fn(wal: *mut Wal) -> i32,
+        find_frame: extern "C" fn(wal: *mut Wal, pgno: i32, frame: *mut i32) -> i32,
+        read_frame: extern "C" fn(wal: *mut Wal, frame: u32, n_out: i32, p_out: *mut u8) -> i32,
+        db_size: extern "C" fn(wal: *mut Wal) -> i32,
+        begin_write: extern "C" fn(wal: *mut Wal) -> i32,
+        end_write: extern "C" fn(wal: *mut Wal) -> i32,
+        undo: extern "C" fn(
+            wal: *const extern "C" fn(*mut c_void, i32) -> i32,
+            ctx: *mut c_void,
+        ) -> i32,
+        savepoint: extern "C" fn(wal: *mut Wal, wal_data: *mut u32),
+        savepoint_undo: extern "C" fn(wal: *mut Wal, wal_data: *mut u32) -> i32,
+        frames: extern "C" fn(
+            wal: *mut Wal,
+            page_size: u32,
+            page_headers: *const PgHdr,
+            size_after: i32,
+            is_commit: i32,
+            sync_flags: i32,
+        ) -> i32,
+        checkpoint: extern "C" fn(
+            wal: *mut Wal,
+            db: *mut c_void,
+            emode: i32,
+            busy_handler: extern "C" fn(busy_param: *mut c_void) -> i32,
+            sync_flags: i32,
+            n_buf: i32,
+            z_buf: *mut u8,
+            frames_in_wal: *mut i32,
+            backfilled_frames: *mut i32,
+        ) -> i32,
+        callback: extern "C" fn(wal: *mut Wal) -> i32,
+        exclusive_mode: extern "C" fn(wal: *mut Wal) -> i32,
+        heap_memory: extern "C" fn(wal: *mut Wal) -> i32,
+        // snapshot: get, open, recover, check, unlock
+        // enable_zipvfs: framesize
+        file: extern "C" fn(wal: *mut Wal) -> *const c_void,
+        db: extern "C" fn(wal: *mut Wal, db: *const c_void),
+        pathname_len: extern "C" fn(orig_len: i32) -> i32,
+        get_pathname: extern "C" fn(buf: *mut u8, orig: *const u8, orig_len: i32),
+        b_uses_shm: i32,
+        name: *const u8,
+        p_next: *const c_void,
+
+        // User data
+        pages: std::collections::HashMap<i32, std::vec::Vec<u8>>,
+    }
+
+    #[repr(C)]
+    struct PgHdr {
+        page: *const c_void,
+        data: *const c_void,
+        extra: *const c_void,
+        pcache: *const c_void,
+        dirty: *const PgHdr,
+        pager: *const c_void,
+        pgno: i32,
+        flags: u16,
+    }
+
+    extern "C" {
+        fn libsql_open(
+            filename: *const u8,
+            ppdb: *mut *mut rusqlite::ffi::sqlite3,
+            flags: i32,
+            vfs: *const u8,
+            wal: *const u8,
+        ) -> i32;
+        fn libsql_wal_methods_register(wal_methods: *const libsql_wal_methods) -> i32;
+        fn sqlite3_initialize();
+    }
+
+    extern "C" fn open(
+        vfs: *const c_void,
+        _file: *const c_void,
+        wal_name: *const u8,
+        _no_shm_mode: i32,
+        max_size: i64,
+        methods: *mut libsql_wal_methods,
+        wal: *mut *const Wal,
+    ) -> i32 {
+        let new_wal = Box::new(Wal {
+            vfs: vfs,
+            db_fd: std::ptr::null(),
+            wal_fd: std::ptr::null(),
+            callback_value: 0,
+            max_wal_size: max_size,
+            wi_data: 0,
+            size_first_block: 0,
+            ap_wi_data: std::ptr::null(),
+            page_size: 4096,
+            read_lock: 0,
+            sync_flags: 0,
+            exclusive_mode: 1,
+            write_lock: 0,
+            checkpoint_lock: 0,
+            read_only: 0,
+            truncate_on_commit: 0,
+            sync_header: 0,
+            pad_to_section_boundary: 0,
+            b_shm_unreliable: 1,
+            hdr: WalIndexHdr {
+                version: 1,
+                unused: 0,
+                change: 0,
+                is_init: 0,
+                big_endian_checksum: 0,
+                page_size: 4096,
+                last_valid_frame: 1,
+                n_pages: 1,
+                frame_checksum: [0, 0],
+                salt: [0, 0],
+                checksum: [0, 0],
+            },
+            min_frame: 0,
+            recalculate_checksums: 0,
+            wal_name: wal_name,
+            n_checkpoints: 0,
+            wal_methods: methods,
+        });
+        unsafe { *wal = &*new_wal }
+        Box::leak(new_wal);
+        0
+    }
+    extern "C" fn close(
+        _wal: *mut Wal,
+        _db: *mut c_void,
+        _sync_flags: i32,
+        _n_buf: i32,
+        _z_buf: *mut u8,
+    ) -> i32 {
+        println!("Closing WAL");
+        0
+    }
+    extern "C" fn limit(wal: *mut Wal, limit: i64) {
+        println!("Limit: {}", limit);
+        unsafe { (*wal).max_wal_size = limit }
+    }
+    extern "C" fn begin_read(_wal: *mut Wal, changed: *mut i32) -> i32 {
+        println!("Read started");
+        unsafe { *changed = 1 }
+        0
+    }
+    extern "C" fn end_read(_wal: *mut Wal) -> i32 {
+        println!("Read ended");
+        0
+    }
+    extern "C" fn find_frame(wal: *mut Wal, pgno: i32, frame: *mut i32) -> i32 {
+        println!("\tLooking for page {}", pgno);
+        let methods = unsafe { &*(*wal).wal_methods };
+        if methods.pages.contains_key(&pgno) {
+            println!("\t\tpage found");
+            unsafe { *frame = pgno };
+        } else {
+            println!("\t\tpage not found - serving from the main database file");
+        }
+        0
+    }
+    extern "C" fn read_frame(wal: *mut Wal, frame: u32, n_out: i32, p_out: *mut u8) -> i32 {
+        println!("\tReading frame {}", frame);
+        let n_out = n_out as usize;
+        let methods = unsafe { &*(*wal).wal_methods };
+        let data = methods.pages.get(&(frame as i32)).unwrap();
+        if n_out < data.len() {
+            return ERR_MISUSE;
+        }
+        let out_buffer = unsafe { std::slice::from_raw_parts_mut(p_out, n_out) };
+        out_buffer.copy_from_slice(&data);
+        println!("\t\tread {} bytes", data.len());
+        0
+    }
+    extern "C" fn db_size(_wal: *mut Wal) -> i32 {
+        ERR_MISUSE
+    }
+    extern "C" fn begin_write(_wal: *mut Wal) -> i32 {
+        println!("Write started");
+        0
+    }
+    extern "C" fn end_write(_wal: *mut Wal) -> i32 {
+        println!("Write ended");
+        0
+    }
+    extern "C" fn undo(
+        _wal: *const extern "C" fn(*mut c_void, i32) -> i32,
+        _ctx: *mut c_void,
+    ) -> i32 {
+        panic!("Not implemented")
+    }
+    extern "C" fn savepoint(_wal: *mut Wal, _wal_data: *mut u32) {
+        panic!("Not implemented")
+    }
+    extern "C" fn savepoint_undo(_wal: *mut Wal, _wal_data: *mut u32) -> i32 {
+        panic!("Not implemented")
+    }
+    extern "C" fn frames(
+        wal: *mut Wal,
+        page_size: u32,
+        page_headers: *const PgHdr,
+        _size_after: i32,
+        _is_commit: i32,
+        _sync_flags: i32,
+    ) -> i32 {
+        println!("\tWriting frames...");
+        unsafe { (*wal).page_size = page_size };
+        let methods = unsafe { &mut *(*wal).wal_methods };
+        let mut current_ptr = page_headers;
+        loop {
+            let current: &PgHdr = unsafe { &*current_ptr };
+            println!("\t\tpage {} written", current.pgno);
+            let data = unsafe {
+                std::slice::from_raw_parts(current.data as *const u8, page_size as usize)
+            }
+            .to_vec();
+            methods.pages.insert(current.pgno, data);
+            if current.dirty == std::ptr::null() {
+                break;
+            }
+            current_ptr = current.dirty
+        }
+        0
+    }
+    extern "C" fn checkpoint(
+        _wal: *mut Wal,
+        _db: *mut c_void,
+        _emode: i32,
+        _busy_handler: extern "C" fn(busy_param: *mut c_void) -> i32,
+        _sync_flags: i32,
+        _n_buf: i32,
+        _z_buf: *mut u8,
+        _frames_in_wal: *mut i32,
+        _backfilled_frames: *mut i32,
+    ) -> i32 {
+        println!("Checkpointed");
+        0
+    }
+    extern "C" fn callback(_wal: *mut Wal) -> i32 {
+        ERR_MISUSE
+    }
+    extern "C" fn exclusive_mode(_wal: *mut Wal) -> i32 {
+        1
+    }
+    extern "C" fn heap_memory(wal: *mut Wal) -> i32 {
+        unsafe { &*(*wal).wal_methods }.pages.len() as i32 * 64
+    }
+    extern "C" fn file(_wal: *mut Wal) -> *const c_void {
+        panic!("Should never be called")
+    }
+    extern "C" fn db(_wal: *mut Wal, _db: *const c_void) {}
+    extern "C" fn pathname_len(_orig_len: i32) -> i32 {
+        println!("Returning length 0");
+        0
+    }
+    extern "C" fn get_pathname(_buf: *mut u8, _orig: *const u8, _orig_len: i32) {
+        panic!("Should never be called")
+    }
+
+    #[test]
+    fn test_vwal_register() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let path = format!("{}\0", tmpfile.path().to_str().unwrap());
+        println!("Temporary database created at {}", path);
+
+        let conn = unsafe {
+            let mut pdb: *mut rusqlite::ffi::sqlite3 = std::ptr::null_mut();
+            let ppdb: *mut *mut rusqlite::ffi::sqlite3 = &mut pdb;
+            let mut vwal = Box::new(libsql_wal_methods {
+                open: open,
+                close: close,
+                limit: limit,
+                begin_read: begin_read,
+                end_read: end_read,
+                find_frame: find_frame,
+                read_frame: read_frame,
+                db_size: db_size,
+                begin_write: begin_write,
+                end_write: end_write,
+                undo: undo,
+                savepoint: savepoint,
+                savepoint_undo: savepoint_undo,
+                frames: frames,
+                checkpoint: checkpoint,
+                callback: callback,
+                exclusive_mode: exclusive_mode,
+                heap_memory: heap_memory,
+                file: file,
+                db: db,
+                pathname_len: pathname_len,
+                get_pathname: get_pathname,
+                b_uses_shm: 0,
+                name: "vwal\0".as_ptr(),
+                p_next: std::ptr::null(),
+                pages: std::collections::HashMap::new(),
+            });
+
+            sqlite3_initialize();
+            let register_err = libsql_wal_methods_register(&mut *vwal as *mut libsql_wal_methods);
+            assert_eq!(register_err, 0);
+            let open_err = libsql_open(path.as_ptr(), ppdb, 6, std::ptr::null(), "vwal\0".as_ptr());
+            assert_eq!(open_err, 0);
+            Box::leak(vwal);
+            Connection::from_handle(pdb).unwrap()
+        };
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+        conn.execute("CREATE TABLE t(id)", ()).unwrap();
+        conn.execute("INSERT INTO t(id) VALUES (42)", ()).unwrap();
+        conn.execute("INSERT INTO t(id) VALUES (zeroblob(8193))", ())
+            .unwrap();
+        conn.execute("INSERT INTO t(id) VALUES (7.0)", ()).unwrap();
+
+        let seven: f64 = conn
+            .query_row("SELECT id FROM t WHERE typeof(id) = 'real'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let blob: Vec<u8> = conn
+            .query_row("SELECT id FROM t WHERE typeof(id) = 'blob'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let forty_two: i64 = conn
+            .query_row("SELECT id FROM t WHERE typeof(id) = 'integer'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+
+        assert_eq!(seven, 7.);
+        assert!(blob.iter().all(|v| v == &0_u8));
+        assert_eq!(blob.len(), 8193);
+        assert_eq!(forty_two, 42);
+    }
+}


### PR DESCRIPTION
This preparatory commit moves all WAL routines to a virtual table.
Also, a helper libsql_open() function is provided. It allows passing
a new parameter - name of the custom WAL methods implementation.