### PR TITLE
test: link to correct library in Rust tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1299,7 +1299,7 @@ quicktest:	./testfixture$(TEXE)
 	./testfixture$(TEXE) $(TOP)/test/extraquick.test $(TESTOPTS)
 
 rusttest:	sqlite3.h libsqlite3.la
-	( cd test/rust_suite; cargo test )
+	( cd test/rust_suite; LD_LIBRARY_PATH=../../.libs cargo test )
 
 # This is the common case.  Run many tests that do not take too long,
 # including fuzzcheck, sqlite3_analyzer, and sqldiff tests.


### PR DESCRIPTION
Coincidentally, default GitHub CI environment contains libsqlite.so library in place, which hid the fact that Rust tests fail to prefer the locally built library. The tests were previously effectively verifying that the library from system path is correct, which is also nice, but not the desired effect. The amended rusttest command correctly prefers locally build libraries.