### PR TITLE
Add RANDOM ROWID keywords

### DIFF
--- a/doc/libsql_extensions.md
+++ b/doc/libsql_extensions.md
@@ -1,0 +1,42 @@
+# libSQL extensions
+
+This document describes extensions to the library provided by libSQL, not available in upstream SQLite at the time of writing.
+
+## RANDOM ROWID
+
+Regular tables use an implicitly defined, unique, 64-bit rowid column as its primary key.
+If rowid value is not specified during insertion, it's auto-generated with the following heuristics:
+ 1. Find the current max rowid value.
+ 2. If max value is less than i64::max, use the next available value
+ 3. If max value is i64::max:
+     a. pick a random value
+     b. if it's not taken, use it
+     c. if it's taken, go to (a.), rinse, repeat
+
+Based on this algorithm, the following trick can be used to trick libSQL into generating random rowid values instead of consecutive ones - simply insert a sentinel row with `rowid = i64::max`.
+
+The newly introduced `RANDOM ROWID` option can be used to explicitly state that the table generates random rowid values on insertions, without having to insert a dummy row with special rowid value, or manually trying to generate a random unique rowid, which some user applications may find problematic.
+
+### Usage
+
+`RANDOM ROWID` keywords can be used during table creation, in a manner similar to its syntactic cousin, `WITHOUT ROWID`:
+```sql
+CREATE TABLE shopping_list(item text, quantity int) RANDOM ROWID;
+```
+
+On insertion, pseudorandom rowid values will be generated:
+```sql
+CREATE TABLE shopping_list(item text, quantity int) RANDOM ROWID;
+INSERT INTO shopping_list(item, quantity) VALUES ('bread', 2);
+INSERT INTO shopping_list(item, quantity) VALUES ('butter', 1);
+.mode column
+SELECT rowid, * FROM shopping_list;
+rowid                item    quantity
+-------------------  ------  --------
+1177193729061749947  bread   2       
+4433412906245401374  butter  1  
+```
+
+### Restrictions
+
+`RANDOM ROWID` is mutually exclusive with `WITHOUT ROWID` option, and cannot be used with tables having an `AUTOINCREMENT` primary key.

--- a/src/build.c
+++ b/src/build.c
@@ -2708,6 +2708,15 @@ void sqlite3EndTable(
     p->tabFlags |= TF_WithoutRowid | TF_NoVisibleRowid;
     convertToWithoutRowidTable(pParse, p);
   }
+  if( tabOpts & TF_RandomRowid ){
+    assert( (p->tabFlags & TF_WithoutRowid) == 0 );
+    if( (p->tabFlags & TF_Autoincrement) ){
+      sqlite3ErrorMsg(pParse,
+          "AUTOINCREMENT not allowed on RANDOM ROWID tables");
+      return;
+    }
+    p->tabFlags |= TF_RandomRowid;
+  }
   iDb = sqlite3SchemaToIndex(db, p->pSchema);
 
 #ifndef SQLITE_OMIT_CHECK

--- a/src/parse.y
+++ b/src/parse.y
@@ -216,6 +216,14 @@ table_option(A) ::= WITHOUT nm(X). {
     sqlite3ErrorMsg(pParse, "unknown table option: %.*s", X.n, X.z);
   }
 }
+table_option(A) ::= RANDOM nm(X). {
+  if( X.n==5 && sqlite3_strnicmp(X.z,"rowid",5)==0 ){
+    A = TF_RandomRowid;
+  }else{
+    A = 0;
+    sqlite3ErrorMsg(pParse, "unknown table option: %.*s", X.n, X.z);
+  }
+}
 table_option(A) ::= nm(X). {
   if( X.n==6 && sqlite3_strnicmp(X.z,"strict",6)==0 ){
     A = TF_Strict;
@@ -248,7 +256,7 @@ columnname(A) ::= nm(A) typetoken(Y). {sqlite3AddColumn(pParse,A,Y);}
   CONFLICT DATABASE DEFERRED DESC DETACH DO
   EACH END EXCLUSIVE EXPLAIN FAIL FOR
   IGNORE IMMEDIATE INITIALLY INSTEAD LIKE_KW MATCH NO PLAN
-  QUERY KEY OF OFFSET PRAGMA RAISE RECURSIVE RELEASE REPLACE RESTRICT ROW ROWS
+  QUERY KEY OF OFFSET PRAGMA RAISE RANDOM RECURSIVE RELEASE REPLACE RESTRICT ROW ROWS
   ROLLBACK SAVEPOINT TEMP TRIGGER VACUUM VIEW VIRTUAL WITH WITHOUT
   NULLS FIRST LAST
 %ifdef SQLITE_OMIT_COMPOUND_SELECT

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -2341,6 +2341,10 @@ struct Table {
 #define TF_Ephemeral      0x00004000 /* An ephemeral table */
 #define TF_Eponymous      0x00008000 /* An eponymous virtual table */
 #define TF_Strict         0x00010000 /* STRICT mode */
+/* libSQL extension */
+#define TF_RandomRowid    0x01000000 /* Random rowid */
+
+#define LIBSQL_RANDOM_ROWID_MARKER 0xffffffff
 
 /*
 ** Allowed values for Table.eTabType

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -5419,6 +5419,11 @@ case OP_NewRowid: {           /* out2 */
       }
     }
 
+    if ( pOp->p3 == LIBSQL_RANDOM_ROWID_MARKER) {
+      pC->useRandomRowid = 1;
+      pOp->p3 = 0;
+    }
+
 #ifndef SQLITE_OMIT_AUTOINCREMENT
     if( pOp->p3 ){
       /* Assert that P3 is a valid memory cell. */

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -1,3 +1,5 @@
+mod random_rowid;
+
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;

--- a/test/rust_suite/src/random_rowid.rs
+++ b/test/rust_suite/src/random_rowid.rs
@@ -1,0 +1,65 @@
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    // Test that RANDOM ROWID tables indeed generate rowid values in a pseudorandom way
+    #[test]
+    fn test_random_rowid_distribution() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        conn.execute("CREATE TABLE t(id)", ()).unwrap();
+        conn.execute("CREATE TABLE tr(id) RANDOM ROWID", ())
+            .unwrap();
+        for _ in 1..=1024 {
+            conn.execute("INSERT INTO t(id) VALUES (42)", ()).unwrap();
+            conn.execute("INSERT INTO tr(id) VALUES (42)", ()).unwrap();
+        }
+
+        let seq_rowids: Vec<i64> = conn
+            .prepare("SELECT rowid FROM t")
+            .unwrap()
+            .query_map([], |row| Ok(row.get_unwrap(0)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(seq_rowids, (1..=1024_i64).collect::<Vec<i64>>());
+
+        let random_rowids: Vec<i64> = conn
+            .prepare("SELECT rowid FROM tr")
+            .unwrap()
+            .query_map([], |row| Ok(row.get_unwrap(0)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        // This assertion is technically just probabilistic, but in practice
+        // precise enough to ~never cause false positives
+        assert_ne!(random_rowids, (1..=1024_i64).collect::<Vec<i64>>())
+    }
+
+    // Test that RANDOM ROWID can only be used in specific context - table creation
+    #[test]
+    fn test_random_rowid_validate_create() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        for wrong in [
+            "CREATE TABLE t(id) RANDOM ROWID WITHOUT ROWID",
+            "CREATE TABLE t(id int PRIMARY KEY AUTOINCREMENT) RANDOM ROWID",
+            "CREATE TABLE t(id) RANDOM ROW_ID",
+            "CREATE TABLE t(id) RANDO ROWID",
+        ] {
+            assert!(conn.execute(wrong, ()).is_err());
+        }
+    }
+
+    // Test that providing rowid value explicitly still works
+    // and is respected with higher priority
+    #[test]
+    fn test_random_rowid_explicit_rowid() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        conn.execute("CREATE TABLE t(id) RANDOM ROWID", ()).unwrap();
+        conn.execute("INSERT INTO t(rowid) VALUES (42)", ()).unwrap();
+        let rowid: i64 = conn.query_row("SELECT rowid FROM t", [], |r| r.get(0)).unwrap();
+        assert_eq!(rowid, 42);
+    }
+}

--- a/tool/mkkeywordhash.c
+++ b/tool/mkkeywordhash.c
@@ -278,6 +278,7 @@ static Keyword aKeywordTable[] = {
   { "PRIMARY",          "TK_PRIMARY",      ALWAYS,           1      },
   { "QUERY",            "TK_QUERY",        EXPLAIN,          0      },
   { "RAISE",            "TK_RAISE",        TRIGGER,          1      },
+  { "RANDOM",           "TK_RANDOM",       ALWAYS,           1      },
   { "RANGE",            "TK_RANGE",        WINDOWFUNC,       3      },
   { "RECURSIVE",        "TK_RECURSIVE",    CTE,              3      },
   { "REFERENCES",       "TK_REFERENCES",   FKEY,             1      },


### PR DESCRIPTION
With the new RANDOM ROWID keywords, a table can explicitly state that it wants its rowid to be generated randomly, not consecutively, without having to previously create a sentinel record with rowid == max(i64).
RANDOM ROWID is mutually exclusive with WITHOUT ROWID,
and cannot be combined with AUTOINCREMENT primary key.

This series come with tests.

Fixes #12