### PR TITLE
wasm: post-process optimize for smaller module size

### DIFF
--- a/ext/wasm/GNUmakefile
+++ b/ext/wasm/GNUmakefile
@@ -444,6 +444,7 @@ $(sqlite3.js): $(MAKEFILE) $(sqlite3.wasm.obj) \
     $(cflags.common) $(SQLITE_OPT) $(sqlite3-wasm.c)
 	chmod -x $(sqlite3.wasm)
 	$(maybe-wasm-strip) $(sqlite3.wasm)
+	$(maybe-wasm-shrink) $(sqlite3.wasm) -o $(sqlite3.wasm)
 	@ls -la $@ $(sqlite3.wasm)
 $(sqlite3.wasm): $(sqlite3.js)
 CLEAN_FILES += $(sqlite3.js) $(sqlite3.wasm)
@@ -537,6 +538,7 @@ $(speedtest1.js): $(MAKEFILE) $(speedtest1.cses) \
         $(speedtest1.exit-runtime0) \
         -o $@ $(speedtest1.cses) -lm
 	$(maybe-wasm-strip) $(speedtest1.wasm)
+	$(maybe-wasm-shrink) $(speedtest1.wasm) -o $(speedtest1.wasm)
 	ls -la $@ $(speedtest1.wasm)
 
 speedtest1: $(speedtest1.js)

--- a/ext/wasm/GNUmakefile
+++ b/ext/wasm/GNUmakefile
@@ -60,6 +60,13 @@ else
   maybe-wasm-strip = $(wasm-strip)
 endif
 
+wasm-opt ?= $(shell which wasm-opt 2>/dev/null)
+ifeq (,$(wasm-opt))
+  maybe-wasm-shrink = echo "not using wasm-opt for post-process optimizing"
+else
+  maybe-wasm-shrink = $(wasm-opt) -Oz
+endif
+
 dir.top := ../..
 # Reminder: some Emscripten flags require absolute paths but we want
 # relative paths for most stuff simply to reduce noise. The

--- a/ext/wasm/fiddle.make
+++ b/ext/wasm/fiddle.make
@@ -66,6 +66,7 @@ $(fiddle-module.js): $(MAKEFILE) $(MAKEFILE.fiddle) \
     $(pre-post-common.flags) $(pre-post-fiddle-module.flags) \
     $(fiddle.cses)
 	$(maybe-wasm-strip) $(fiddle-module.wasm)
+	$(maybe-wasm-shrink) $(fiddle-module.wasm) -o $(fiddle-module.wasm)
 	gzip < $@ > $@.gz
 	gzip < $(fiddle-module.wasm) > $(fiddle-module.wasm).gz
 


### PR DESCRIPTION
In addition to compiling with -Os and stripping the binary, an extra round of post-process optimization is optionally run with the help of Binaryen's wasm-opt utility.
With the additional pass, the resulting binary size drops from 3.1MiB to 792K, which is almost a 75% reduction.