### PR TITLE
fiddle: add a small Python server for COOP/COEP

### DIFF
--- a/ext/wasm/fiddle/serve.py
+++ b/ext/wasm/fiddle/serve.py
@@ -1,0 +1,10 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+class COOPCOEPHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+httpd = HTTPServer(('localhost', 8000), COOPCOEPHandler)
+httpd.serve_forever()


### PR DESCRIPTION
In order to experiment with Origin-Private File System (OPFS), certain HTTP headers need to be sent from the server to opt-in into newest features. It's also advised to run bleeding-edge Chrome, e.g. version 108 seems to support all of it. To make development easier, a simple server which adds the required headers is added in fiddle/ directory.