### PR TITLE
fiddle: default to terminal view, scripts hosted by cdnjs.com

### DIFF
--- a/ext/wasm/fiddle/fiddle-worker.js
+++ b/ext/wasm/fiddle/fiddle-worker.js
@@ -163,7 +163,7 @@
         fiddleModule.isDead = true;
         return false;
       }
-      stdout("SQLite version", capi.sqlite3_libversion(),
+      stdout("libSQL version", capi.sqlite3_libversion(),
              capi.sqlite3_sourceid().substr(0,19));
       stdout('Welcome to the "fiddle" shell.');
       if(sqlite3.opfs){

--- a/ext/wasm/fiddle/fiddle.js
+++ b/ext/wasm/fiddle/fiddle.js
@@ -787,7 +787,7 @@
       /* Set up the terminal-style view... */
       const eTerm = window.jQuery('#view-terminal').empty();
       SF.jqTerm = eTerm.terminal(SF.dbExec.bind(SF),{
-        prompt: 'sqlite> ',
+        prompt: 'libsql> ',
         greetings: false /* note that the docs incorrectly call this 'greeting' */
       });
       /* Set up a button to toggle the views... */
@@ -803,10 +803,6 @@
       }, false);
       btnToggleView.click()/*default to terminal view*/;
     }
-    SF.echo('This experimental app is provided in the hope that it',
-            'may prove interesting or useful but is not an officially',
-            'supported deliverable of the sqlite project. It is subject to',
-            'any number of changes or outright removal at any time.\n');
     const urlParams = new URL(self.location.href).searchParams;
     SF.dbExec(urlParams.get('sql') || null);
     delete ForceResizeKludge.$disabled;

--- a/ext/wasm/fiddle/index.html
+++ b/ext/wasm/fiddle/index.html
@@ -5,10 +5,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>SQLite3 Fiddle</title>
     <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
-    <!-- to add a togglable terminal-style view, uncomment the following
-         two lines and ensure that these files are on the web server. -->
-    <!--script src="jqterm/jqterm-bundle.min.js"></script>
-    <link rel="stylesheet" href="jqterm/jquery.terminal.min.css"/-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.34.0/js/jquery.terminal.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.34.0/css/jquery.terminal.min.css"/>
     <link rel="stylesheet" href="emscripten.css"/>
     <style>
       /* The following styles are for app-level use. */


### PR DESCRIPTION
This commit switches the default view from split to terminal. The scripts are now fetched from cdnjs.com, which is expected to be generally available for the time being.