### PR TITLE
configure: error if readline not found, but requested explicitly

### DIFF
--- a/configure
+++ b/configure
@@ -11171,6 +11171,9 @@ fi
 	fi
 
 	if test x"$found" = xno; then
+		if test x"$enable_readline" = xyes; then
+			as_fn_error 1 "No suitable readline library found"
+		fi
 		TARGET_READLINE_LIBS=""
 		TARGET_READLINE_INC=""
 		TARGET_HAVE_READLINE=0

--- a/configure.ac
+++ b/configure.ac
@@ -533,6 +533,9 @@ if test x"$with_readline" != xno; then
 	fi
 
 	if test x"$found" = xno; then
+		if test x"$enable_readline" = xyes; then
+			AC_MSG_ERROR(["No suitable readline library found"])
+		fi
 		TARGET_READLINE_LIBS=""
 		TARGET_READLINE_INC=""
 		TARGET_HAVE_READLINE=0


### PR DESCRIPTION
If --enable-readline option is passed to configure, but no readline support is found, previous behavior was to silently continue and not enable readline support. The new behavior is to error out if readline was explicitly enabled, but there's no library that provides it. Users are expected to either drop the --enable-readline flag or install the missing dependency.

#65 