### PR TITLE
iotrace: flush on each entry

### DIFF
--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -535,6 +535,7 @@ static void SQLITE_CDECL iotracePrintf(const char *zFormat, ...){
   z = sqlite3_vmprintf(zFormat, ap);
   va_end(ap);
   utf8_printf(iotrace, "%s", z);
+  fflush(iotrace);
   sqlite3_free(z);
 }
 #endif


### PR DESCRIPTION
Flushing the buffer on each new entry makes iotrace much more useful for debugging interactive sessions.