### PR TITLE
Add scripts for creating release artifacts

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1538,6 +1538,7 @@ clean:
 	rm -f dbhash dbhash.exe
 	rm -f fts5.* fts5parse.*
 	rm -f threadtest5
+	rm -f libsql*.tar.gz
 
 distclean:	clean
 	rm -f sqlite_cfg.h config.log config.status libtool Makefile sqlite3.pc sqlite3session.h \

--- a/tool/generate-artifacts.sh
+++ b/tool/generate-artifacts.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Generates artifacts from the current build:
+# - .c and .h amalgamation files
+# - a precompiled binary package
+#
+# Assumes that ./configure and make steps were executed and succeeded
+
+LIBSQL_WASM_UDF_SUFFIX=
+if grep -s "TARGET_OPT_WASM_RUNTIME_LINK.*libwblibsql\.a" Makefile; then
+  LIBSQL_WASM_UDF_SUFFIX="-wasm-udf"
+elif grep -s "TARGET_OPT_WASM_RUNTIME_LINK.*lwblibsql" Makefile; then
+  LIBSQL_WASM_UDF_SUFFIX="-wasm-udf-dynamic"
+fi
+
+set -x
+
+tar czvf libsql-amalgamation-$(<LIBSQL_VERSION)${LIBSQL_WASM_UDF_SUFFIX}.tar.gz sqlite3.c sqlite3.h
+tar czvf libsql-$(<LIBSQL_VERSION)${LIBSQL_WASM_UDF_SUFFIX}.tar.gz sqlite3 libsql .libs

--- a/tool/pre-release.sh
+++ b/tool/pre-release.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Compiles libSQL in the following flavors:
+#  - vanilla
+#  - with Wasm user-defined functions support linked statically
+#  - with Wasm user-defined functions support linked as a separate dynamic library
+
+if [[ "$#" != "1" ]]; then
+    echo "Usage: $0 <release-number>"
+fi
+
+for mode in "" "--enable-wasm-runtime" "--enable-wasm-runtime-dynamic"; do
+    echo Mode: ${mode:-regular}
+    ./configure --enable-releasemode --enable-all $mode && make -j12 && ./tool/generate-artifacts.sh
+done


### PR DESCRIPTION
The scripts are meant to be run during releases
in order to automate producing artifacts, like
precompiled binaries and the amalgamation files.