### PR TITLE
docker: add LIBSQL_VERSION to docker image

### DIFF
--- a/Dockerfile-wasm-udf
+++ b/Dockerfile-wasm-udf
@@ -11,6 +11,7 @@ WORKDIR /home/libsql
 ADD src src
 ADD ext ext
 ADD tool tool
+ADD VERSION LIBSQL_VERSION
 
 RUN apt-get update
 RUN apt-get install -y tcl8.6-dev build-essential autoconf


### PR DESCRIPTION
Our Dockerfile suffered from bitrot after LIBSQL_VERSION file was introduced - let's fix.