### PR TITLE
Let virtual table implementations know which SQL string is being executed

### DIFF
--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -7076,6 +7076,8 @@ struct sqlite3_module {
   /* The methods above are in versions 1 and 2 of the sqlite_module object.
   ** Those below are for version 3 and greater. */
   int (*xShadowName)(const char*);
+  /** The methods below are for version 4 and greater. */
+  int (*xPrepareSql)(sqlite3_vtab_cursor*, const char*);
 };
 
 /*

--- a/src/test8.c
+++ b/src/test8.c
@@ -1293,6 +1293,17 @@ static int echoRollbackTo(sqlite3_vtab *pVTab, int iSavepoint){
   return SQLITE_OK;
 }
 
+static int echoShadowName(const char *name){
+  assert( name );
+  return SQLITE_OK;
+}
+
+static int echoPrepareSql(sqlite3_vtab_cursor *cur, const char *sql){
+  assert( cur );
+  assert( sql );
+  return SQLITE_OK;
+}
+
 /*
 ** A virtual table module that merely "echos" the contents of another
 ** table (like an SQL VIEW).
@@ -1321,7 +1332,7 @@ static sqlite3_module echoModule = {
 };
 
 static sqlite3_module echoModuleV2 = {
-  2,                         /* iVersion */
+  4,                         /* iVersion */
   echoCreate,
   echoConnect,
   echoBestIndex,
@@ -1343,7 +1354,9 @@ static sqlite3_module echoModuleV2 = {
   echoRename,                /* xRename - rename the table */
   echoSavepoint,
   echoRelease,
-  echoRollbackTo
+  echoRollbackTo,
+  echoShadowName,
+  echoPrepareSql,
 };
 
 /*

--- a/src/wherecode.c
+++ b/src/wherecode.c
@@ -1415,6 +1415,8 @@ Bitmask sqlite3WhereCodeOneLoopStart(
     int addrNotFound;
     int nConstraint = pLoop->nLTerm;
 
+    sqlite3VdbeAddOp1(v, OP_VPrepareSql, iCur);
+
     iReg = sqlite3GetTempRange(pParse, nConstraint+2);
     addrNotFound = pLevel->addrBrk;
     for(j=0; j<nConstraint; j++){

--- a/test/rowvaluevtab.test
+++ b/test/rowvaluevtab.test
@@ -22,6 +22,10 @@ ifcapable !vtab {
 
 register_echo_module db
 
+#############
+# Test echo
+#############
+
 do_execsql_test 1.0 {
   CREATE TABLE t1(a, b, c);
   CREATE INDEX t1b ON t1(b);
@@ -91,5 +95,41 @@ do_execsql_test 1.4 {
 do_vfilter4_test 1.4f {
   SELECT a FROM e1 WHERE (b, c) IN ( VALUES(2, 2) )
 } {{SELECT rowid, a, b, c FROM 't1' WHERE b = ?}}
+
+######################################################################
+# Test echo_v2. We simply want to ensure that OP_VPrepareSql executes
+######################################################################
+
+do_execsql_test 2.0 {
+  CREATE TABLE t2(a, b, c);
+  CREATE INDEX t2b ON t2(b);
+  INSERT INTO t2 VALUES('one', 1, 1);
+  INSERT INTO t2 VALUES('two', 1, 2);
+  INSERT INTO t2 VALUES('three', 1, 3);
+
+  WITH s(i) AS (
+    SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i<10000
+  ) INSERT INTO t2 SELECT NULL, NULL, NULL FROM s;
+  CREATE VIRTUAL TABLE e2 USING echo_v2(t2);
+}
+
+proc do_vpreparesql1_test {tn sql expected} {
+  set rc -1
+  db eval "explain $sql" {
+    if {$opcode=="VPrepareSql"} {
+      set rc 0
+    }
+  }
+  if {$rc != $expected} {
+    error "Unexpected result $rc, was hoping for $expected"
+  }
+}
+
+do_execsql_test 2.1 {
+  SELECT a FROM e2 WHERE (b, c) IN ( VALUES(1, 3) )
+} {three}
+do_vpreparesql1_test 2.1f {
+  SELECT a FROM e2 WHERE (b, c) IN ( VALUES(2, 2) )
+} {0}
 
 finish_test


### PR DESCRIPTION
SQLite provides an interface to expose different data sources (such as files or other database systems) as virtual tables. There are several callbacks one must implement to enable e.g., connection handling and pagination, but one key attribute is missing on all callbacks: the query string being executed by the application. 

The query string is especially relevant when virtual tables are used to mirror data from external databases hosted on different machines. A virtual table implementation that knows about the SQL string is able to reduce the amount of data transferred over the network when an application is only concerned about a subset of the columns. 

This patch adds a new opcode `VPrepareSql` that's called immediately before `VFilter` when dispatching queries to a virtual table. The new opcode triggers the execution of the new `xPrepareSql` method which provides the SQL text to the virtual table implementation.

I am open to suggestions regarding the implementation approach and the new method's name. I'm looking forward to reading your feedback. Thanks!