### PR TITLE
add workspace to rust crate

### DIFF
--- a/src/rust/wasmtime-bindings/Cargo.toml
+++ b/src/rust/wasmtime-bindings/Cargo.toml
@@ -20,3 +20,5 @@ opt-level = "s"
 strip = true
 debug = false
 panic = "abort"
+
+[workspace]


### PR DESCRIPTION
This PR adds the `[workspace]` directive to the `Cargo.toml` for the rust wasm crate. This is for when libsql is built from within a cargo workspace, so cargo undertand that this crate is in fact part of its own workspace.
