### PR TITLE
wal: include relevant virtual WAL headers in sqlite3.h

### DIFF
--- a/src/page_header.h
+++ b/src/page_header.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef LIBSQL_PAGE_HEADER_H
+#define LIBSQL_PAGE_HEADER_H
+
+typedef struct sqlite3_pcache_page sqlite3_pcache_page;
+typedef struct Pager Pager;
+typedef struct PgHdr PgHdr;
+typedef struct PCache PCache;
+
+/*
+** Every page in the cache is controlled by an instance of the following
+** structure.
+*/
+struct PgHdr {
+  sqlite3_pcache_page *pPage;    /* Pcache object page handle */
+  void *pData;                   /* Page data */
+  void *pExtra;                  /* Extra content */
+  PCache *pCache;                /* PRIVATE: Cache that owns this page */
+  PgHdr *pDirty;                 /* Transient list of dirty sorted by pgno */
+  Pager *pPager;                 /* The pager this page is part of */
+  unsigned int pgno;             /* Page number for this page */
+#ifdef SQLITE_CHECK_PAGES
+  unsigned int pageHash;         /* Hash of page content */
+#endif
+  unsigned short flags;          /* PGHDR flags defined below */
+
+  /**********************************************************************
+  ** Elements above, except pCache, are public.  All that follow are 
+  ** private to pcache.c and should not be accessed by other modules.
+  ** pCache is grouped with the public elements for efficiency.
+  */
+  short nRef;                    /* Number of users of this page */
+  PgHdr *pDirtyNext;             /* Next element in list of dirty pages */
+  PgHdr *pDirtyPrev;             /* Previous element in list of dirty pages */
+                          /* NB: pDirtyNext and pDirtyPrev are undefined if the
+                          ** PgHdr object is not dirty */
+};
+
+#endif // LIBSQL_PAGE_HEADER_H

--- a/src/pcache.h
+++ b/src/pcache.h
@@ -15,37 +15,7 @@
 
 #ifndef _PCACHE_H_
 
-typedef struct PgHdr PgHdr;
-typedef struct PCache PCache;
-
-/*
-** Every page in the cache is controlled by an instance of the following
-** structure.
-*/
-struct PgHdr {
-  sqlite3_pcache_page *pPage;    /* Pcache object page handle */
-  void *pData;                   /* Page data */
-  void *pExtra;                  /* Extra content */
-  PCache *pCache;                /* PRIVATE: Cache that owns this page */
-  PgHdr *pDirty;                 /* Transient list of dirty sorted by pgno */
-  Pager *pPager;                 /* The pager this page is part of */
-  Pgno pgno;                     /* Page number for this page */
-#ifdef SQLITE_CHECK_PAGES
-  u32 pageHash;                  /* Hash of page content */
-#endif
-  u16 flags;                     /* PGHDR flags defined below */
-
-  /**********************************************************************
-  ** Elements above, except pCache, are public.  All that follow are 
-  ** private to pcache.c and should not be accessed by other modules.
-  ** pCache is grouped with the public elements for efficiency.
-  */
-  i16 nRef;                      /* Number of users of this page */
-  PgHdr *pDirtyNext;             /* Next element in list of dirty pages */
-  PgHdr *pDirtyPrev;             /* Previous element in list of dirty pages */
-                          /* NB: pDirtyNext and pDirtyPrev are undefined if the
-                          ** PgHdr object is not dirty */
-};
+#include "page_header.h"
 
 /* Bit values for PgHdr.flags */
 #define PGHDR_CLEAN           0x001  /* Page not on the PCache.pDirty list */


### PR DESCRIPTION
It was reported on Discord that the amalgamation file only includes libsql_wal_methods as an opaque type, which is not easily consumable, especially for projects which automatically generate bindings to other languages.
This issue was an oversight, rooting from the fact that our Rust bindings were simply written from scratch. And while we still intend to add official Rust bindings, virtual WAL methods should be included in the amalgamation sqlite3.h file, so that they can be easily consumed by other languages.