### PR TITLE
Use WAL journaling mode by default if custom WAL methods are specified

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -4893,16 +4893,15 @@ int sqlite3PagerOpen(
     sqlite3FileSuffix3(zFilename, pPager->zWal);
     pPtr = (u8*)(pPager->zWal + sqlite3Strlen30(pPager->zWal)+1);
 #endif
+  }else{
+    pPager->zWal = 0;
+  }
 
   if (pWalMethods->xPreMainDbOpen) {
     int rc = pWalMethods->xPreMainDbOpen(pWalMethods, zPathname);
     if (rc != SQLITE_OK) {
       return rc;
     }
-  }
-
-  }else{
-    pPager->zWal = 0;
   }
 #endif
   (void)pPtr;  /* Suppress warning about unused pPtr value */

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -51,6 +51,6 @@ mod tests {
         let also_steven = person_iter.next().unwrap().unwrap();
         println!("Read {:#?}", also_steven);
         assert!(also_steven == steven);
-        assert!(person_iter.next() == None)
+        assert!(person_iter.next().is_none())
     }
 }

--- a/test/rust_suite/src/virtual_wal.rs
+++ b/test/rust_suite/src/virtual_wal.rs
@@ -1,3 +1,4 @@
+#![allow(improper_ctypes)]
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;
@@ -164,7 +165,7 @@ mod tests {
         wal: *mut *const Wal,
     ) -> i32 {
         let new_wal = Box::new(Wal {
-            vfs: vfs,
+            vfs,
             db_fd: std::ptr::null(),
             wal_fd: std::ptr::null(),
             callback_value: 0,
@@ -198,7 +199,7 @@ mod tests {
             },
             min_frame: 0,
             recalculate_checksums: 0,
-            wal_name: wal_name,
+            wal_name,
             n_checkpoints: 0,
             lock_error: 0,
             p_snapshot: std::ptr::null(),
@@ -252,7 +253,7 @@ mod tests {
             return ERR_MISUSE;
         }
         let out_buffer = unsafe { std::slice::from_raw_parts_mut(p_out, n_out) };
-        out_buffer.copy_from_slice(&data);
+        out_buffer.copy_from_slice(data);
         println!("\t\tread {} bytes", data.len());
         0
     }
@@ -301,7 +302,7 @@ mod tests {
             }
             .to_vec();
             methods.pages.insert(current.pgno, data);
-            if current.dirty == std::ptr::null() {
+            if current.dirty.is_null() {
                 break;
             }
             current_ptr = current.dirty


### PR DESCRIPTION
It's reasonable to assume that a database open with custom WAL methods should default to WAL journaling mode.

This commit comes with an updated test which ensures that the database is open in WAL mode without having to resort to calling `PRAGMA journal_mode=wal` manually.