### PR TITLE
ext: split libSQL extension API to a separate struct

### DIFF
--- a/src/loadext.c
+++ b/src/loadext.c
@@ -512,14 +512,15 @@ static const sqlite3_api_routines sqlite3Apis = {
   /* Version 3.40.0 and later */
   sqlite3_value_encoding,
   /* Version 3.41.0 and later */
-  sqlite3_is_interrupted,
+  sqlite3_is_interrupted
+};
 
+static const libsql_api_routines libsqlApis = {
   /* libSQL 0.1.1 */
   libsql_wal_methods_find,
   libsql_wal_methods_register,
   libsql_wal_methods_unregister
 };
-
 /* True if x is the directory separator character
 */
 #if SQLITE_OS_WIN
@@ -653,7 +654,7 @@ static int sqlite3LoadExtension(
     return SQLITE_ERROR;
   }
   sqlite3_free(zAltEntry);
-  rc = xInit(db, &zErrmsg, &sqlite3Apis);
+  rc = xInit(db, &zErrmsg, &sqlite3Apis, &libsqlApis);
   if( rc ){
     if( rc==SQLITE_OK_LOAD_PERMANENTLY ) return SQLITE_OK;
     if( pzErrMsg ){
@@ -880,8 +881,10 @@ void sqlite3AutoLoadExtensions(sqlite3 *db){
 #endif
 #ifdef SQLITE_OMIT_LOAD_EXTENSION
     const sqlite3_api_routines *pThunk = 0;
+    const libsql_api_routines *pThunkLibsql = 0;
 #else
     const sqlite3_api_routines *pThunk = &sqlite3Apis;
+    const libsql_api_routines *pThunkLibsql = &libsqlApis;
 #endif
     sqlite3_mutex_enter(mutex);
     if( i>=wsdAutoext.nExt ){
@@ -892,7 +895,7 @@ void sqlite3AutoLoadExtensions(sqlite3 *db){
     }
     sqlite3_mutex_leave(mutex);
     zErrmsg = 0;
-    if( xInit && (rc = xInit(db, &zErrmsg, pThunk))!=0 ){
+    if( xInit && (rc = xInit(db, &zErrmsg, pThunk, pThunkLibsql))!=0 ){
       sqlite3ErrorWithMsg(db, rc,
             "automatic extension loading failed: %s", zErrmsg);
       go = 0;

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -1289,6 +1289,16 @@ typedef struct sqlite3_mutex sqlite3_mutex;
 typedef struct sqlite3_api_routines sqlite3_api_routines;
 
 /*
+** CAPI3REF: Loadable Extension Thunk
+**
+** A pointer to the opaque libsql_api_routines structure is passed as
+** the fourth parameter to entry points of [loadable extensions].  This
+** structure must be typedefed in order to work around compiler warnings
+** on some platforms.
+*/
+typedef struct libsql_api_routines libsql_api_routines;
+
+/*
 ** CAPI3REF: File Name
 **
 ** Type [sqlite3_filename] is used by SQLite to pass filenames to the

--- a/src/sqlite3ext.h
+++ b/src/sqlite3ext.h
@@ -362,7 +362,10 @@ struct sqlite3_api_routines {
   /* Version 3.41.0 and later */
   int (*is_interrupted)(sqlite3*);
 
-  /* libSQL 0.1.1 */
+};
+
+struct libsql_api_routines {
+    /* libSQL 0.1.1 */
   struct libsql_wal_methods *(*wal_methods_find)(const char *);
   int (*wal_methods_register)(struct libsql_wal_methods*);
   int (*wal_methods_unregister)(struct libsql_wal_methods*);
@@ -373,9 +376,10 @@ struct sqlite3_api_routines {
 ** is also defined in the file "loadext.c".
 */
 typedef int (*sqlite3_loadext_entry)(
-  sqlite3 *db,                       /* Handle to the database. */
-  char **pzErrMsg,                   /* Used to set error string on failure. */
-  const sqlite3_api_routines *pThunk /* Extension API function pointers. */
+  sqlite3 *db,                            /* Handle to the database. */
+  char **pzErrMsg,                        /* Used to set error string on failure. */
+  const sqlite3_api_routines *pThunk,     /* Extension API function pointers. */
+  const libsql_api_routines *pThunkLibsql /* Extension API function pointers - libSQL.*/
 );
 
 /*
@@ -695,9 +699,9 @@ typedef int (*sqlite3_loadext_entry)(
 /* Version 3.41.0 and later */
 #define sqlite3_is_interrupted         sqlite3_api->is_interrupted
 /* libSQL 0.1.1 */
-#define libsql_wal_methods_find        sqlite3_api->wal_methods_find
-#define libsql_wal_methods_register    sqlite3_api->wal_methods_register
-#define libsql_wal_methods_unregister  sqlite3_api->wal_methods_unregister
+#define libsql_wal_methods_find        libsql_api->wal_methods_find
+#define libsql_wal_methods_register    libsql_api->wal_methods_register
+#define libsql_wal_methods_unregister  libsql_api->wal_methods_unregister
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)
@@ -707,12 +711,23 @@ typedef int (*sqlite3_loadext_entry)(
 # define SQLITE_EXTENSION_INIT2(v)  sqlite3_api=v;
 # define SQLITE_EXTENSION_INIT3     \
     extern const sqlite3_api_routines *sqlite3_api;
+
+# define LIBSQL_EXTENSION_INIT1     const libsql_api_routines *libsql_api=0;
+# define LIBSQL_EXTENSION_INIT2(v)  libsql_api=v;
+# define LIBSQL_EXTENSION_INIT3     \
+    extern const libsql_api_routines *libsql_api;
+
 #else
   /* This case when the file is being statically linked into the 
   ** application */
 # define SQLITE_EXTENSION_INIT1     /*no-op*/
 # define SQLITE_EXTENSION_INIT2(v)  (void)v; /* unused parameter */
 # define SQLITE_EXTENSION_INIT3     /*no-op*/
+
+# define LIBSQL_EXTENSION_INIT1     /*no-op*/
+# define LIBSQL_EXTENSION_INIT2(v)  (void)v; /* unused parameter */
+# define LIBSQL_EXTENSION_INIT3     /*no-op*/
+
 #endif
 
 #endif /* SQLITE3EXT_H */


### PR DESCRIPTION
Following the suggestion from #101, libSQL-specific extension API is split to a separate structure in order to avoid compatibility issues once new API entries are added to SQLite.

Fixes #101

Solution suggested by @thomcc

Smoke-tested with https://github.com/libsql/bottomless extension