### PR TITLE
pager: use journal_mode=delete if default WAL doesn't work

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -3317,7 +3317,10 @@ static int pagerOpenWalIfPresent(Pager *pPager){
           rc = sqlite3PagerOpenWal(pPager, 0);
         }
       }else if( pPager->journalMode==PAGER_JOURNALMODE_WAL ){
-        rc = sqlite3PagerOpenWal(pPager, 0);
+        if ( pPager->readOnly || sqlite3PagerOpenWal(pPager, 0) != SQLITE_OK ) {
+        // Fall back to default journaling mode if it's not possible to open WAL
+          pPager->journalMode = PAGER_JOURNALMODE_DELETE;
+        }
       }
     }
   }


### PR DESCRIPTION
The fallback is needed, because sometimes it's impossible to open the WAL journal - e.g. on a read-only file system.