### PR TITLE
pager: do not open an empty WAL

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -3316,8 +3316,6 @@ static int pagerOpenWalIfPresent(Pager *pPager){
           testcase( sqlite3PcachePagecount(pPager->pPCache)==0 );
           rc = sqlite3PagerOpenWal(pPager, 0);
         }
-      }else if( pPager->journalMode==PAGER_JOURNALMODE_WAL ){
-        rc = sqlite3PagerOpenWal(pPager, 0);
       }
     }
   }


### PR DESCRIPTION
That makes the behavior consistent with how this code used to work
- if there are no pages in WAL (e.g. an empty database), opening WAL is deferred.