### PR TITLE
Revert auto-WAL detection

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -3316,6 +3316,8 @@ static int pagerOpenWalIfPresent(Pager *pPager){
           testcase( sqlite3PcachePagecount(pPager->pPCache)==0 );
           rc = sqlite3PagerOpenWal(pPager, 0);
         }
+      }else if( pPager->journalMode==PAGER_JOURNALMODE_WAL ){
+        rc = sqlite3PagerOpenWal(pPager, 0);
       }
     }
   }

--- a/src/pager.c
+++ b/src/pager.c
@@ -3280,11 +3280,13 @@ static int pagerPagecount(Pager *pPager, Pgno *pnPage){
 #ifndef SQLITE_OMIT_WAL
 /*
 ** Check if the *-wal file that corresponds to the database opened by pPager
-** exists if the database is not empty, or verify that the *-wal file does
+** exists if the database is not empy, or verify that the *-wal file does
 ** not exist (by deleting it) if the database file is empty.
 **
 ** If the database is not empty and the *-wal file exists, open the pager
-** in WAL mode. If the journaling mode is already set to wal, open it.
+** in WAL mode.  If the database is empty or if no *-wal file exists and
+** if no error occurs, make sure Pager.journalMode is not set to
+** PAGER_JOURNALMODE_WAL.
 **
 ** Return SQLITE_OK or an error code.
 **
@@ -3317,7 +3319,7 @@ static int pagerOpenWalIfPresent(Pager *pPager){
           rc = sqlite3PagerOpenWal(pPager, 0);
         }
       }else if( pPager->journalMode==PAGER_JOURNALMODE_WAL ){
-        rc = sqlite3PagerOpenWal(pPager, 0);
+        pPager->journalMode = PAGER_JOURNALMODE_DELETE;
       }
     }
   }
@@ -4891,9 +4893,6 @@ int sqlite3PagerOpen(
     sqlite3FileSuffix3(zFilename, pPager->zWal);
     pPtr = (u8*)(pPager->zWal + sqlite3Strlen30(pPager->zWal)+1);
 #endif
-  }else{
-    pPager->zWal = 0;
-  }
 
   if (pWalMethods->xPreMainDbOpen) {
     int rc = pWalMethods->xPreMainDbOpen(pWalMethods, zPathname);
@@ -4901,9 +4900,9 @@ int sqlite3PagerOpen(
       return rc;
     }
   }
-  if (strcmp(pWalMethods->zName, "default") != 0) {
-    // use WAL journaling by default if custom WAL methods are set
-    sqlite3PagerSetJournalMode(pPager, PAGER_JOURNALMODE_WAL);
+
+  }else{
+    pPager->zWal = 0;
   }
 #endif
   (void)pPtr;  /* Suppress warning about unused pPtr value */

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -51,6 +51,6 @@ mod tests {
         let also_steven = person_iter.next().unwrap().unwrap();
         println!("Read {:#?}", also_steven);
         assert!(also_steven == steven);
-        assert!(person_iter.next().is_none())
+        assert!(person_iter.next() == None)
     }
 }

--- a/test/rust_suite/src/virtual_wal.rs
+++ b/test/rust_suite/src/virtual_wal.rs
@@ -1,4 +1,3 @@
-#![allow(improper_ctypes)]
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;
@@ -122,7 +121,8 @@ mod tests {
         db: extern "C" fn(wal: *mut Wal, db: *const c_void),
         pathname_len: extern "C" fn(orig_len: i32) -> i32,
         get_pathname: extern "C" fn(buf: *mut u8, orig: *const u8, orig_len: i32),
-        pre_main_db_open: extern "C" fn(methods: *mut libsql_wal_methods, name: *const i8) -> i32,
+        pre_main_db_open:
+            extern "C" fn(methods: *mut libsql_wal_methods, name: *const i8) -> i32,
         b_uses_shm: i32,
         name: *const u8,
         p_next: *const c_void,
@@ -165,7 +165,7 @@ mod tests {
         wal: *mut *const Wal,
     ) -> i32 {
         let new_wal = Box::new(Wal {
-            vfs,
+            vfs: vfs,
             db_fd: std::ptr::null(),
             wal_fd: std::ptr::null(),
             callback_value: 0,
@@ -199,7 +199,7 @@ mod tests {
             },
             min_frame: 0,
             recalculate_checksums: 0,
-            wal_name,
+            wal_name: wal_name,
             n_checkpoints: 0,
             lock_error: 0,
             p_snapshot: std::ptr::null(),
@@ -253,14 +253,12 @@ mod tests {
             return ERR_MISUSE;
         }
         let out_buffer = unsafe { std::slice::from_raw_parts_mut(p_out, n_out) };
-        out_buffer.copy_from_slice(data);
+        out_buffer.copy_from_slice(&data);
         println!("\t\tread {} bytes", data.len());
         0
     }
-    extern "C" fn db_size(wal: *mut Wal) -> i32 {
-        println!("Db size called");
-        let methods = unsafe { &*(*wal).wal_methods };
-        methods.pages.len() as i32
+    extern "C" fn db_size(_wal: *mut Wal) -> i32 {
+        ERR_MISUSE
     }
     extern "C" fn begin_write(_wal: *mut Wal) -> i32 {
         println!("Write started");
@@ -302,7 +300,7 @@ mod tests {
             }
             .to_vec();
             methods.pages.insert(current.pgno, data);
-            if current.dirty.is_null() {
+            if current.dirty == std::ptr::null() {
                 break;
             }
             current_ptr = current.dirty
@@ -336,14 +334,12 @@ mod tests {
         panic!("Should never be called")
     }
     extern "C" fn db(_wal: *mut Wal, _db: *const c_void) {}
-    extern "C" fn pathname_len(orig_len: i32) -> i32 {
-        orig_len + 4
+    extern "C" fn pathname_len(_orig_len: i32) -> i32 {
+        println!("Returning length 0");
+        0
     }
-    extern "C" fn get_pathname(buf: *mut u8, orig: *const u8, orig_len: i32) {
-        unsafe {
-            std::ptr::copy_nonoverlapping(orig, buf, orig_len as usize);
-            std::ptr::copy_nonoverlapping(".wal".as_ptr(), buf.offset(orig_len as isize), 4);
-        }
+    extern "C" fn get_pathname(_buf: *mut u8, _orig: *const u8, _orig_len: i32) {
+        panic!("Should never be called")
     }
     extern "C" fn pre_main_db_open(_methods: *mut libsql_wal_methods, _name: *const i8) -> i32 {
         0
@@ -406,11 +402,7 @@ mod tests {
             Box::leak(vwal);
             Connection::from_handle(pdb).unwrap()
         };
-        let journal_mode: String = conn
-            .query_row("PRAGMA journal_mode", [], |r| r.get(0))
-            .unwrap();
-        println!("Journaling mode: {}", journal_mode);
-        assert_eq!(journal_mode, "wal".to_string());
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
         conn.execute("CREATE TABLE t(id)", ()).unwrap();
         conn.execute("INSERT INTO t(id) VALUES (42)", ()).unwrap();
         conn.execute("INSERT INTO t(id) VALUES (zeroblob(8193))", ())


### PR DESCRIPTION
The code that automatically set WAL mode in connections that define custom WAL methods is broken - let's revert it asap, and then debug.