### PR TITLE
src,tool: fix including ext/udf/wasm_bindings.h in the amalgamation

### DIFF
--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -1330,7 +1330,7 @@ typedef int VList;
 #include "pcache.h"
 #include "mutex.h"
 
-#ifdef LIBSQL_ENABLE_WASM_RUNTIME
+#if defined(LIBSQL_ENABLE_WASM_RUNTIME) && !defined(SQLITE_AMALGAMATION)
 #include "ext/udf/wasm_bindings.h"
 #endif
 

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -177,6 +177,7 @@ foreach hdr {
 set available_hdr(sqliteInt.h) 0
 set available_hdr(os_common.h) 0
 set available_hdr(sqlite3session.h) 0
+set available_hdr(wasm_bindings.h) 0
 
 # These headers should be copied into the amalgamation without modifying any
 # of their function declarations or definitions.

--- a/tool/mksqlite3h.tcl
+++ b/tool/mksqlite3h.tcl
@@ -100,6 +100,7 @@ set filelist [subst {
   $TOP/ext/fts5/fts5.h
   $TOP/src/page_header.h
   $TOP/src/wal.h
+  $TOP/ext/udf/wasm_bindings.h
 }]
 if {$enable_recover} {
   lappend filelist "$TOP/ext/recover/sqlite3recover.h"


### PR DESCRIPTION
The amalgamation files now properly include the contents of wasm_bindings.h header.