### PR TITLE
build: initialize Wasm func table before CREATE FUNCTION

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -5713,6 +5713,8 @@ void libsql_create_function(
     return;
   }
 
+  libsql_try_initialize_wasm_func_table(pParse->db);
+
   Token table = {"libsql_wasm_func_table", 22};
   Token name = {"name", 4};
   Token body = {"body", 4};

--- a/src/rust/wasmtime-bindings/Cargo.lock
+++ b/src/rust/wasmtime-bindings/Cargo.lock
@@ -525,6 +525,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
+name = "libsql-wasmtime-bindings"
+version = "0.1.0"
+dependencies = [
+ "wasmtime",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,13 +993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de327cf46d5218315957138131ed904621e6f99018aa2da508c0dcf0c65f1bf2"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-bindings"
-version = "0.1.0"
-dependencies = [
- "wasmtime",
 ]
 
 [[package]]

--- a/test/rust_suite/src/user_defined_functions.rs
+++ b/test/rust_suite/src/user_defined_functions.rs
@@ -10,14 +10,9 @@ fn fib(n: i32) -> i32 {
     }
 }
 
-extern "C" {
-    fn libsql_try_initialize_wasm_func_table(db: *mut libsqlite3_sys::sqlite3);
-}
-
 #[test]
 fn test_create_drop_fib() {
     let conn = Connection::open_in_memory().unwrap();
-    unsafe { libsql_try_initialize_wasm_func_table(conn.handle()) }
 
     conn.execute("CREATE TABLE t (id)", ()).unwrap();
     for i in 1..7 {
@@ -50,7 +45,6 @@ fn test_contains() {
     use itertools::Itertools;
 
     let conn = Connection::open_in_memory().unwrap();
-    unsafe { libsql_try_initialize_wasm_func_table(conn.handle()) }
 
     conn.execute("CREATE TABLE t (a, b)", ()).unwrap();
     for perm in vec!["eenie", "meenie", "miny", "mo", "m", "o"]
@@ -104,7 +98,6 @@ fn test_contains() {
 #[test]
 fn test_concat3() {
     let conn = Connection::open_in_memory().unwrap();
-    unsafe { libsql_try_initialize_wasm_func_table(conn.handle()) }
 
     conn.execute("CREATE TABLE t (a, b)", ()).unwrap();
     conn.execute("INSERT INTO t(a, b) VALUES ('hello', 'world')", ())
@@ -146,7 +139,6 @@ fn test_concat3() {
 #[test]
 fn test_reverse_blob() {
     let conn = Connection::open_in_memory().unwrap();
-    unsafe { libsql_try_initialize_wasm_func_table(conn.handle()) }
 
     conn.execute("CREATE TABLE t (id)", ()).unwrap();
     for vec in [
@@ -186,7 +178,6 @@ fn test_reverse_blob() {
 #[test]
 fn test_get_null() {
     let conn = Connection::open_in_memory().unwrap();
-    unsafe { libsql_try_initialize_wasm_func_table(conn.handle()) }
 
     conn.execute(
         &format!(
@@ -210,7 +201,6 @@ fn test_get_null() {
 #[test]
 fn test_explain() {
     let conn = Connection::open_in_memory().unwrap();
-    unsafe { libsql_try_initialize_wasm_func_table(conn.handle()) }
 
     let mut create_stmt = conn
         .prepare("EXPLAIN CREATE FUNCTION mj LANGUAGE wasm AS 'hee-hee'")


### PR DESCRIPTION
The call is idempotent, so it's safe to just run it on each CREATE FUNCTION, which is a rare operation in the first place.

Fixes #123 