### PR TITLE
udf: add WasmEdge bindings

### DIFF
--- a/.github/workflows/maketestwasm.yml
+++ b/.github/workflows/maketestwasm.yml
@@ -18,6 +18,12 @@ jobs:
     - name: get TCL
       run: sudo apt-get install -y tcl8.6-dev
 
+    - name: get WasmEdge
+      run: > 
+        wget -O- https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-slim-runtime-0.11.2-manylinux2014_x86_64.tar.gz | tar zxv
+        && sudo cp -r WasmEdge-0.11.2-Linux/include/* /usr/include/
+        && sudo cp -r WasmEdge-0.11.2-Linux/lib64/* /usr/lib64/
+
     - name: configure with Wasm
       run: ./configure --enable-wasm-runtime
 
@@ -28,4 +34,13 @@ jobs:
       run: make test
 
     - name: Run Rust tests with Wasm
+      run: make rusttestwasm
+
+    - name: reconfigure with Wasm in WasmEdge mode
+      run: make clean && ./configure --enable-wasm-runtime-wasmedge
+
+    - name: Run tests
+      run: make test
+
+    - name: Run tests with Wasm
       run: make rusttestwasm

--- a/.github/workflows/maketestwasm.yml
+++ b/.github/workflows/maketestwasm.yml
@@ -22,7 +22,7 @@ jobs:
       run: > 
         wget -O- https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-slim-runtime-0.11.2-manylinux2014_x86_64.tar.gz | tar zxv
         && sudo cp -r WasmEdge-0.11.2-Linux/include/* /usr/include/
-        && sudo cp -r WasmEdge-0.11.2-Linux/lib64/* /usr/lib64/
+        && sudo cp -r WasmEdge-0.11.2-Linux/lib64/* /usr/lib/
 
     - name: configure with Wasm
       run: ./configure --enable-wasm-runtime

--- a/.github/workflows/maketestwasm.yml
+++ b/.github/workflows/maketestwasm.yml
@@ -25,7 +25,7 @@ jobs:
         && sudo cp -r WasmEdge-0.11.2-Linux/lib64/* /usr/lib/
 
     - name: configure with Wasm
-      run: ./configure --enable-wasm-runtime
+      run: ./configure --enable-wasm-runtime-dynamic
 
     - name: make the library generally available
       run: mkdir tmp_lib && DESTDIR=$(pwd)/tmp_lib  make liblibsql_install && sudo cp -r tmp_lib/usr/local/lib/* /usr/lib/

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ sqltclsh.c
 srcck1
 test-out.txt
 test/rust_suite/target
+test/rust_suite/Cargo.lock
 testfixture
 libsql

--- a/Makefile.in
+++ b/Makefile.in
@@ -196,7 +196,7 @@ LIBOBJS0 = alter.lo analyze.lo attach.lo auth.lo \
          update.lo userauth.lo upsert.lo util.lo vacuum.lo \
          vdbe.lo vdbeapi.lo vdbeaux.lo vdbeblob.lo vdbemem.lo vdbesort.lo \
          vdbetrace.lo vdbevtab.lo \
-         wal.lo walker.lo where.lo wherecode.lo whereexpr.lo \
+         wal.lo walker.lo wasmedge_bindings.lo where.lo wherecode.lo whereexpr.lo \
          window.lo utf.lo vtab.lo
 
 # Object files for the amalgamation.
@@ -357,6 +357,8 @@ SRC += \
   $(TOP)/ext/rbu/sqlite3rbu.c
 SRC += \
   $(TOP)/ext/misc/stmt.c
+SRC += \
+  $(TOP)/ext/udf/wasmedge_bindings.c
 
 # Generated source code files
 #
@@ -543,6 +545,7 @@ TESTSRC2 = \
   $(TOP)/ext/async/sqlite3async.c \
   $(TOP)/ext/session/sqlite3session.c \
   $(TOP)/ext/misc/stmt.c \
+  $(TOP)/ext/udf/wasmedge_bindings.c \
   fts5.c
 
 # Header files used by all library source files.
@@ -1214,6 +1217,9 @@ sqlite3session.lo:	$(TOP)/ext/session/sqlite3session.c $(HDR) $(EXTHDR)
 
 stmt.lo:	$(TOP)/ext/misc/stmt.c
 	$(LTCOMPILE) -DSQLITE_CORE -c $(TOP)/ext/misc/stmt.c
+
+wasmedge_bindings.lo:	$(TOP)/ext/udf/wasmedge_bindings.c $(HDR) $(EXTHDR)
+	$(LTCOMPILE) -DSQLITE_CORE -c $(TOP)/ext/udf/wasmedge_bindings.c
 
 # FTS5 things
 #

--- a/Makefile.in
+++ b/Makefile.in
@@ -791,7 +791,7 @@ mptest:	mptester$(TEXE)
 	touch .target_source
 
 liblibsql_wasm:	$(WBSRC)
-	cd $(WBTOP) && cargo build --release --lib
+	cd $(WBTOP) && cargo build --release --lib && mkdir -p $(TOP)/.libs && cp target/release/liblibsql_wasm.* $(TOP)/.libs/
 
 sqlite3.c:	.target_source $(TOP)/tool/mksqlite3c.tcl
 	$(TCLSH_CMD) $(TOP)/tool/mksqlite3c.tcl $(AMALGAMATION_LINE_MACROS)
@@ -1336,7 +1336,7 @@ quicktest:	./testfixture$(TEXE)
 rusttest:	sqlite3.h libsqlite3.la
 	( cd test/rust_suite; LD_LIBRARY_PATH=../../.libs cargo test )
 
-rusttestwasm:	sqlite3.h libsqlite3.la
+rusttestwasm:	sqlite3.h libsqlite3.la sqlite3
 	( cd test/rust_suite; LD_LIBRARY_PATH=../../.libs cargo test --features udf )
 
 # This is the common case.  Run many tests that do not take too long,

--- a/configure
+++ b/configure
@@ -937,6 +937,7 @@ enable_math
 enable_json
 enable_wasm_runtime
 enable_wasm_runtime_dynamic
+enable_wasm_runtime_wasmedge
 enable_all
 enable_memsys5
 enable_memsys3
@@ -1603,6 +1604,9 @@ Optional Features:
   --enable-wasm-runtime   Enable WebAssembly runtime integration
   --enable-wasm-runtime-dynamic
                           Link with WebAssembly runtime dynamically
+  --enable-wasm-runtime-wasmedge
+                          Enable WebAssembly runtime integration (WasmEdge
+                          library)
   --enable-all            Enable FTS4, FTS5, Geopoly, RTree, Sessions
   --enable-memsys5        Enable MEMSYS5
   --enable-memsys3        Enable MEMSYS3
@@ -4465,13 +4469,13 @@ then :
 else $as_nop
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:4468: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:4472: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4471: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:4475: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4474: output\"" >&5)
+  (eval echo "\"\$as_me:4478: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -5722,7 +5726,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 5725 "configure"' > conftest.$ac_ext
+  echo '#line 5729 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7065,11 +7069,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7068: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7072: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7072: \$? = $ac_status" >&5
+   echo "$as_me:7076: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -7405,11 +7409,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7408: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7412: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7412: \$? = $ac_status" >&5
+   echo "$as_me:7416: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -7512,11 +7516,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7515: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7519: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:7519: \$? = $ac_status" >&5
+   echo "$as_me:7523: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -7568,11 +7572,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7571: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7575: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:7575: \$? = $ac_status" >&5
+   echo "$as_me:7579: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -9956,7 +9960,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 9959 "configure"
+#line 9963 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10053,7 +10057,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10056 "configure"
+#line 10060 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -12070,7 +12074,15 @@ then :
   enableval=$enable_wasm_runtime_dynamic;
 fi
 
-if test "$enable_wasm_runtime" = "yes" -o "$enable_wasm_runtime_dynamic" = "yes"; then
+# Check whether --enable-wasm_runtime_wasmedge was given.
+if test ${enable_wasm_runtime_wasmedge+y}
+then :
+  enableval=$enable_wasm_runtime_wasmedge;
+fi
+
+if test "$enable_wasm_runtime" = "yes" \
+    -o "$enable_wasm_runtime_dynamic" = "yes" \
+    -o "$enable_wasm_runtime_wasmedge" = "yes"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
   OPT_FEATURE_FLAGS="${OPT_FEATURE_FLAGS} -DLIBSQL_ENABLE_WASM_RUNTIME"
@@ -12116,15 +12128,81 @@ printf "%s\n" "no" >&6; }
 fi
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to link WebAssembly runtime dynamically" >&5
-printf %s "checking whether to link WebAssembly runtime dynamically... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to set up WebAssembly runtime" >&5
+printf %s "checking how to set up WebAssembly runtime... " >&6; }
   if test "$enable_wasm_runtime_dynamic" = "yes"; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: link dynamically" >&5
+printf "%s\n" "link dynamically" >&6; }
     OPT_WASM_RUNTIME=d
+  elif test "$enable_wasm_runtime_wasmedge" = "yes"; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: link libwasmedge" >&5
+printf "%s\n" "link libwasmedge" >&6; }
+    OPT_FEATURE_FLAGS="${OPT_FEATURE_FLAGS} -DLIBSQL_ENABLE_WASM_RUNTIME_WASMEDGE"
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing WasmEdge_VMInstantiate" >&5
+printf %s "checking for library containing WasmEdge_VMInstantiate... " >&6; }
+if test ${ac_cv_search_WasmEdge_VMInstantiate+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char WasmEdge_VMInstantiate ();
+int
+main (void)
+{
+return WasmEdge_VMInstantiate ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' wasmedge
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
   else
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_WasmEdge_VMInstantiate=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_WasmEdge_VMInstantiate+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_WasmEdge_VMInstantiate+y}
+then :
+
+else $as_nop
+  ac_cv_search_WasmEdge_VMInstantiate=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_WasmEdge_VMInstantiate" >&5
+printf "%s\n" "$ac_cv_search_WasmEdge_VMInstantiate" >&6; }
+ac_res=$ac_cv_search_WasmEdge_VMInstantiate
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else $as_nop
+  as_fn_error $? "\"WasmEdge library not found - install libwasmedge\"" "$LINENO" 5
+fi
+
+    OPT_WASM_RUNTIME=wasmedge
+  else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: link statically" >&5
+printf "%s\n" "link statically" >&6; }
     OPT_WASM_RUNTIME=y # static linking
   fi
 else

--- a/configure.ac
+++ b/configure.ac
@@ -635,16 +635,25 @@ AS_HELP_STRING([--enable-wasm-runtime],[Enable WebAssembly runtime integration])
 AC_MSG_CHECKING([whether to support WebAssembly integration])
 AC_ARG_ENABLE(wasm_runtime_dynamic, 
 AS_HELP_STRING([--enable-wasm-runtime-dynamic],[Link with WebAssembly runtime dynamically]))
-if test "$enable_wasm_runtime" = "yes" -o "$enable_wasm_runtime_dynamic" = "yes"; then
+AC_ARG_ENABLE(wasm_runtime_wasmedge, 
+AS_HELP_STRING([--enable-wasm-runtime-wasmedge],[Enable WebAssembly runtime integration (WasmEdge library)]))
+if test "$enable_wasm_runtime" = "yes" \
+    -o "$enable_wasm_runtime_dynamic" = "yes" \
+    -o "$enable_wasm_runtime_wasmedge" = "yes"; then
   AC_MSG_RESULT([yes])
   OPT_FEATURE_FLAGS="${OPT_FEATURE_FLAGS} -DLIBSQL_ENABLE_WASM_RUNTIME"
   AC_CHECK_PROG(CARGO_BIN, cargo)
-  AC_MSG_CHECKING([whether to link WebAssembly runtime dynamically])
+  AC_MSG_CHECKING([how to set up WebAssembly runtime])
   if test "$enable_wasm_runtime_dynamic" = "yes"; then
-    AC_MSG_RESULT([yes])
+    AC_MSG_RESULT([link dynamically])
     OPT_WASM_RUNTIME=d
+  elif test "$enable_wasm_runtime_wasmedge" = "yes"; then
+    AC_MSG_RESULT([link libwasmedge])
+    OPT_FEATURE_FLAGS="${OPT_FEATURE_FLAGS} -DLIBSQL_ENABLE_WASM_RUNTIME_WASMEDGE"
+    AC_SEARCH_LIBS(WasmEdge_VMInstantiate, wasmedge, [], [AC_MSG_ERROR("WasmEdge library not found - install libwasmedge")])
+    OPT_WASM_RUNTIME=wasmedge
   else
-    AC_MSG_RESULT([no])
+    AC_MSG_RESULT([link statically])
     OPT_WASM_RUNTIME=y # static linking
   fi
 else

--- a/ext/udf/wasmedge_bindings.c
+++ b/ext/udf/wasmedge_bindings.c
@@ -1,0 +1,186 @@
+#if defined(LIBSQL_ENABLE_WASM_RUNTIME) && defined(LIBSQL_ENABLE_WASM_RUNTIME_WASMEDGE)
+
+#include "sqliteInt.h"
+#include "wasm_bindings.h"
+#include <wasmedge/wasmedge.h>
+
+void libsql_run_wasm(libsql_wasm_udf_api *api, sqlite3_context *context, libsql_wasm_engine_t *engine,
+    libsql_wasm_module_t *module, const char *func_name, int argc, sqlite3_value **argv) {
+
+  WasmEdge_VMContext *ctx = (WasmEdge_VMContext *)module;
+
+
+  WasmEdge_Result res = WasmEdge_VMInstantiate(ctx);
+  if (!WasmEdge_ResultOK(res)) {
+      sqlite3_result_error(context, "Instantiation failed", -1);
+      return;
+  }
+
+  const WasmEdge_ModuleInstanceContext* instance_ctx = WasmEdge_VMGetActiveModule(ctx);
+  WasmEdge_String mem_name = WasmEdge_StringCreateByCString("memory");
+  WasmEdge_MemoryInstanceContext* mem_ctx = WasmEdge_ModuleInstanceFindMemory(instance_ctx, mem_name);
+  WasmEdge_StringDelete(mem_name);
+
+  WasmEdge_Value params[argc];
+  WasmEdge_Value results[1];
+
+  int mem_size = WasmEdge_MemoryInstanceGetPageSize(mem_ctx) * 65536;
+  int mem_offset = mem_size;
+
+  for (unsigned i = 0; i < argc; ++i) {
+    u8 type = sqlite3_value_type(argv[i]);
+    switch (type) {
+    case SQLITE_INTEGER:
+      params[i] = WasmEdge_ValueGenI64(sqlite3_value_int(argv[i]));
+      break;
+    case SQLITE_FLOAT:
+      params[i] = WasmEdge_ValueGenI64(sqlite3_value_double(argv[i]));
+      break;
+    case SQLITE_TEXT: {
+      int text_len = sqlite3_value_bytes(argv[i]);
+      const char *text = sqlite3_value_text(argv[i]);
+      if (mem_offset + text_len + 2 > mem_size) {
+        int delta = (text_len + 2 + 65535) / 65536;
+        WasmEdge_Result res = WasmEdge_MemoryInstanceGrowPage(mem_ctx, delta);
+        if (!WasmEdge_ResultOK(res)) {
+          sqlite3_result_error(context, WasmEdge_ResultGetMessage(res), -1);
+        }
+      }
+      u8 *data = WasmEdge_MemoryInstanceGetPointer(mem_ctx, mem_offset, text_len);
+      data[0] = type;
+      memcpy(data + 1, text, text_len);
+      data[1 + text_len] = '\0';
+      params[i] = WasmEdge_ValueGenI32(mem_offset);
+      mem_offset += text_len + 2;
+      break;
+    }
+    case SQLITE_BLOB: {
+      int blob_len = sqlite3_value_bytes(argv[i]);
+      const void *blob = sqlite3_value_blob(argv[i]);
+      if (mem_offset + 4 + blob_len > mem_size) {
+        int delta = (blob_len + 1 + 65535) / 65536;
+        WasmEdge_Result res = WasmEdge_MemoryInstanceGrowPage(mem_ctx, delta);
+        if (!WasmEdge_ResultOK(res)) {
+          sqlite3_result_error(context, WasmEdge_ResultGetMessage(res), -1);
+        }
+      }
+      u8 *data = WasmEdge_MemoryInstanceGetPointer(mem_ctx, mem_offset, blob_len);
+      data[0] = type;
+      sqlite3Put4byte(data + 1, blob_len);
+      memcpy(data + 1 + 4, blob, blob_len);
+      params[i] = WasmEdge_ValueGenI32(mem_offset);
+      mem_offset += blob_len + 1;
+      break;
+    }
+    case SQLITE_NULL:
+      if (mem_offset + 1 > mem_size) {
+        WasmEdge_Result res = WasmEdge_MemoryInstanceGrowPage(mem_ctx, 1);
+        if (!WasmEdge_ResultOK(res)) {
+          sqlite3_result_error(context, WasmEdge_ResultGetMessage(res), -1);
+        }
+      }
+      u8 *data = WasmEdge_MemoryInstanceGetPointer(mem_ctx, mem_offset, 1);
+      data[0] = type;
+      params[i] = WasmEdge_ValueGenI32(mem_offset);
+      mem_offset++;
+      break;
+    }
+  }
+
+  WasmEdge_String wasmedge_func_name = WasmEdge_StringCreateByCString(func_name);
+  res = WasmEdge_VMExecute(ctx, wasmedge_func_name, params, argc, results, 1);
+  if (!WasmEdge_ResultOK(res)) {
+      sqlite3_result_error(context, "Execution failed", -1);
+      WasmEdge_StringDelete(wasmedge_func_name);
+      return;
+  }
+  WasmEdge_StringDelete(wasmedge_func_name);
+
+  switch (results[0].Type) {
+  case WasmEdge_ValType_I64:
+    sqlite3_result_int(context, WasmEdge_ValueGetI64(results[0]));
+    break;
+  case WasmEdge_ValType_F64:
+    sqlite3_result_double(context, WasmEdge_ValueGetF64(results[0]));
+    break;
+  case WasmEdge_ValType_I32: {
+    int type_offset = WasmEdge_ValueGetI32(results[0]);
+    char *type_ptr = WasmEdge_MemoryInstanceGetPointer(mem_ctx, type_offset, 1);
+    if (!type_ptr) {
+      sqlite3_result_error(context, "Unexpected end of Wasm memory when trying to fetch results", -1);
+      return;
+    }
+    char type = *type_ptr;
+    switch (type) {
+    case SQLITE_TEXT: {
+      const char *wasm_result = type_ptr + 1;
+      size_t wasm_result_len = strlen(wasm_result);
+      char *result = sqlite3Malloc(wasm_result_len + 1);
+      if (!result) {
+        sqlite3_result_error_nomem(context);
+        return;
+      }
+      memcpy(result, wasm_result, wasm_result_len);
+      sqlite3_result_text(context, result, wasm_result_len, sqlite3_free);
+      break;
+    }
+    case SQLITE_BLOB: {
+      void *wasm_result = type_ptr + 1;
+      int wasm_result_len = sqlite3Get4byte(wasm_result);
+      wasm_result += 4;
+      if (wasm_result_len > 2*1024*1024) {
+        sqlite3_result_error_nomem(context);
+        return;
+      }
+      char *result = sqlite3Malloc(wasm_result_len);
+      if (!result) {
+        sqlite3_result_error_nomem(context);
+        return;
+      }
+      memcpy(result, wasm_result, wasm_result_len);
+      sqlite3_result_blob(context, result, wasm_result_len, sqlite3_free);
+      break;
+    }
+    case SQLITE_NULL:
+      sqlite3_result_null(context);
+      break;
+    default:
+      sqlite3_result_error(context, "Wasm function returned malformed result type", -1);
+    }
+  }
+  break;
+  default:
+    fprintf(stderr, "res %d\n", results[0].Type);
+    sqlite3_result_error(context, "Wasm function returned an unsupported result type", -1);
+  }
+}
+
+void libsql_free_wasm_module(void *ctx) {
+  WasmEdge_VMDelete(*(WasmEdge_VMContext **)ctx);
+}
+
+libsql_wasm_engine_t *libsql_wasm_engine_new() {
+  return NULL;
+}
+
+libsql_wasm_module_t *libsql_compile_wasm_module(libsql_wasm_engine_t* engine, const char *pSrcBody, int nBody,
+    void *(*alloc_err_buf)(unsigned long long), char **err_msg_buf) {
+  WasmEdge_VMContext *ctx = WasmEdge_VMCreate(NULL, NULL);
+  WasmEdge_Result res = WasmEdge_VMLoadWasmFromBuffer(ctx, (const uint8_t *)pSrcBody, nBody);
+  if (!WasmEdge_ResultOK(res)) {
+    *err_msg_buf = sqlite3_mprintf("Compilation failed: %s", WasmEdge_ResultGetMessage(res));
+    return NULL;
+  }
+  res = WasmEdge_VMValidate(ctx);
+  if (!WasmEdge_ResultOK(res)) {
+    *err_msg_buf = sqlite3_mprintf("Validation failed: %s", WasmEdge_ResultGetMessage(res));
+    return NULL;
+  }
+  return (libsql_wasm_module_t*)ctx;
+}
+
+void libsql_wasm_free_msg_buf(char *err_msg_buf) {
+  sqlite3_free(err_msg_buf);
+}
+
+#endif

--- a/ext/udf/wasmedge_bindings.c
+++ b/ext/udf/wasmedge_bindings.c
@@ -165,6 +165,14 @@ libsql_wasm_engine_t *libsql_wasm_engine_new() {
 
 libsql_wasm_module_t *libsql_compile_wasm_module(libsql_wasm_engine_t* engine, const char *pSrcBody, int nBody,
     void *(*alloc_err_buf)(unsigned long long), char **err_msg_buf) {
+
+  if (nBody < 4 || memcmp(pSrcBody, "\0asm", 4) != 0) {
+    *err_msg_buf = sqlite3_mprintf("Magic header was not detected. "
+        "WasmEdge backend supports compiled binary Wasm format only. "
+        "If you passed WAT source, please transform it with wat2wasm or any similar tool");
+    return NULL;
+  }
+
   WasmEdge_VMContext *ctx = WasmEdge_VMCreate(NULL, NULL);
   WasmEdge_Result res = WasmEdge_VMLoadWasmFromBuffer(ctx, (const uint8_t *)pSrcBody, nBody);
   if (!WasmEdge_ResultOK(res)) {

--- a/src/rust/wasmtime-bindings/src/lib.rs
+++ b/src/rust/wasmtime-bindings/src/lib.rs
@@ -211,8 +211,8 @@ pub fn libsql_run_wasm(
                 };
                 let text_len = unsafe { ((*api).libsql_value_bytes)(arg) } as usize;
 
-                if mem_offset + text_len + 1 > mem_size {
-                    let delta = (text_len + 1 + 65535) / 65536;
+                if mem_offset + text_len + 2 > mem_size {
+                    let delta = (text_len + 2 + 65535) / 65536;
                     match memory.grow(&mut store, delta as u64) {
                         Ok(_) => (),
                         Err(e) => {

--- a/test/rust_suite/Cargo.toml
+++ b/test/rust_suite/Cargo.toml
@@ -10,6 +10,8 @@ rusqlite = { version = "0.28", features = ["buildtime_bindgen"] }
 libsqlite3-sys = "0.25"
 itertools = "0.10"
 tempfile = "3.3"
+wabt = "0.10.0"
+hex = "0.4.3"
 
 [features]
 default = []

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -49,7 +49,7 @@ mod tests {
             .unwrap();
 
         let also_steven = person_iter.next().unwrap().unwrap();
-        println!("Read {:#?}", also_steven);
+        println!("Read {also_steven:#?}");
         assert!(also_steven == steven);
         assert!(person_iter.next().is_none())
     }

--- a/test/rust_suite/src/user_defined_functions.rs
+++ b/test/rust_suite/src/user_defined_functions.rs
@@ -20,7 +20,7 @@ fn test_create_drop_fib() {
     }
 
     conn.execute(
-        &format!("CREATE FUNCTION fib LANGUAGE wasm AS '{}'", fib_src()),
+        &format!("CREATE FUNCTION fib LANGUAGE wasm AS x'{}'", fib_src()),
         (),
     )
     .unwrap();
@@ -57,7 +57,7 @@ fn test_contains() {
 
     conn.execute(
         &format!(
-            "CREATE FUNCTION contains LANGUAGE wasm AS '{}'",
+            "CREATE FUNCTION contains LANGUAGE wasm AS x'{}'",
             contains_src()
         ),
         (),
@@ -105,7 +105,7 @@ fn test_concat3() {
 
     conn.execute(
         &format!(
-            "CREATE FUNCTION concat3 LANGUAGE wasm AS '{}'",
+            "CREATE FUNCTION concat3 LANGUAGE wasm AS x'{}'",
             concat3_src()
         ),
         (),
@@ -153,7 +153,7 @@ fn test_reverse_blob() {
 
     conn.execute(
         &format!(
-            "CREATE FUNCTION reverse_blob LANGUAGE wasm AS '{}'",
+            "CREATE FUNCTION reverse_blob LANGUAGE wasm AS x'{}'",
             reverse_blob_src()
         ),
         (),
@@ -181,7 +181,7 @@ fn test_get_null() {
 
     conn.execute(
         &format!(
-            "CREATE FUNCTION get_null LANGUAGE wasm AS '{}'",
+            "CREATE FUNCTION get_null LANGUAGE wasm AS x'{}'",
             get_null_src()
         ),
         (),

--- a/test/rust_suite/src/user_defined_functions_src.rs
+++ b/test/rust_suite/src/user_defined_functions_src.rs
@@ -3157,22 +3157,22 @@ static GET_NULL_SRC: &str = r#"
   (export "get_null" (func $get_null)))
 "#;
 
-pub fn fib_src() -> &'static str {
-    FIB_SRC
+pub fn fib_src() -> String {
+    hex::encode(wabt::wat2wasm(FIB_SRC).unwrap())
 }
 
-pub fn contains_src() -> &'static str {
-    CONTAINS_SRC
+pub fn contains_src() -> String {
+    hex::encode(wabt::wat2wasm(CONTAINS_SRC).unwrap())
 }
 
-pub fn concat3_src() -> &'static str {
-    CONCAT3_SRC
+pub fn concat3_src() -> String {
+    hex::encode(wabt::wat2wasm(CONCAT3_SRC).unwrap())
 }
 
-pub fn reverse_blob_src() -> &'static str {
-    REVERSE_BLOB_SRC
+pub fn reverse_blob_src() -> String {
+    hex::encode(wabt::wat2wasm(REVERSE_BLOB_SRC).unwrap())
 }
 
-pub fn get_null_src() -> &'static str {
-    GET_NULL_SRC
+pub fn get_null_src() -> String {
+    hex::encode(wabt::wat2wasm(GET_NULL_SRC).unwrap())
 }

--- a/test/rust_suite/src/virtual_wal.rs
+++ b/test/rust_suite/src/virtual_wal.rs
@@ -221,7 +221,7 @@ mod tests {
         0
     }
     extern "C" fn limit(wal: *mut Wal, limit: i64) {
-        println!("Limit: {}", limit);
+        println!("Limit: {limit}");
         unsafe { (*wal).max_wal_size = limit }
     }
     extern "C" fn begin_read(_wal: *mut Wal, changed: *mut i32) -> i32 {
@@ -234,7 +234,7 @@ mod tests {
         0
     }
     extern "C" fn find_frame(wal: *mut Wal, pgno: i32, frame: *mut i32) -> i32 {
-        println!("\tLooking for page {}", pgno);
+        println!("\tLooking for page {pgno}");
         let methods = unsafe { &*(*wal).wal_methods };
         if methods.pages.contains_key(&pgno) {
             println!("\t\tpage found");
@@ -245,7 +245,7 @@ mod tests {
         0
     }
     extern "C" fn read_frame(wal: *mut Wal, frame: u32, n_out: i32, p_out: *mut u8) -> i32 {
-        println!("\tReading frame {}", frame);
+        println!("\tReading frame {frame}");
         let n_out = n_out as usize;
         let methods = unsafe { &*(*wal).wal_methods };
         let data = methods.pages.get(&(frame as i32)).unwrap();
@@ -353,7 +353,7 @@ mod tests {
     fn test_vwal_register() {
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
         let path = format!("{}\0", tmpfile.path().to_str().unwrap());
-        println!("Temporary database created at {}", path);
+        println!("Temporary database created at {path}");
 
         let conn = unsafe {
             let mut pdb: *mut rusqlite::ffi::sqlite3 = std::ptr::null_mut();
@@ -409,7 +409,7 @@ mod tests {
         let journal_mode: String = conn
             .query_row("PRAGMA journal_mode", [], |r| r.get(0))
             .unwrap();
-        println!("Journaling mode: {}", journal_mode);
+        println!("Journaling mode: {journal_mode}");
         assert_eq!(journal_mode, "wal".to_string());
         conn.execute("CREATE TABLE t(id)", ()).unwrap();
         conn.execute("INSERT INTO t(id) VALUES (42)", ()).unwrap();

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -451,6 +451,7 @@ set flist {
    sqlite3session.c
    fts5.c
    stmt.c
+   wasmedge_bindings.c
 } 
 if {$enable_recover} {
   lappend flist sqlite3recover.c dbdata.c


### PR DESCRIPTION
Depends on having libwasmtime.so installed,
which can be done e.g. manually by compiling from source
and invoking `make install` later.

WasmEdge may not come with wat2wasm capabilities - in which case
only binary input will be accepted. That's still a very good
deal, because WasmEdge's slim runtime weighs just ~1.5MiB.

Tests need to be amended to fall back to using binary blobs
if wat2wasm is not available.

Fixes #94 