### PR TITLE
build: bring back enable-wasm-runtime-dynamic

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -383,6 +383,10 @@ WBSRC = \
 ifeq ($(OPT_WASM_RUNTIME),y)
 OPT_WASM_RUNTIME_LIBRARY_TARGET=liblibsql_wasm
 OPT_WASM_RUNTIME_INSTALL_TARGET=liblibsql_wasm_install
+TLIBS += $(WBTOP)/target/release/liblibsql_wasm.a
+else ifeq ($(OPT_WASM_RUNTIME),d)
+OPT_WASM_RUNTIME_LIBRARY_TARGET=liblibsql_wasm
+OPT_WASM_RUNTIME_INSTALL_TARGET=liblibsql_wasm_install
 TLIBS += -L$(WBTOP)/target/release -llibsql_wasm
 else
 OPT_WASM_RUNTIME_LIBRARY_TARGET=
@@ -677,7 +681,7 @@ libtclsqlite3.la:	tclsqlite.lo libsqlite3.la
 		-version-info "8:6:8" \
 		-avoid-version
 
-sqlite3$(TEXE):	shell.c sqlite3.c
+sqlite3$(TEXE):	shell.c sqlite3.c $(OPT_WASM_RUNTIME_LIBRARY_TARGET)
 	$(LTLINK) $(READLINE_FLAGS) $(SHELL_OPT) -o $@ \
 		shell.c sqlite3.c \
 		$(LIBREADLINE) $(TLIBS) -rpath "$(libdir)"

--- a/configure
+++ b/configure
@@ -936,6 +936,7 @@ enable_load_extension
 enable_math
 enable_json
 enable_wasm_runtime
+enable_wasm_runtime_dynamic
 enable_all
 enable_memsys5
 enable_memsys3
@@ -1600,6 +1601,8 @@ Optional Features:
   --disable-math          Disable math functions
   --disable-json          Disable JSON functions
   --enable-wasm-runtime   Enable WebAssembly runtime integration
+  --enable-wasm-runtime-dynamic
+                          Link with WebAssembly runtime dynamically
   --enable-all            Enable FTS4, FTS5, Geopoly, RTree, Sessions
   --enable-memsys5        Enable MEMSYS5
   --enable-memsys3        Enable MEMSYS3
@@ -4462,13 +4465,13 @@ then :
 else $as_nop
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
-  (eval echo "\"\$as_me:4465: $ac_compile\"" >&5)
+  (eval echo "\"\$as_me:4468: $ac_compile\"" >&5)
   (eval "$ac_compile" 2>conftest.err)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4468: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
+  (eval echo "\"\$as_me:4471: $NM \\\"conftest.$ac_objext\\\"\"" >&5)
   (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
   cat conftest.err >&5
-  (eval echo "\"\$as_me:4471: output\"" >&5)
+  (eval echo "\"\$as_me:4474: output\"" >&5)
   cat conftest.out >&5
   if $GREP 'External.*some_variable' conftest.out > /dev/null; then
     lt_cv_nm_interface="MS dumpbin"
@@ -5719,7 +5722,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 5722 "configure"' > conftest.$ac_ext
+  echo '#line 5725 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7062,11 +7065,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7065: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7068: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7069: \$? = $ac_status" >&5
+   echo "$as_me:7072: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -7402,11 +7405,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7405: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7408: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7409: \$? = $ac_status" >&5
+   echo "$as_me:7412: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -7509,11 +7512,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7512: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7515: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:7516: \$? = $ac_status" >&5
+   echo "$as_me:7519: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -7565,11 +7568,11 @@ else $as_nop
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7568: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7571: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:7572: \$? = $ac_status" >&5
+   echo "$as_me:7575: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -9953,7 +9956,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 9956 "configure"
+#line 9959 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10050,7 +10053,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 10053 "configure"
+#line 10056 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -12061,7 +12064,13 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to support WebAssembly integration" >&5
 printf %s "checking whether to support WebAssembly integration... " >&6; }
-if test "$enable_wasm_runtime" = "yes"; then
+# Check whether --enable-wasm_runtime_dynamic was given.
+if test ${enable_wasm_runtime_dynamic+y}
+then :
+  enableval=$enable_wasm_runtime_dynamic;
+fi
+
+if test "$enable_wasm_runtime" = "yes" -o "$enable_wasm_runtime_dynamic" = "yes"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
   OPT_FEATURE_FLAGS="${OPT_FEATURE_FLAGS} -DLIBSQL_ENABLE_WASM_RUNTIME"
@@ -12107,7 +12116,17 @@ printf "%s\n" "no" >&6; }
 fi
 
 
-  OPT_WASM_RUNTIME=y
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to link WebAssembly runtime dynamically" >&5
+printf %s "checking whether to link WebAssembly runtime dynamically... " >&6; }
+  if test "$enable_wasm_runtime_dynamic" = "yes"; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+    OPT_WASM_RUNTIME=d
+  else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+    OPT_WASM_RUNTIME=y # static linking
+  fi
 else
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -633,11 +633,20 @@ fi
 AC_ARG_ENABLE(wasm_runtime, 
 AS_HELP_STRING([--enable-wasm-runtime],[Enable WebAssembly runtime integration]))
 AC_MSG_CHECKING([whether to support WebAssembly integration])
-if test "$enable_wasm_runtime" = "yes"; then
+AC_ARG_ENABLE(wasm_runtime_dynamic, 
+AS_HELP_STRING([--enable-wasm-runtime-dynamic],[Link with WebAssembly runtime dynamically]))
+if test "$enable_wasm_runtime" = "yes" -o "$enable_wasm_runtime_dynamic" = "yes"; then
   AC_MSG_RESULT([yes])
   OPT_FEATURE_FLAGS="${OPT_FEATURE_FLAGS} -DLIBSQL_ENABLE_WASM_RUNTIME"
   AC_CHECK_PROG(CARGO_BIN, cargo)
-  OPT_WASM_RUNTIME=y
+  AC_MSG_CHECKING([whether to link WebAssembly runtime dynamically])
+  if test "$enable_wasm_runtime_dynamic" = "yes"; then
+    AC_MSG_RESULT([yes])
+    OPT_WASM_RUNTIME=d
+  else
+    AC_MSG_RESULT([no])
+    OPT_WASM_RUNTIME=y # static linking
+  fi
 else
   AC_MSG_RESULT([no])
   OPT_WASM_RUNTIME=n


### PR DESCRIPTION
The switch between static and dynamic linking is especially important in the context of "make libsql" or "make sqlite3". Without default static linking, running the shell fails out of the box, which results in poor DX.