### PR TITLE
libsql-shell: initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ test/rust_suite/target
 test/rust_suite/Cargo.lock
 testfixture
 libsql
+src/rust/libsql-shell/target/

--- a/src/rust/libsql-shell/Cargo.toml
+++ b/src/rust/libsql-shell/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "libsql-shell"
+version = "0.1.1"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+keywords = ["libsql", "sqlite", "cli", "database", "shell"]
+description = "Command-line interface for libSQL - an open-source and open-contribution fork of SQLite"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.69"
+base64 = "0.21.0"
+clap = { version = "4.1.8", features = [ "derive", "env"] }
+home = "0.5.4"
+rusqlite = "0.28.0"
+rustyline = "11.0.0"
+tabled = "0.10.0"
+tracing-subscriber = "0.3.16"
+
+[[bin]]
+name = "libsql"
+path = "src/main.rs"

--- a/src/rust/libsql-shell/README.md
+++ b/src/rust/libsql-shell/README.md
@@ -1,0 +1,33 @@
+# libSQL shell
+
+This project contains [libSQL](https://libsql.org)'s new shell,
+implemented in Rust on top of a few industry standard crates: `rusqlite`, `rustyline`, `clap`, `tracing`, etc.
+
+The long-term goal of this project is to:
+ - Match all features of the original libSQL shell (inherited from SQLite and implemented in C),
+ - Add new features on top, for instance:
+   - importing and exporting additional formats (Parquet and friends);
+   - accessing network resources.
+ - Make contributions to libSQL as easy as possible.
+
+## Status
+This project is still in early development phase, so expect missing items!
+
+## Example
+```
+$ ./libsql
+libSQL version 0.2.0
+Connected to a transient in-memory database.
+
+libsql> create table test(id, v);
+libsql> insert into test values(42, zeroblob(12));
+libsql> insert into test values(3.14, 'hello');
+libsql> insert into test values(null, null);
+libsql> select id, v, length(v), hex(v) from test;
+ id   | v                  | length(v) | hex(v)                   
+------+--------------------+-----------+--------------------------
+ 42   | 0xAAAAAAAAAAAAAAAA | 12        | 000000000000000000000000 
+ 3.14 | hello              | 5         | 68656C6C6F               
+ null | null               | null      |                          
+libsql> 
+```

--- a/src/rust/libsql-shell/src/main.rs
+++ b/src/rust/libsql-shell/src/main.rs
@@ -1,0 +1,119 @@
+use anyhow::Result;
+use base64::{engine::general_purpose, Engine as _};
+use clap::Parser;
+use rusqlite::{types::ValueRef, Connection, Statement};
+use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
+
+#[derive(Debug, Parser)]
+#[command(name = "libsql")]
+#[command(about = "libSQL client", long_about = None)]
+struct Args {
+    #[clap()]
+    db_path: Option<String>,
+}
+
+// Presents libSQL values in human-readable form
+fn format_value(v: ValueRef) -> String {
+    match v {
+        ValueRef::Null => "null".to_owned(),
+        ValueRef::Integer(i) => format!("{i}"),
+        ValueRef::Real(r) => format!("{r}"),
+        ValueRef::Text(s) => std::str::from_utf8(s).unwrap().to_owned(),
+        ValueRef::Blob(b) => format!("0x{}", general_purpose::STANDARD_NO_PAD.encode(b)),
+    }
+}
+
+// Executes a libSQL statement
+// TODO: introduce paging for presenting large results, get rid of Vec
+fn execute(stmt: &mut Statement) -> Result<Vec<Vec<String>>> {
+    let column_count = stmt.column_count();
+
+    let rows = stmt.query_map((), |row| {
+        let row = (0..column_count)
+            .map(|idx| format_value(row.get_ref(idx).unwrap()))
+            .collect::<Vec<String>>();
+        Ok(row)
+    })?;
+    Ok(rows.map(|r| r.unwrap()).collect())
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    let mut rl = DefaultEditor::new()?;
+
+    let mut history = home::home_dir().unwrap_or_default();
+    history.push(".libsql_history");
+    rl.load_history(history.as_path()).ok();
+
+    println!("libSQL version 0.2.0");
+    let connection = match args.db_path.as_deref() {
+        None | Some("") | Some(":memory:") => {
+            println!("Connected to a transient in-memory database.");
+            Connection::open_in_memory()?
+        }
+        Some(path) => Connection::open(path)?,
+    };
+
+    let mut leftovers = String::new();
+    loop {
+        let prompt = if leftovers.is_empty() {
+            "libsql> "
+        } else {
+            "...   > "
+        };
+        let readline = rl.readline(prompt);
+        match readline {
+            Ok(line) => {
+                let line = leftovers + line.trim_end();
+                if line.ends_with(';') {
+                    leftovers = String::new();
+                } else {
+                    leftovers = line + " ";
+                    continue;
+                };
+                rl.add_history_entry(&line).ok();
+                let mut stmt = match connection.prepare(&line) {
+                    Ok(stmt) => stmt,
+                    Err(e) => {
+                        println!("Error: {e}");
+                        continue;
+                    }
+                };
+                let rows = match execute(&mut stmt) {
+                    Ok(rows) => rows,
+                    Err(e) => {
+                        println!("Error: {e}");
+                        continue;
+                    }
+                };
+                if rows.is_empty() {
+                    continue;
+                }
+                let mut builder = tabled::builder::Builder::new();
+                builder.set_columns(stmt.column_names());
+                for row in rows {
+                    builder.add_record(row);
+                }
+                let mut table = builder.build();
+                table.with(tabled::Style::psql());
+                println!("{table}")
+            }
+            Err(ReadlineError::Interrupted) => {
+                leftovers = String::new();
+                continue;
+            }
+            Err(ReadlineError::Eof) => {
+                break;
+            }
+            Err(err) => {
+                println!("Error: {:?}", err);
+                break;
+            }
+        }
+    }
+    rl.save_history(history.as_path()).ok();
+    Ok(())
+}


### PR DESCRIPTION
This commit adds an initial version of the new libSQL shell. It still misses lots of features, but it's already functional.

Example:
```
$ ./libsql
libSQL version 0.2.0
Connected to a transient in-memory database.

libsql> create table test(id, v); 
libsql> insert into test values(42, zeroblob(12));
libsql> insert into test values(3.14, 'hello');
libsql> insert into test values(null, null);
libsql> select id, v, length(v), hex(v) from test;
 id   | v                  | length(v) | hex(v)    
------+--------------------+-----------+--------------------------
 42   | 0xAAAAAAAAAAAAAAAA | 12        | 000000000000000000000000 
 3.14 | hello              | 5         | 68656C6C6F    
 null | null               | null      |    
libsql>
```