### PR TITLE
metrics: add LIBSQL_STMTSTATUS_ROWS_READ and _WRITTEN

### DIFF
--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -3079,6 +3079,11 @@ static int display_stats(
     raw_printf(pArg->out, "Number of times run:                 %d\n", iCur);
     iCur = sqlite3_stmt_status(pArg->pStmt, SQLITE_STMTSTATUS_MEMUSED, bReset);
     raw_printf(pArg->out, "Memory used by prepared stmt:        %d\n", iCur);
+
+    iCur = sqlite3_stmt_status(pArg->pStmt, LIBSQL_STMTSTATUS_ROWS_READ, bReset);
+    raw_printf(pArg->out, "Rows read:                           %d\n", iCur);
+    iCur = sqlite3_stmt_status(pArg->pStmt, LIBSQL_STMTSTATUS_ROWS_WRITTEN, bReset);
+    raw_printf(pArg->out, "Rows written:                        %d\n", iCur);
   }
 
 #ifdef __linux__

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -8708,6 +8708,14 @@ int sqlite3_stmt_status(sqlite3_stmt*, int op,int resetFlg);
 ** is ignored when the opcode is SQLITE_STMTSTATUS_MEMUSED.
 ** </dd>
 ** </dl>
+**
+** [[LIBSQL_STMTSTATUS_ROWS_READ]]
+** [[LIBSQL_STMTSTATUS_ROWS_WRITTEN]] 
+** <dt>LIBSQL_STMTSTATUS_ROWS_READ<br>
+** LIBSQL_STMTSTATUS_ROWS_WRITTEN</dt>
+** <dd>^LIBSQL_STMTSTATUS_ROWS_READ is the number of rows read when executing
+** this statement. LIBSQL_STMTSTATUS_ROWS_WRITTEN value is the number of
+** rows written.
 */
 #define SQLITE_STMTSTATUS_FULLSCAN_STEP     1
 #define SQLITE_STMTSTATUS_SORT              2
@@ -8718,6 +8726,10 @@ int sqlite3_stmt_status(sqlite3_stmt*, int op,int resetFlg);
 #define SQLITE_STMTSTATUS_FILTER_MISS       7
 #define SQLITE_STMTSTATUS_FILTER_HIT        8
 #define SQLITE_STMTSTATUS_MEMUSED           99
+
+#define LIBSQL_STMTSTATUS_BASE              1024
+#define LIBSQL_STMTSTATUS_ROWS_READ         LIBSQL_STMTSTATUS_BASE + 1
+#define LIBSQL_STMTSTATUS_ROWS_WRITTEN      LIBSQL_STMTSTATUS_BASE + 2
 
 /*
 ** CAPI3REF: Custom Page Cache Object

--- a/src/vdbeInt.h
+++ b/src/vdbeInt.h
@@ -478,6 +478,7 @@ struct Vdbe {
   yDbMask btreeMask;      /* Bitmask of db->aDb[] entries referenced */
   yDbMask lockMask;       /* Subset of btreeMask that requires a lock */
   u32 aCounter[9];        /* Counters used by sqlite3_stmt_status() */
+  u32 aLibsqlCounter[3];  /* libSQL extension: Counters used by sqlite3_stmt_status()*/
   char *zSql;             /* Text of the SQL statement that generated this */
 #ifdef SQLITE_ENABLE_NORMALIZE
   char *zNormSql;         /* Normalization of the associated SQL statement */

--- a/src/vdbeapi.c
+++ b/src/vdbeapi.c
@@ -1870,6 +1870,9 @@ int sqlite3_stmt_status(sqlite3_stmt *pStmt, int op, int resetFlag){
     db->pnBytesFreed = 0;
     db->lookaside.pEnd = db->lookaside.pTrueEnd;
     sqlite3_mutex_leave(db->mutex);
+  }else if( op>=LIBSQL_STMTSTATUS_BASE ){
+    v = pVdbe->aLibsqlCounter[op - LIBSQL_STMTSTATUS_BASE];
+    if( resetFlag ) pVdbe->aLibsqlCounter[op - LIBSQL_STMTSTATUS_BASE] = 0;
   }else{
     v = pVdbe->aCounter[op];
     if( resetFlag ) pVdbe->aCounter[op] = 0;

--- a/test/rust_suite/Cargo.lock
+++ b/test/rust_suite/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,9 +65,18 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
- "glob",
+ "glob 0.3.0",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -104,6 +119,12 @@ dependencies = [
 
 [[package]]
 name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+
+[[package]]
+name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -127,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +170,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "lazy_static"
@@ -174,12 +207,14 @@ dependencies = [
 
 [[package]]
 name = "libsql_rust_suite"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "hex",
  "itertools",
  "libsqlite3-sys",
  "rusqlite",
  "tempfile",
+ "wabt",
 ]
 
 [[package]]
@@ -305,6 +340,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +384,17 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "tempfile"
@@ -347,6 +427,29 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wabt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bef93d5e6c81a293bccf107cf43aa47239382f455ba14869d36695d8963b9c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wabt-sys",
+]
+
+[[package]]
+name = "wabt-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4e043159f63e16986e713e9b5e1c06043df4848565bf672e27c523864c7791"
+dependencies = [
+ "cc",
+ "cmake",
+ "glob 0.2.11",
+]
 
 [[package]]
 name = "wasi"

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -53,4 +53,77 @@ mod tests {
         assert!(also_steven == steven);
         assert!(person_iter.next().is_none())
     }
+
+    fn get_read_written(conn: &Connection, stmt: &str) -> (i32, i32) {
+        const STMT_ROWS_READ: i32 = 1024 + 1;
+        const STMT_ROWS_WRITTEN: i32 = 1024 + 2;
+        let mut stmt = conn.prepare(stmt).unwrap();
+        let mut rows = stmt.query(()).unwrap();
+        while let Ok(Some(_)) = rows.next() {}
+        drop(rows);
+        let mut rows_read = rusqlite::StatementStatus::FullscanStep;
+        let mut rows_written = rusqlite::StatementStatus::FullscanStep;
+        // FIXME: there's no API for ROWS_READ/WRITTEN yet, so let's rewrite to checking ROWS_* instead
+        unsafe {
+            std::ptr::copy(
+                &[STMT_ROWS_READ] as *const i32,
+                &mut rows_read as *mut _ as *mut i32,
+                4,
+            )
+        }
+        unsafe {
+            std::ptr::copy(
+                &[STMT_ROWS_WRITTEN] as *const i32,
+                &mut rows_written as *mut _ as *mut i32,
+                4,
+            )
+        }
+        (stmt.get_status(rows_read), stmt.get_status(rows_written))
+    }
+
+    #[test]
+    fn test_rows_read_written() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE test(id)", ()).unwrap();
+        for _ in 0..16 {
+            conn.execute("INSERT INTO test values (1)", ()).unwrap();
+        }
+        assert_eq!(get_read_written(&conn, "SELECT * FROM test"), (16, 0));
+        assert_eq!(
+            get_read_written(&conn, "SELECT count(*) FROM test"),
+            (16, 0)
+        );
+        assert_eq!(
+            get_read_written(&conn, "SELECT min(id), max(id) FROM test where 1 = 1"),
+            (16, 0)
+        );
+        assert_eq!(
+            get_read_written(&conn, "SELECT * FROM test LIMIT 3"),
+            (3, 0)
+        );
+        assert_eq!(
+            get_read_written(&conn, "SELECT * FROM test LIMIT 3"),
+            (3, 0)
+        );
+        assert_eq!(
+            get_read_written(&conn, "SELECT * FROM test WHERE id = 2"),
+            (16, 0)
+        );
+        assert_eq!(
+            get_read_written(&conn, "SELECT * FROM test WHERE rowid = 1"),
+            (1, 0)
+        );
+        assert_eq!(
+            get_read_written(&conn, "INSERT INTO test VALUES (1)"),
+            (0, 1)
+        );
+        assert_eq!(
+            get_read_written(&conn, "INSERT INTO test(id) SELECT id FROM test"),
+            (34, 17)
+        );
+        assert_eq!(
+            get_read_written(&conn, "INSERT INTO test VALUES (1), (2), (3), (4)"),
+            (0, 4)
+        );
+    }
 }


### PR DESCRIPTION
The stats are gathered in order to estimate how many rows were accessed when executing a statement.
While similar metrics already exist - like fullscan steps and VM steps - they are not always 1:1 with the number of rows touched in the process. The built-in count() aggregate is one of the exceptions. It technically does not read rows, but instead iterates over B-Tree pages, but it's asymptotically the same.
For writes, sqlite3_changes() function already exists and informs how many rows were affected by the most recent insert/update/delete, but it does not count triggers, replaces, etc into account.

Example output:
```
$ ./libsql /tmp/x < /tmp/test_paylod | grep Rows
Rows read:                           4602
Rows written:                        0
Rows read:                           4602
Rows written:                        0
Rows read:                           4602
Rows written:                        0
Rows read:                           4602
Rows written:                        0
Rows read:                           4602
Rows written:                        0
Rows read:                           0
Rows written:                        3
Rows read:                           9210
Rows written:                        4605
```