### PR TITLE
parse: unconditionally support CREATE FUNCTION in the grammar

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -5810,4 +5810,26 @@ void libsql_drop_function(
 
   sqlite3VdbeAddOp4(sqlite3GetVdbe(pParse), OP_DropWasmFunc, noErr, 0, 0, zName, P4_DYNAMIC);
 }
+
+#else
+
+void libsql_create_function(
+  Parse *pParse,     /* The parsing context */
+  Token *pName,      /* Function name */
+  Token *pLang,      /* Language of the function */
+  Token *pBody,      /* Body of the function */
+  int isBlob,        /* If the input token is blob */
+  int noErr          /* Suppress error messages if FUNCTION already exists */
+) {
+  sqlite3ErrorMsg(pParse, "Support for user-defined functions is not compiled-in. Try ./configure --enable-wasm-runtime");
+}
+
+void libsql_drop_function(
+  Parse *pParse,     /* The parsing context */
+  Token *pName,      /* Function name */
+  int noErr          /* Suppress error messages if FUNCTION does not exist */
+) {
+  sqlite3ErrorMsg(pParse, "Support for user-defined functions is not compiled-in. Try ./configure --enable-wasm-runtime");
+}
+
 #endif

--- a/src/parse.y
+++ b/src/parse.y
@@ -492,7 +492,6 @@ cmd ::= DROP VIEW ifexists(E) fullname(X). {
 }
 %endif  SQLITE_OMIT_VIEW
 
-%ifdef LIBSQL_ENABLE_WASM_RUNTIME
 ///////////////////// The CREATE FUNCTION statement /////////////////////////
 //
 
@@ -510,7 +509,6 @@ cmd ::= createkw FUNCTION ifnotexists(E) nm(N) LANGUAGE nm(L) AS BLOB(B). {
 cmd ::= DROP FUNCTION ifexists(E) nm(N). {
   libsql_drop_function(pParse, &N, E);
 }
-%endif
 
 //////////////////////// The SELECT statement /////////////////////////////////
 //


### PR DESCRIPTION
In order to keep the grammar definition identical between Wasm and non-Wasm builds, let's support CREATE FUNCTION syntax uncondtionally - it will simply inform the users that user-defined functions support wasn't compiled in, if it wasn't.