### PR TITLE
ext/embeddings: initial patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .libs/
 .target_source
 .vscode/
-Makefile
+/Makefile
 autom4te.cache/
 config.h
 config.log
@@ -56,6 +56,7 @@ srcck1
 test-out.txt
 test/rust_suite/target
 test/rust_suite/Cargo.lock
+ext/embeddings/Cargo.lock
 testfixture
 libsql
 src/rust/libsql-shell/target/

--- a/ext/embeddings/Cargo.toml
+++ b/ext/embeddings/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "libsql-embeddings"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rust-bert = "0.20.0"
+tch = "0.10.0"
+
+[lib]
+crate-type = ["rlib", "staticlib", "dylib"]

--- a/ext/embeddings/Makefile
+++ b/ext/embeddings/Makefile
@@ -1,0 +1,11 @@
+all: release
+
+release:	src/lib.rs embeddings.c
+	$(CC) -I../.. -Wall -c embeddings.c && ar -crs libembeddings.a embeddings.o && cargo build --release && cp target/release/liblibsql_embeddings.so embeddings.so
+
+test:
+	cargo test
+
+.PHONY:	clean
+clean:
+	rm embeddings.o libembeddings.a embeddings.so || :

--- a/ext/embeddings/build.rs
+++ b/ext/embeddings/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-search=.");
+    println!("cargo:rustc-link-lib=static=embeddings");
+}

--- a/ext/embeddings/embeddings.c
+++ b/ext/embeddings/embeddings.c
@@ -1,0 +1,44 @@
+#include "sqlite3ext.h"
+SQLITE_EXTENSION_INIT1
+LIBSQL_EXTENSION_INIT1
+#include <assert.h>
+#include <string.h>
+
+int sentence_embeddings(const char *sentence, int sentence_len, char *out_embedding);
+
+static void sentence_embeddings_func(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+) {
+  char result[384 * sizeof(float)];
+
+  if(sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    return;
+  }
+  const unsigned char *sentence = (const unsigned char*)sqlite3_value_text(argv[0]);
+  int sentence_len = sqlite3_value_bytes(argv[0]);
+
+  sentence_embeddings((const char*)sentence, sentence_len, result);
+
+  sqlite3_result_blob(context, (char*)result, sizeof(result), SQLITE_TRANSIENT);
+}
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+int embeddings_c_init(
+  sqlite3 *db, 
+  char **pzErrMsg, 
+  const sqlite3_api_routines *pApi,
+  const libsql_api_routines *pLibsqlApi
+){
+  int rc = SQLITE_OK;
+  SQLITE_EXTENSION_INIT2(pApi);
+  LIBSQL_EXTENSION_INIT2(pLibsqlApi);
+  (void)pzErrMsg;  /* Unused parameter */
+  rc = sqlite3_create_function(db, "sentence_embeddings", 1,
+                   SQLITE_UTF8|SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC,
+                   0, sentence_embeddings_func, 0, 0);
+  return rc;
+}

--- a/ext/embeddings/src/lib.rs
+++ b/ext/embeddings/src/lib.rs
@@ -1,0 +1,62 @@
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use std::ffi::{c_char, c_int, c_void, CStr};
+
+fn sentence_embeddings_rs(sentence: &str) -> Result<Vec<f32>, rust_bert::RustBertError> {
+    use rust_bert::pipelines::sentence_embeddings::{
+        SentenceEmbeddingsBuilder, SentenceEmbeddingsModelType,
+    };
+    let model = SentenceEmbeddingsBuilder::remote(SentenceEmbeddingsModelType::AllMiniLmL12V2)
+        .create_model()
+        .unwrap();
+
+    let sentences = [sentence.to_string()];
+
+    let mut embeddings = model.encode(&sentences)?;
+    Ok(embeddings.pop().unwrap())
+}
+
+extern "C" {
+    fn embeddings_c_init(a: *mut c_void, b: *mut c_void, c: *mut c_void, d: *mut c_void);
+}
+
+#[no_mangle]
+pub fn sqlite3_embeddings_init(a: *mut c_void, b: *mut c_void, c: *mut c_void, d: *mut c_void) {
+    unsafe { embeddings_c_init(a, b, c, d) }
+}
+
+#[no_mangle]
+pub extern "C" fn sentence_embeddings(
+    sentence: *const c_char,
+    sentence_len: c_int,
+    out: *mut c_char,
+) -> c_int {
+    let sentence = unsafe { CStr::from_ptr(sentence).to_str().unwrap() };
+    let embeddings = match sentence_embeddings_rs(sentence) {
+        Ok(embeddings) => embeddings,
+        Err(_) => {
+            return 1;
+        }
+    };
+    let embeddings = embeddings.as_ptr();
+    let embeddings = embeddings as *const c_char;
+    unsafe {
+        std::ptr::copy(
+            embeddings,
+            out,
+            sentence_len as usize * std::mem::size_of::<f32>(),
+        );
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn embeddings1() {
+        for sentence in ["apple", "banana", "orange"].iter() {
+            let embedding = super::sentence_embeddings_rs(sentence);
+            println!("Embedding for {sentence}: {embedding:?}");
+        }
+    }
+}


### PR DESCRIPTION
This patch introduces the ext/embeddings extension which can provide [sentence embeddings](https://en.wikipedia.org/wiki/Sentence_embedding) in the form of a set of built-in functions.

The initial implementation only accepts a single sentence (i.e. text) at a time and is hardcoded to use the remote all-MiniLM-L12-v2 model (courtesy of huggingface.co), but it is planned to be more generic, especially for being able to use local files only.

The implementation is based on [rust-bert](https://crates.io/crates/rust-bert)