### PR TITLE
revert signature change of sqlite3_snapshot_cmp

### DIFF
--- a/src/wal.c
+++ b/src/wal.c
@@ -4038,7 +4038,7 @@ static void sqlite3WalSnapshotOpen(
 ** Return a +ve value if snapshot p1 is newer than p2. A -ve value if
 ** p1 is older than p2 and zero if p1 and p2 are the same snapshot.
 */
-static int sqlite3_snapshot_cmp(sqlite3_snapshot *p1, sqlite3_snapshot *p2){
+int sqlite3_snapshot_cmp(sqlite3_snapshot *p1, sqlite3_snapshot *p2){
   WalIndexHdr *pHdr1 = (WalIndexHdr*)p1;
   WalIndexHdr *pHdr2 = (WalIndexHdr*)p2;
 


### PR DESCRIPTION
This PR fixes #144. Commit 519a33b changed the function signature of `sqlite3_snapshot_cmp` which causes a compiler error when compiled with `-DSQLITE_ENABLE_SNAPSHOT`

Reverting this function signature back to `int sqlite3_snapshot_cmp` clears up the compiler error.

I've rebuilt this locally and done a `make test` and all the tests pass.
```
% grep SNAPSHOT Makefile
OPT_FEATURE_FLAGS =  -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_GEOPOLY -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK -DSQLITE_ENABLE_SNAPSHOT
% make test
# .. skipped lots of output
Time: snapshot.test 19 ms
Time: snapshot2.test 11 ms
Time: snapshot3.test 5 ms
Time: snapshot4.test 5 ms
Time: snapshot_up.test 6 ms
# ... skipped more output
SQLite 2023-04-19 20:29:26 48505ad950bc0902d58210be066d4672e6085eb27c525ba2bc663fde7e93alt1
0 errors out of 263631 tests on cft.local Darwin 64-bit little-endian
All memory allocations freed - no leaks
Maximum memory usage: 9330592 bytes
Current memory usage: 0 bytes
```
