### PR TITLE
add user context pointer to sqlite3 struct

### DIFF
--- a/doc/libsql_extensions.md
+++ b/doc/libsql_extensions.md
@@ -214,6 +214,8 @@ to manage it:
 ```
 , and they are quite self-descriptive. They also work similarly to their `sqlite3_vfs*` counterparts, which they were modeled after.
 
+It is important to note that wal_methods in themselves should be stateless. There are registered globally, and accessible from every connection. When state needs to be accessed from the WAL methods, state can be passed as the 7th argument to `libsql_open_v2`. This state will then become accessible in the `pMethodData` field of the `libsql_wal` struct passed to the WAL methods.
+
 ### Using WAL methods
 
 Custom WAL methods need to be declared when opening a new database connection.

--- a/src/btree.c
+++ b/src/btree.c
@@ -2646,7 +2646,9 @@ int sqlite3BtreeOpen(
       rc = SQLITE_NOMEM_BKPT;
       goto btree_open_out;
     }
-    rc = sqlite3PagerOpen(pVfs, pWal, db->pMethodsData,&pBt->pPager, zFilename,
+    void* pWalMethodsData = NULL;
+    if (db) pWalMethodsData= db->pWalMethodsData;
+    rc = sqlite3PagerOpen(pVfs, pWal, pWalMethodsData, &pBt->pPager, zFilename,
                           sizeof(MemPage), flags, vfsFlags, pageReinit);
     if( rc==SQLITE_OK ){
       sqlite3PagerSetMmapLimit(pBt->pPager, db->szMmap);

--- a/src/btree.c
+++ b/src/btree.c
@@ -2646,7 +2646,7 @@ int sqlite3BtreeOpen(
       rc = SQLITE_NOMEM_BKPT;
       goto btree_open_out;
     }
-    rc = sqlite3PagerOpen(pVfs, pWal, &pBt->pPager, zFilename,
+    rc = sqlite3PagerOpen(pVfs, pWal, db->pMethodsData,&pBt->pPager, zFilename,
                           sizeof(MemPage), flags, vfsFlags, pageReinit);
     if( rc==SQLITE_OK ){
       sqlite3PagerSetMmapLimit(pBt->pPager, db->szMmap);

--- a/src/pager.c
+++ b/src/pager.c
@@ -700,7 +700,7 @@ struct Pager {
   libsql_wal *pWal;                       /* Write-ahead log used by "journal_mode=wal" */
   libsql_wal_methods *pWalMethods; /* Virtual methods for interacting with WAL */
   char *zWal;                      /* File name for write-ahead log */
-  void *pMethodsData;
+  void *pWalMethodsData;           /* WA: methods context data */
 #endif
 };
 
@@ -4686,7 +4686,7 @@ int sqlite3PagerFlush(Pager *pPager){
 int sqlite3PagerOpen(
   sqlite3_vfs *pVfs,       /* The virtual file system to use */
   libsql_wal_methods *pWalMethods, /* WAL methods to use */
-  void *pMethodsData,
+  void *pWalMethodsData,   /* WAL methods context data */
   Pager **ppPager,         /* OUT: Return the Pager structure here */
   const char *zFilename,   /* Name of the database file to open */
   int nExtra,              /* Extra bytes append to each in-memory page */
@@ -4851,7 +4851,7 @@ int sqlite3PagerOpen(
   pPager->fd = (sqlite3_file*)pPtr;       pPtr += ROUND8(pVfs->szOsFile);
   pPager->sjfd = (sqlite3_file*)pPtr;     pPtr += journalFileSize;
   pPager->jfd =  (sqlite3_file*)pPtr;     pPtr += journalFileSize;
-  pPager->pMethodsData = pMethodsData;
+  pPager->pWalMethodsData = pWalMethodsData;
   assert( EIGHT_BYTE_ALIGNMENT(pPager->jfd) );
   memcpy(pPtr, &pPager, sizeof(pPager));  pPtr += sizeof(pPager);
 
@@ -7579,8 +7579,8 @@ static int pagerOpenWal(Pager *pPager){
         pPager->journalSizeLimit, pPager->pWalMethods, &pPager->pWal
     );
 
-    if (rc == SQLITE_OK) {
-        pPager->pWal->pMethodsData = pPager->pMethodsData;
+    if (rc == SQLITE_OK && pPager->pWal) {
+        pPager->pWal->pMethodsData = pPager->pWalMethodsData;
     }
   }
   pagerFixMaplimit(pPager);

--- a/src/pager.h
+++ b/src/pager.h
@@ -119,6 +119,7 @@ typedef struct libsql_wal_methods libsql_wal_methods;
 int sqlite3PagerOpen(
   sqlite3_vfs*,
   libsql_wal_methods*,
+  void* pMethodsData,
   Pager **ppPager,
   const char*,
   int,

--- a/src/pager.h
+++ b/src/pager.h
@@ -119,7 +119,7 @@ typedef struct libsql_wal_methods libsql_wal_methods;
 int sqlite3PagerOpen(
   sqlite3_vfs*,
   libsql_wal_methods*,
-  void* pMethodsData,
+  void* pWalMethodsData,
   Pager **ppPager,
   const char*,
   int,

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -3766,8 +3766,16 @@ int libsql_open(
   sqlite3 **ppDb,         /* OUT: SQLite db handle */
   int flags,              /* Flags */
   const char *zVfs,       /* Name of VFS module to use, NULL for default */
+  const char *zWal        /* Name of WAL module to use */
+);
+
+int libsql_open_v2(
+  const char *filename,   /* Database filename (UTF-8) */
+  sqlite3 **ppDb,         /* OUT: SQLite db handle */
+  int flags,              /* Flags */
+  const char *zVfs,       /* Name of VFS module to use, NULL for default */
   const char *zWal,       /* Name of WAL module to use */
-  void *pMethodData       /* optional data for the wal methods */
+  void* pWalMethodsData   /* User data, passed to the libsql_wal struct*/
 );
 
 LIBSQL_API int libsql_try_initialize_wasm_func_table(sqlite3 *db);

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -3766,7 +3766,8 @@ int libsql_open(
   sqlite3 **ppDb,         /* OUT: SQLite db handle */
   int flags,              /* Flags */
   const char *zVfs,       /* Name of VFS module to use, NULL for default */
-  const char *zWal        /* Name of WAL module to use */
+  const char *zWal,       /* Name of WAL module to use */
+  void *pMethodData       /* optional data for the wal methods */
 );
 
 LIBSQL_API int libsql_try_initialize_wasm_func_table(sqlite3 *db);

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -1745,6 +1745,7 @@ struct sqlite3 {
   libsql_wasm_ctx wasm;        /* WebAssembly runtime context */
 #endif
   libsql_wal_methods* pWalMethods; /* Custom WAL methods */
+  void* pMethodsData; /* optional data for WAL methods */
 };
 
 /*

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -1745,7 +1745,7 @@ struct sqlite3 {
   libsql_wasm_ctx wasm;        /* WebAssembly runtime context */
 #endif
   libsql_wal_methods* pWalMethods; /* Custom WAL methods */
-  void* pMethodsData; /* optional data for WAL methods */
+  void* pWalMethodsData;           /* optional data for WAL methods */
 };
 
 /*

--- a/src/test2.c
+++ b/src/test2.c
@@ -65,7 +65,7 @@ static int SQLITE_TCLAPI pager_open(
 #ifndef SQLITE_OMIT_WAL
   pWalMethods = libsql_wal_methods_find(NULL);
 #endif
-  rc = sqlite3PagerOpen(sqlite3_vfs_find(0), pWalMethods, NULL,&pPager, argv[1], 0, 0,
+  rc = sqlite3PagerOpen(sqlite3_vfs_find(0), pWalMethods, NULL, &pPager, argv[1], 0, 0,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB,
       pager_test_reiniter);
   if( rc!=SQLITE_OK ){

--- a/src/test2.c
+++ b/src/test2.c
@@ -65,7 +65,7 @@ static int SQLITE_TCLAPI pager_open(
 #ifndef SQLITE_OMIT_WAL
   pWalMethods = libsql_wal_methods_find(NULL);
 #endif
-  rc = sqlite3PagerOpen(sqlite3_vfs_find(0), pWalMethods, &pPager, argv[1], 0, 0,
+  rc = sqlite3PagerOpen(sqlite3_vfs_find(0), pWalMethods, NULL,&pPager, argv[1], 0, 0,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB,
       pager_test_reiniter);
   if( rc!=SQLITE_OK ){

--- a/test/rust_suite/src/virtual_wal.rs
+++ b/test/rust_suite/src/virtual_wal.rs
@@ -36,6 +36,7 @@ mod tests {
         p_snapshot: *const c_void,
         p_db: *const c_void,
         wal_methods: *mut libsql_wal_methods,
+        p_methods_data: *mut c_void,
     }
 
     #[repr(C)]
@@ -205,6 +206,7 @@ mod tests {
             p_snapshot: std::ptr::null(),
             p_db: std::ptr::null(),
             wal_methods: methods,
+            p_methods_data: std::ptr::null_mut(),
         });
         unsafe { *wal = &*new_wal }
         Box::leak(new_wal);


### PR DESCRIPTION
Adds the ability to pass user context to the WAL methods. The user_context is passed as the 7th argument to the `libsql_open_v2` function and is passed down to the first instantiation of the WAL struct, which happens in a call to `pagerOpenWal`. If the WAL struct is successfully allocated, then the pointer to the user data is installed in the WAL struct, where it becomes available to the wal_methods