### PR TITLE
vdbe: count virtual table reads in ROWS_READ metrics

### DIFF
--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -8303,6 +8303,7 @@ case OP_VNext: {   /* jump, ncycle */
   rc = pModule->xNext(pCur->uc.pVCur);
   sqlite3VtabImportErrmsg(p, pVtab);
   if( rc ) goto abort_due_to_error;
+  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE]++;
   res = pModule->xEof(pCur->uc.pVCur);
   VdbeBranchTaken(!res,2);
   if( !res ){


### PR DESCRIPTION
They were not taken into account in the original patch, because virtual tables use a separate opcode for reads.