### PR TITLE
fix: access pRet only when sqlite3_free is not called

### DIFF
--- a/src/wal.c
+++ b/src/wal.c
@@ -1520,8 +1520,8 @@ static int sqlite3WalOpen(
     }
     *ppWal = pRet;
     WALTRACE(("WAL%d: opened\n", pRet));
+    pRet->pMethods = pMethods;
   }
-  pRet->pMethods = pMethods;
   return rc;
 }
 


### PR DESCRIPTION
Hi all,
I found an UAF bug from `src/wal.c:1524` with AddressSanitizer.

Environment:
    - Ubuntu 22.04
    - Clang 14.0.0

At `sqlite3WalOpen` function, `pRet` can be accessed after sqlite3_free called on it if `rc!=SQLITE_OK`.


```
static int sqlite3WalOpen(
  sqlite3_vfs *pVfs,              /* vfs module to open wal and wal-index */
  sqlite3_file *pDbFd,            /* The open database file */
  const char *zWalName,           /* Name of the WAL file */
  int bNoShm,                     /* True to run in heap-memory mode */
  i64 mxWalSize,                  /* Truncate WAL to this size on reset */
  libsql_wal_methods* pMethods,   /* Virtual methods for interacting with WAL */
  Wal **ppWal                     /* OUT: Allocated Wal handle */
){
  int rc;                         /* Return Code */
  Wal *pRet;                      /* Object to allocate and return */
  int flags;                      /* Flags passed to OsOpen() */

  ...

  /* Allocate an instance of struct Wal to return. */
  *ppWal = 0;
  pRet = (Wal*)sqlite3MallocZero(sizeof(Wal) + pVfs->szOsFile); // allocated at here
  if( !pRet ){
    return SQLITE_NOMEM_BKPT;
  }
 ...
  if( rc==SQLITE_OK && flags&SQLITE_OPEN_READONLY ){
    pRet->readOnly = WAL_RDONLY;
  }

  if( rc!=SQLITE_OK ){
    walIndexClose(pRet, 0);
    sqlite3OsClose(pRet->pWalFd);
    sqlite3_free(pRet);  // <- freed at here
  }else{
    int iDC = sqlite3OsDeviceCharacteristics(pDbFd);
    if( iDC & SQLITE_IOCAP_SEQUENTIAL ){ pRet->syncHeader = 0; }
    if( iDC & SQLITE_IOCAP_POWERSAFE_OVERWRITE ){
      pRet->padToSectorBoundary = 0;
    }
    *ppWal = pRet;
    WALTRACE(("WAL%d: opened\n", pRet));
  }
  pRet->pMethods = pMethods; // <- UAF at here
  return rc;
}

```

I found this from `wal2.test` of `tcltest`, and patched by simply moving the access code inside the else statement.

Thank you.

![image](https://github.com/libsql/libsql/assets/17183234/61691187-9a02-41b2-af00-5ad706de2c20)


