### PR TITLE
release pipeline for linux x86_64, aarch64, darwin arm64

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,202 @@
+name: Create and publish libsql binaries
+
+on:
+  push:
+    #branches: ['main']
+    tags:
+      - v*.*.*
+
+jobs:
+        
+  start-runner:
+    name: Start self-hosted EC2 runner
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ami-0e811aad4d084edb9
+          ec2-instance-type: t4g.2xlarge
+          subnet-id: subnet-05010d45bfb86f5fb
+          security-group-id: sg-01bd3845621443669
+
+  build_binaries:
+    needs: start-runner
+    strategy:
+      matrix:
+        os: 
+          - linux-x86_64
+          - macos-arm64
+          - ${{ needs.start-runner.outputs.label }}
+        variant: 
+          - 'wasm-udf-dynamic'
+          - 'wasm-udf-wasmedge'
+          - 'wasm-udf'
+          - ''
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      #Debug output + special rustup config for the ubuntu/aarch64 runner
+      - name: show step matrix details
+        run: |
+          env
+          set -ex
+          uname -a
+          echo "os: ${{ matrix.os }}"
+          echo "variant: ${{ matrix.variant }}"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > ./rustup.sh
+          chmod a+x rustup.sh
+          ./rustup.sh -y
+          if [[ "${{ matrix.os}}" == "${{ needs.start-runner.outputs.label }}" ]]; then 
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+            echo "PATH=$PATH:/root/.cargo/bin" >> $GITHUB_PATH
+          fi
+          pwd
+          whoami
+
+      #for windows only, use correct newlines
+      - name: Set git to use LF
+        if: matrix.os == 'windows-latest'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+  
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: setup msys2 for windows
+        if: matrix.os == 'windows-latest'
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3 gcc make base-devel mingw-w64-x86_64-rust zip
+          msystem: mingw64
+          path-type: inherit
+
+      - name: run configure
+        run: |
+          set -ex
+          mkdir build
+          pushd build
+          case "${{ matrix.variant }}" in
+            "wasm-udf-dynamic")
+              ../configure --enable-wasm-runtime-dynamic
+              ;;
+            "wasm-udf-wasmedge")
+              # Fix for https://github.com/WasmEdge/WasmEdge/issues/2622
+              if [[ "${{ matrix.os}}" == "${{ needs.start-runner.outputs.label }}" ]]; then 
+                curl -SLO https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh
+                chmod a+x install.sh
+                ./install.sh --dist manylinux2014 -D
+              else
+                curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
+              fi
+              source ~/.wasmedge/env
+              ../configure --enable-wasm-runtime-wasmedge
+              ;;
+            "wasm-udf")
+              ../configure --enable-wasm-runtime
+              ;;
+            *)
+              ../configure
+              ;;
+          esac
+          popd
+
+      - name: build
+        run: |
+          set -ex
+          if [[ "${{ matrix.variant }}" == "wasm-udf-wasmedge" ]]; then 
+            source ~/.wasmedge/env || echo "no wasmedge installed"
+          fi
+          pushd build
+          make 
+          make sqlite3.c
+          ls -la
+          popd
+
+      - name: package artefacts (for named variants)
+        if: matrix.variant != ''
+        run: |
+          set -ex
+          uname -a
+          OS=$(uname -s)
+          ARCH=$(uname -m)
+          cd build
+          tar cvzf libsql-${{ github.ref_name }}-${{ matrix.variant }}-$OS-$ARCH.tar.gz .libs libsql sqlite3
+          tar cvzf libsql-amalgamation-${{ github.ref_name }}-${{ matrix.variant }}-$OS-$ARCH.tar.gz sqlite3.c sqlite3.h
+          ls -la
+          cd ..
+
+      - name: package artefacts
+        if: matrix.variant == ''
+        run: |
+          set -ex
+          uname -a
+          OS=$(uname -s)
+          ARCH=$(uname -m)
+          cd build
+          tar cvzf libsql-${{ github.ref_name }}-$OS-$ARCH.tar.gz .libs libsql sqlite3
+          tar cvzf libsql-amalgamation-${{ github.ref_name }}-$OS-$ARCH.tar.gz sqlite3.c sqlite3.h
+          ls -la
+          cd ..
+
+      - name: Push artefacts into release draft
+        uses: softprops/action-gh-release@v1
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          fail_on_unmatched_files: false
+          files: |
+            build/libsql-${{ github.ref_name }}-${{ matrix.variant }}-Linux-x86_64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-${{ matrix.variant }}-Linux-x86_64.tar.gz
+            build/libsql-${{ github.ref_name }}-Linux-x86_64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-Linux-x86_64.tar.gz
+            build/libsql-${{ github.ref_name }}-${{ matrix.variant }}-Linux-aarch64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-${{ matrix.variant }}-Linux-aarch64.tar.gz
+            build/libsql-${{ github.ref_name }}-Linux-aarch64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-Linux-aarch64.tar.gz
+            build/libsql-${{ github.ref_name }}-${{ matrix.variant }}-Darwin-x86_64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-${{ matrix.variant }}-Darwin-x86_64.tar.gz
+            build/libsql-${{ github.ref_name }}-Darwin-x86_64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-Darwin-x86_64.tar.gz
+            build/libsql-${{ github.ref_name }}-${{ matrix.variant }}-Darwin-arm64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-${{ matrix.variant }}-Darwin-arm64.tar.gz
+            build/libsql-${{ github.ref_name }}-Darwin-arm64.tar.gz
+            build/libsql-amalgamation-${{ github.ref_name }}-Darwin-arm64.tar.gz
+
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner # required to get output from the start-runner job
+      - build_binaries # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,41 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See the generated artefacts at https://github.com/libsql/libsql-dev/releases/tag/v0.1.39

The new release flow will be as follows: 
- On a push to main, a new tag will be created as a release draft, the tag is autogenerated based on the current largest tag in the repo, e.g. with 0.2.1 right now, the new one will be 0.2.2. This will be a draft release, and every PR pushed to main will be added to the draft. 
- Once we are ready to release, edit the draft release (change the tag if the automatic one isn't right) and hit the "publish" button. 
- This will create a release with the given tag and autogenerated note, and trigger a workflow that builds the artefacts.
- The workflow creates an aarch64 AWS VM, and also uses our self hosted linux and mac machines. 
- As each build completes it will add the generated artefacts to the release. 