### PR TITLE
rust: add Rust bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ libsql
 /src/rust/libsql-shell/target/
 /src/rust/wasmtime-bindings/Cargo.lock
 /src/rust/wasmtime-bindings/Cargo.lock
+/bindings.rs
+/src/rust/libsql-sys/target
+/src/rust/libsql-sys/Cargo.lock

--- a/Makefile.in
+++ b/Makefile.in
@@ -376,6 +376,9 @@ SRC += \
 #
 WBTOP = $(TOP)/src/rust/wasmtime-bindings
 
+# Path to Rust bindings
+BINDTOP = $(TOP)/src/rust/libsql-sys
+
 # Source code of the wasm bindings
 #
 WBSRC = \
@@ -684,7 +687,7 @@ SQLITE3_SHELL_TARGET   = $(SQLITE3_SHELL_TARGET_@HAVE_WASI_SDK@)
 # are what get build when you type just "make" with no arguments.
 #
 all:	sqlite3.h libsqlite3.la liblibsql.la $(SQLITE3_SHELL_TARGET) \
-  $(HAVE_TCL:1=libtclsqlite3.la)
+  $(HAVE_TCL:1=libtclsqlite3.la) rust_bindings
 
 Makefile: $(TOP)/Makefile.in
 	./config.status
@@ -821,6 +824,9 @@ mptest:	mptester$(TEXE)
 
 liblibsql_wasm:	$(WBSRC)
 	cd $(WBTOP) && cargo build --release --lib && mkdir -p $(TOP)/.libs && cp target/release/liblibsql_wasm.* $(TOP)/.libs/
+
+rust_bindings: sqlite3.h
+	cd $(BINDTOP) && LIBSQL_SRC_DIR=$(TOP) cargo build --release --lib
 
 sqlite3.c:	.target_source $(TOP)/tool/mksqlite3c.tcl
 	$(TCLSH_CMD) $(TOP)/tool/mksqlite3c.tcl $(AMALGAMATION_LINE_MACROS)
@@ -1592,6 +1598,7 @@ clean:
 	rm -f threadtest5
 	rm -f libsql*.tar.gz
 	rm -rf $(WBTOP)/target
+	rm -f bindings.rs
 
 distclean:	clean
 	rm -f sqlite_cfg.h config.log config.status libtool Makefile sqlite3.pc libsql.pc sqlite3session.h \

--- a/src/rust/libsql-sys/Cargo.toml
+++ b/src/rust/libsql-sys/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "libsql-sys"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Native bindings to libSQL"
+repository = "https://github.com/libsql/libsql"
+build = "build.rs"
+keywords = ["libsql", "sqlite", "ffi", "bindings", "database"]
+categories = ["external-ffi-bindings"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[build-dependencies]
+bindgen = "0.66.1"

--- a/src/rust/libsql-sys/build.rs
+++ b/src/rust/libsql-sys/build.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let src_dir = PathBuf::from(
+        env::var("LIBSQL_SRC_DIR").expect("LIBSQL_SRC_DIR must be defined at compile time"),
+    );
+    let bindings = bindgen::Builder::default()
+        .header(
+            src_dir
+                .join("sqlite3.h")
+                .as_path()
+                .to_str()
+                .expect("Unable to parse path"),
+        )
+        .generate()
+        .expect("Unable to generate bindings");
+
+    bindings
+        .write_to_file(src_dir.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/src/rust/libsql-sys/src/lib.rs
+++ b/src/rust/libsql-sys/src/lib.rs
@@ -1,0 +1,7 @@
+#[allow(clippy::all)]
+#[allow(non_snake_case)]
+#[allow(non_camel_case_types)]
+mod bindings {
+    include!(concat!(env!("LIBSQL_SRC_DIR"), "/bindings.rs"));
+}
+pub use bindings::*;


### PR DESCRIPTION
The official bindings are generated with
`make rust_bindings`, and are based on the current sqlite3.h header file.