### PR TITLE
crates/core: update to newest libsql-sys

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.28"
-libsql-sys = "0.1.1"
+libsql-sys = { path = "../libsql-sys" }
 thiserror = "1.0.40"
 libsql_replication = { path = "../replication" }
 

--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -4,7 +4,7 @@ use std::ffi::c_int;
 
 /// A connection to a libSQL database.
 pub struct Connection {
-    pub(crate) raw: *mut libsql_sys::sqlite3,
+    pub(crate) raw: *mut libsql_sys::ffi::sqlite3,
 }
 
 unsafe impl Send for Connection {} // TODO: is this safe?
@@ -15,16 +15,16 @@ impl Connection {
         let mut raw = std::ptr::null_mut();
         let url = db.url.clone();
         let err = unsafe {
-            libsql_sys::sqlite3_open_v2(
+            libsql_sys::ffi::sqlite3_open_v2(
                 url.as_ptr() as *const i8,
                 &mut raw,
-                libsql_sys::SQLITE_OPEN_READWRITE as c_int
-                    | libsql_sys::SQLITE_OPEN_CREATE as c_int,
+                libsql_sys::ffi::SQLITE_OPEN_READWRITE as c_int
+                    | libsql_sys::ffi::SQLITE_OPEN_CREATE as c_int,
                 std::ptr::null(),
             )
         };
         match err as u32 {
-            libsql_sys::SQLITE_OK => {}
+            libsql_sys::ffi::SQLITE_OK => {}
             _ => {
                 return Err(Error::ConnectionFailed(url));
             }
@@ -35,7 +35,7 @@ impl Connection {
     /// Disconnect from the database.
     pub fn disconnect(&self) {
         unsafe {
-            libsql_sys::sqlite3_close_v2(self.raw);
+            libsql_sys::ffi::sqlite3_close_v2(self.raw);
         }
     }
 

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -13,8 +13,8 @@ impl Database {
         let url = url.into();
         if url.starts_with("libsql:") {
             let url = url.replace("libsql:", "http:");
-            let filename = format!("file:tmp.db");
-            let replicator = Some(Replicator::new(url.clone()));
+            let filename = "file:tmp.db".to_string();
+            let replicator = Some(Replicator::new(url));
             Database::new(filename, replicator)
         } else {
             Database::new(url, None)

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -11,9 +11,6 @@ pub enum Error {
 pub fn sqlite_error_message(raw: *mut libsql_sys::ffi::sqlite3) -> String {
     let error = unsafe { libsql_sys::ffi::sqlite3_errmsg(raw) };
     let error = unsafe { std::ffi::CStr::from_ptr(error) };
-    let error = match error.to_str() {
-        Ok(error) => error,
-        Err(_) => "N/A",
-    };
+    let error = error.to_str().unwrap_or("N/A");
     format!("{}", error)
 }

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -8,8 +8,8 @@ pub enum Error {
     UnknownColumnType(i32, i32),
 }
 
-pub fn sqlite_error_message(raw: *mut libsql_sys::sqlite3) -> String {
-    let error = unsafe { libsql_sys::sqlite3_errmsg(raw) };
+pub fn sqlite_error_message(raw: *mut libsql_sys::ffi::sqlite3) -> String {
+    let error = unsafe { libsql_sys::ffi::sqlite3_errmsg(raw) };
     let error = unsafe { std::ffi::CStr::from_ptr(error) };
     let error = match error.to_str() {
         Ok(error) => error,

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -21,11 +21,11 @@ impl Rows {
             libsql_sys::ffi::SQLITE_OK => None,
             libsql_sys::ffi::SQLITE_DONE => None,
             _ => {
-                return Some(Rows {
+                Some(Rows {
                     raw,
                     raw_stmt,
                     err: RefCell::new(Some(err)),
-                });
+                })
             }
         }
     }

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -4,8 +4,8 @@ use crate::{errors, Error, Params, Result, Statement};
 
 /// Query result rows.
 pub struct Rows {
-    pub(crate) raw: *mut libsql_sys::sqlite3,
-    pub(crate) raw_stmt: *mut libsql_sys::sqlite3_stmt,
+    pub(crate) raw: *mut libsql_sys::ffi::sqlite3,
+    pub(crate) raw_stmt: *mut libsql_sys::ffi::sqlite3_stmt,
     err: RefCell<Option<i32>>,
 }
 
@@ -13,13 +13,13 @@ unsafe impl Send for Rows {} // TODO: is this safe?
 
 impl Rows {
     pub fn execute(
-        raw: *mut libsql_sys::sqlite3,
-        raw_stmt: *mut libsql_sys::sqlite3_stmt,
+        raw: *mut libsql_sys::ffi::sqlite3,
+        raw_stmt: *mut libsql_sys::ffi::sqlite3_stmt,
     ) -> Option<Rows> {
-        let err = unsafe { libsql_sys::sqlite3_step(raw_stmt) };
+        let err = unsafe { libsql_sys::ffi::sqlite3_step(raw_stmt) };
         match err as u32 {
-            libsql_sys::SQLITE_OK => None,
-            libsql_sys::SQLITE_DONE => None,
+            libsql_sys::ffi::SQLITE_OK => None,
+            libsql_sys::ffi::SQLITE_DONE => None,
             _ => {
                 return Some(Rows {
                     raw,
@@ -33,12 +33,12 @@ impl Rows {
     pub fn next(&self) -> Result<Option<Row>> {
         let err = match self.err.take() {
             Some(err) => err,
-            None => unsafe { libsql_sys::sqlite3_step(self.raw_stmt) },
+            None => unsafe { libsql_sys::ffi::sqlite3_step(self.raw_stmt) },
         };
         match err as u32 {
-            libsql_sys::SQLITE_OK => Ok(None),
-            libsql_sys::SQLITE_DONE => Ok(None),
-            libsql_sys::SQLITE_ROW => Ok(Some(Row { raw: self.raw_stmt })),
+            libsql_sys::ffi::SQLITE_OK => Ok(None),
+            libsql_sys::ffi::SQLITE_DONE => Ok(None),
+            libsql_sys::ffi::SQLITE_ROW => Ok(Some(Row { raw: self.raw_stmt })),
             _ => Err(Error::QueryFailed(format!(
                 "Failed to fetch next row: {}",
                 errors::sqlite_error_message(self.raw)
@@ -47,12 +47,12 @@ impl Rows {
     }
 
     pub fn column_count(&self) -> i32 {
-        unsafe { libsql_sys::sqlite3_column_count(self.raw_stmt) }
+        unsafe { libsql_sys::ffi::sqlite3_column_count(self.raw_stmt) }
     }
 }
 
 pub struct RowsFuture {
-    pub(crate) raw: *mut libsql_sys::sqlite3,
+    pub(crate) raw: *mut libsql_sys::ffi::sqlite3,
     pub(crate) sql: String,
     pub(crate) params: Params,
 }
@@ -77,7 +77,7 @@ impl futures::Future for RowsFuture {
 }
 
 pub struct Row {
-    pub(crate) raw: *mut libsql_sys::sqlite3_stmt,
+    pub(crate) raw: *mut libsql_sys::ffi::sqlite3_stmt,
 }
 
 impl Row {
@@ -85,18 +85,18 @@ impl Row {
     where
         T: FromValue,
     {
-        let val = unsafe { libsql_sys::sqlite3_column_value(self.raw, idx) };
+        let val = unsafe { libsql_sys::ffi::sqlite3_column_value(self.raw, idx) };
         T::from_sql(val)
     }
 
     pub fn column_type(&self, idx: i32) -> Result<ValueType> {
-        let val = unsafe { libsql_sys::sqlite3_column_type(self.raw, idx) };
+        let val = unsafe { libsql_sys::ffi::sqlite3_column_type(self.raw, idx) };
         match val as u32 {
-            libsql_sys::SQLITE_INTEGER => Ok(ValueType::Integer),
-            libsql_sys::SQLITE_FLOAT => Ok(ValueType::Float),
-            libsql_sys::SQLITE_BLOB => Ok(ValueType::Blob),
-            libsql_sys::SQLITE_TEXT => Ok(ValueType::Text),
-            libsql_sys::SQLITE_NULL => Ok(ValueType::Null),
+            libsql_sys::ffi::SQLITE_INTEGER => Ok(ValueType::Integer),
+            libsql_sys::ffi::SQLITE_FLOAT => Ok(ValueType::Float),
+            libsql_sys::ffi::SQLITE_BLOB => Ok(ValueType::Blob),
+            libsql_sys::ffi::SQLITE_TEXT => Ok(ValueType::Text),
+            libsql_sys::ffi::SQLITE_NULL => Ok(ValueType::Null),
             _ => Err(Error::UnknownColumnType(idx, val)),
         }
     }
@@ -111,21 +111,21 @@ pub enum ValueType {
 }
 
 pub trait FromValue {
-    fn from_sql(val: *mut libsql_sys::sqlite3_value) -> Result<Self>
+    fn from_sql(val: *mut libsql_sys::ffi::sqlite3_value) -> Result<Self>
     where
         Self: Sized;
 }
 
 impl FromValue for i32 {
-    fn from_sql(val: *mut libsql_sys::sqlite3_value) -> Result<Self> {
-        let ret = unsafe { libsql_sys::sqlite3_value_int(val) };
+    fn from_sql(val: *mut libsql_sys::ffi::sqlite3_value) -> Result<Self> {
+        let ret = unsafe { libsql_sys::ffi::sqlite3_value_int(val) };
         Ok(ret)
     }
 }
 
 impl FromValue for &str {
-    fn from_sql(val: *mut libsql_sys::sqlite3_value) -> Result<Self> {
-        let ret = unsafe { libsql_sys::sqlite3_value_text(val) };
+    fn from_sql(val: *mut libsql_sys::ffi::sqlite3_value) -> Result<Self> {
+        let ret = unsafe { libsql_sys::ffi::sqlite3_value_text(val) };
         let ret = unsafe { std::ffi::CStr::from_ptr(ret as *const i8) };
         let ret = ret.to_str().unwrap();
         Ok(ret)

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -71,7 +71,7 @@ impl Statement {
 
     pub fn execute(&self, params: &Params) -> Option<Rows> {
         unsafe { libsql_sys::ffi::sqlite3_reset(self.raw_stmt) };
-        self.bind(&params);
+        self.bind(params);
         Rows::execute(self.raw, self.raw_stmt)
     }
 }

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -2,15 +2,15 @@ use crate::{errors, Error, Params, Result, Rows, Value};
 
 /// A prepared statement.
 pub struct Statement {
-    raw: *mut libsql_sys::sqlite3,
-    raw_stmt: *mut libsql_sys::sqlite3_stmt,
+    raw: *mut libsql_sys::ffi::sqlite3,
+    raw_stmt: *mut libsql_sys::ffi::sqlite3_stmt,
 }
 
 impl Statement {
-    pub(crate) fn prepare(raw: *mut libsql_sys::sqlite3, sql: &str) -> Result<Statement> {
+    pub(crate) fn prepare(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {
         let mut raw_stmt = std::ptr::null_mut();
         let err = unsafe {
-            libsql_sys::sqlite3_prepare_v2(
+            libsql_sys::ffi::sqlite3_prepare_v2(
                 raw,
                 sql.as_ptr() as *const i8,
                 sql.len() as i32,
@@ -19,7 +19,7 @@ impl Statement {
             )
         };
         match err as u32 {
-            libsql_sys::SQLITE_OK => Ok(Statement { raw, raw_stmt }),
+            libsql_sys::ffi::SQLITE_OK => Ok(Statement { raw, raw_stmt }),
             _ => Err(Error::QueryFailed(format!(
                 "Failed to prepare statement: `{}`: {}",
                 sql,
@@ -36,17 +36,17 @@ impl Statement {
                     let i = i as i32 + 1;
                     match param {
                         Value::Null => unsafe {
-                            libsql_sys::sqlite3_bind_null(self.raw_stmt, i);
+                            libsql_sys::ffi::sqlite3_bind_null(self.raw_stmt, i);
                         },
                         Value::Integer(value) => unsafe {
-                            libsql_sys::sqlite3_bind_int64(self.raw_stmt, i, *value);
+                            libsql_sys::ffi::sqlite3_bind_int64(self.raw_stmt, i, *value);
                         },
                         Value::Float(value) => unsafe {
-                            libsql_sys::sqlite3_bind_double(self.raw_stmt, i, *value);
+                            libsql_sys::ffi::sqlite3_bind_double(self.raw_stmt, i, *value);
                         },
                         Value::Text(value) => unsafe {
                             let value = value.as_bytes();
-                            libsql_sys::sqlite3_bind_text(
+                            libsql_sys::ffi::sqlite3_bind_text(
                                 self.raw_stmt,
                                 i,
                                 value.as_ptr() as *const i8,
@@ -55,7 +55,7 @@ impl Statement {
                             );
                         },
                         Value::Blob(value) => unsafe {
-                            libsql_sys::sqlite3_bind_blob(
+                            libsql_sys::ffi::sqlite3_bind_blob(
                                 self.raw_stmt,
                                 i,
                                 value.as_ptr() as *const std::ffi::c_void,
@@ -70,7 +70,7 @@ impl Statement {
     }
 
     pub fn execute(&self, params: &Params) -> Option<Rows> {
-        unsafe { libsql_sys::sqlite3_reset(self.raw_stmt) };
+        unsafe { libsql_sys::ffi::sqlite3_reset(self.raw_stmt) };
         self.bind(&params);
         Rows::execute(self.raw, self.raw_stmt)
     }


### PR DESCRIPTION
With the new layout in place, the code can rely on a local `../libsql-sys` dependency