### PR TITLE
crates/replicaiton: initial commit

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,8 @@ futures = "0.3.28"
 libsql-sys = { path = "../libsql-sys" }
 thiserror = "1.0.40"
 libsql_replication = { path = "../replication" }
+tokio = { version = "1.29.1", features = ["macros"] }
+tracing-subscriber = "0.3.17"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports", "async", "async_futures"] }

--- a/crates/core/examples/example.rs
+++ b/crates/core/examples/example.rs
@@ -1,7 +1,7 @@
 use libsql_core::Database;
 
 fn main() {
-    let db = Database::open(":memory:");
+    let db = Database::open(":memory:").unwrap();
     let conn = db.connect().unwrap();
     conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)", ())
         .unwrap();

--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -1,0 +1,13 @@
+use libsql_core::Database;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let db = Database::open("libsql://localhost:8888").unwrap();
+    let conn = db.connect().unwrap();
+    tokio::spawn(db.replicator.unwrap().run());
+    loop {
+        println!("rows: {:?}", conn.execute("SELECT * FROM t", ()).ok());
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}

--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -16,7 +16,10 @@ impl Connection {
         let url = db.url.clone();
         let err = unsafe {
             libsql_sys::ffi::sqlite3_open_v2(
-                url.as_ptr() as *const i8,
+                std::ffi::CString::new(url.as_str())
+                    .unwrap()
+                    .as_c_str()
+                    .as_ptr() as *const _,
                 &mut raw,
                 libsql_sys::ffi::SQLITE_OPEN_READWRITE as c_int
                     | libsql_sys::ffi::SQLITE_OPEN_CREATE as c_int,

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -1,6 +1,6 @@
-use crate::{connection::Connection, Result};
+use crate::{connection::Connection, Error, Result};
 
-use libsql_replication::Replicator;
+use libsql_replication::{replica::Replicator, replication_log::configure_rpc};
 
 // A libSQL database.
 pub struct Database {
@@ -9,16 +9,31 @@ pub struct Database {
 }
 
 impl Database {
-    pub fn open<S: Into<String>>(url: S) -> Database {
+    pub fn open<S: Into<String>>(url: S) -> Result<Database> {
         let url = url.into();
-        if url.starts_with("libsql:") {
+        // FIXME: in current state of the code, libsql:// address is assumed to be
+        // the RPC endpoint for receiving frames from an sqld primary.
+        // Primary is the node that runs sqld with a parameter like: --grpc-listen-addr 127.0.0.1:8888
+        // It's *not* what users expect, but it makes testing embedded replicas easy, so ¯\_(ツ)_/¯
+        let db = if url.starts_with("libsql:") {
             let url = url.replace("libsql:", "http:");
-            let filename = "file:tmp.db".to_string();
-            let replicator = Some(Replicator::new(url));
-            Database::new(filename, replicator)
+            let filename = "data.libsql/data".to_string();
+            std::fs::create_dir("data.libsql").ok();
+            std::fs::File::create(filename.as_str())
+                .map_err(|e| Error::ConnectionFailed(e.to_string()))?;
+            // FIXME: this replicator is blatantly copied from sqld and it does perhaps more
+            // than necessary, by also regularly asking for new frames. If we want to control
+            // this mechanism by calling sync() ourselves, we need to expose the lower-level API here.
+            // This is important, because we *do not* want a Tokio dependency in libsql.
+            let (channel, uri) =
+                configure_rpc(url).map_err(|e| Error::ConnectionFailed(e.to_string()))?;
+            let replicator = Replicator::new("data.libsql".into(), channel, uri, true)
+                .map_err(|e| Error::ConnectionFailed(e.to_string()))?;
+            Database::new(filename, Some(replicator))
         } else {
             Database::new(url, None)
-        }
+        };
+        Ok(db)
     }
 
     pub fn new(url: String, replicator: Option<Replicator>) -> Database {
@@ -29,12 +44,5 @@ impl Database {
 
     pub fn connect(&self) -> Result<Connection> {
         Connection::connect(self)
-    }
-
-    pub fn sync(&self) -> Result<()> {
-        if let Some(replicator) = &self.replicator {
-            replicator.sync();
-        }
-        Ok(())
     }
 }

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 use crate::{errors, Error, Params, Result, Statement};
 
 /// Query result rows.
+#[derive(Debug)]
 pub struct Rows {
     pub(crate) raw: *mut libsql_sys::ffi::sqlite3,
     pub(crate) raw_stmt: *mut libsql_sys::ffi::sqlite3_stmt,
@@ -20,13 +21,11 @@ impl Rows {
         match err as u32 {
             libsql_sys::ffi::SQLITE_OK => None,
             libsql_sys::ffi::SQLITE_DONE => None,
-            _ => {
-                Some(Rows {
-                    raw,
-                    raw_stmt,
-                    err: RefCell::new(Some(err)),
-                })
-            }
+            _ => Some(Rows {
+                raw,
+                raw_stmt,
+                err: RefCell::new(Some(err)),
+            }),
         }
     }
 

--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -7,6 +7,23 @@ edition = "2021"
 prost = "0.11.3"
 tonic = { version = "0.8.3", features = ["tls"] }
 tokio = { version = "1.22.2", features = ["rt-multi-thread", "net", "io-std", "io-util", "time", "macros", "sync", "fs", "signal"] }
+anyhow = "1.0.71"
+futures = "0.3.28"
+crc = "3.0.1"
+bytemuck = { version = "1.13.1", features = ["derive"] }
+bytes = "1.4.0"
+thiserror = "1.0.41"
+libsql-sys = { path = "../libsql-sys" }
+uuid = { version = "1.4.0", features = ["v4"] }
+parking_lot = "0.12.1"
+tempfile = "3.6.0"
+memmap = "0.7.0"
+tracing = "0.1.37"
+crossbeam = "0.8.2"
+once_cell = "1.18.0"
+nix = "0.26.2"
+tokio-stream = "0.1.14"
+regex = "1.9.0"
 
 [build-dependencies]
 prost-build = "0.11.4"

--- a/crates/replication/src/frame.rs
+++ b/crates/replication/src/frame.rs
@@ -1,0 +1,106 @@
+use std::borrow::Cow;
+use std::fmt;
+use std::mem::{size_of, transmute};
+use std::ops::Deref;
+
+use bytemuck::{bytes_of, pod_read_unaligned, try_from_bytes, Pod, Zeroable};
+use bytes::{Bytes, BytesMut};
+
+use crate::WAL_PAGE_SIZE;
+
+use super::FrameNo;
+
+/// The file header for the WAL log. All fields are represented in little-endian ordering.
+/// See `encode` and `decode` for actual layout.
+// repr C for stable sizing
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
+pub struct FrameHeader {
+    /// Incremental frame number
+    pub frame_no: FrameNo,
+    /// Rolling checksum of all the previous frames, including this one.
+    pub checksum: u64,
+    /// page number, if frame_type is FrameType::Page
+    pub page_no: u32,
+    /// Size of the database (in page) after commiting the transaction. This is passed from sqlite,
+    /// and serves as commit transaction boundary
+    pub size_after: u32,
+}
+
+#[derive(Clone)]
+/// The owned version of a replication frame.
+/// Cloning this is cheap.
+pub struct Frame {
+    data: Bytes,
+}
+
+impl fmt::Debug for Frame {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Frame")
+            .field("header", &self.header())
+            .field("data", &"[..]")
+            .finish()
+    }
+}
+
+impl Frame {
+    /// size of a single frame
+    pub const SIZE: usize = size_of::<FrameHeader>() + WAL_PAGE_SIZE as usize;
+
+    pub fn from_parts(header: &FrameHeader, data: &[u8]) -> Self {
+        assert_eq!(data.len(), WAL_PAGE_SIZE as usize);
+        let mut buf = BytesMut::with_capacity(Self::SIZE);
+        buf.extend_from_slice(bytes_of(header));
+        buf.extend_from_slice(data);
+
+        Self { data: buf.freeze() }
+    }
+
+    pub fn try_from_bytes(data: Bytes) -> anyhow::Result<Self> {
+        anyhow::ensure!(data.len() == Self::SIZE, "invalid frame size");
+        Ok(Self { data })
+    }
+
+    pub fn bytes(&self) -> Bytes {
+        self.data.clone()
+    }
+}
+
+/// The borrowed version of Frame
+#[repr(transparent)]
+pub struct FrameBorrowed {
+    data: [u8],
+}
+
+impl FrameBorrowed {
+    pub fn header(&self) -> Cow<FrameHeader> {
+        let data = &self.data[..size_of::<FrameHeader>()];
+        try_from_bytes(data)
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|_| Cow::Owned(pod_read_unaligned(data)))
+    }
+
+    /// Returns the bytes for this frame. Includes the header bytes.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn from_bytes(data: &[u8]) -> &Self {
+        assert_eq!(data.len(), Frame::SIZE);
+        // SAFETY: &FrameBorrowed is equivalent to &[u8]
+        unsafe { transmute(data) }
+    }
+
+    /// returns this frame's page data.
+    pub fn page(&self) -> &[u8] {
+        &self.data[size_of::<FrameHeader>()..]
+    }
+}
+
+impl Deref for Frame {
+    type Target = FrameBorrowed;
+
+    fn deref(&self) -> &Self::Target {
+        FrameBorrowed::from_bytes(&self.data)
+    }
+}

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -1,28 +1,23 @@
-use tokio::runtime::Runtime;
+pub mod frame;
+pub mod primary;
+pub mod replica;
+pub mod replication_log;
+mod snapshot;
 
-pub mod rpc {
-    #![allow(clippy::all)]
-    tonic::include_proto!("wal_log");
-}
+use crc::Crc;
+pub use primary::logger::{LogReadError, ReplicationLogger, ReplicationLoggerHook};
 
-pub struct Replicator {
-    url: String,
-}
+pub const WAL_PAGE_SIZE: i32 = 4096;
+pub const WAL_MAGIC: u64 = u64::from_le_bytes(*b"SQLDWAL\0");
+const CRC_64_GO_ISO: Crc<u64> = Crc::<u64>::new(&crc::CRC_64_GO_ISO);
 
-impl Replicator {
-    pub fn new(url: String) -> Replicator {
-        Replicator { url }
-    }
+/// The frame uniquely identifying, monotonically increasing number
+pub type FrameNo = u64;
 
-    pub fn sync(&self) {
-        let rt = Runtime::new().unwrap();
-        rt.block_on(async {
-            let mut client =
-                rpc::replication_log_client::ReplicationLogClient::connect(self.url.to_owned())
-                    .await
-                    .unwrap();
-            let response = client.hello(rpc::HelloRequest {}).await;
-            println!("RESPONSE={:?}", response);
-        });
-    }
-}
+/// Trigger a hard database reset. This cause the database to be wiped, freshly restarted
+/// This is used for replicas that are left in an unrecoverabe state and should restart from a
+/// fresh state.
+///
+/// /!\ use with caution.
+pub(crate) static HARD_RESET: once_cell::sync::Lazy<std::sync::Arc<tokio::sync::Notify>> =
+    once_cell::sync::Lazy::new(|| std::sync::Arc::new(tokio::sync::Notify::new()));

--- a/crates/replication/src/primary/frame_stream.rs
+++ b/crates/replication/src/primary/frame_stream.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+use std::task::{ready, Poll};
+use std::{pin::Pin, task::Context};
+
+use futures::future::BoxFuture;
+use futures::Stream;
+
+use crate::frame::Frame;
+use crate::{FrameNo, LogReadError, ReplicationLogger};
+
+/// Streams frames from the replication log starting at `current_frame_no`.
+/// Only stops if the current frame is not in the log anymore.
+pub struct FrameStream {
+    current_frame_no: FrameNo,
+    max_available_frame_no: FrameNo,
+    logger: Arc<ReplicationLogger>,
+    state: FrameStreamState,
+}
+
+impl FrameStream {
+    pub fn new(logger: Arc<ReplicationLogger>, current_frameno: FrameNo) -> Self {
+        let max_available_frame_no = *logger.new_frame_notifier.subscribe().borrow();
+        Self {
+            current_frame_no: current_frameno,
+            max_available_frame_no,
+            logger,
+            state: FrameStreamState::Init,
+        }
+    }
+
+    fn transition_state_next_frame(&mut self) {
+        if matches!(self.state, FrameStreamState::Closed) {
+            return;
+        }
+
+        let next_frameno = self.current_frame_no;
+        let logger = self.logger.clone();
+        let fut = async move {
+            let res = tokio::task::spawn_blocking(move || logger.get_frame(next_frameno)).await;
+            match res {
+                Ok(Ok(frame)) => Ok(frame),
+                Ok(Err(e)) => Err(e),
+                Err(e) => Err(LogReadError::Error(e.into())),
+            }
+        };
+
+        self.state = FrameStreamState::WaitingFrame(Box::pin(fut));
+    }
+}
+
+enum FrameStreamState {
+    Init,
+    /// waiting for new frames to replicate
+    WaitingFrameNo(BoxFuture<'static, anyhow::Result<FrameNo>>),
+    WaitingFrame(BoxFuture<'static, Result<Frame, LogReadError>>),
+    Closed,
+}
+
+impl Stream for FrameStream {
+    type Item = Result<Frame, LogReadError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.state {
+            FrameStreamState::Init => {
+                self.transition_state_next_frame();
+                self.poll_next(cx)
+            }
+            FrameStreamState::WaitingFrameNo(ref mut fut) => {
+                self.max_available_frame_no = match ready!(fut.as_mut().poll(cx)) {
+                    Ok(frame_no) => frame_no,
+                    Err(e) => {
+                        self.state = FrameStreamState::Closed;
+                        return Poll::Ready(Some(Err(LogReadError::Error(e))));
+                    }
+                };
+                self.transition_state_next_frame();
+                self.poll_next(cx)
+            }
+            FrameStreamState::WaitingFrame(ref mut fut) => match ready!(fut.as_mut().poll(cx)) {
+                Ok(frame) => {
+                    self.current_frame_no += 1;
+                    self.transition_state_next_frame();
+                    Poll::Ready(Some(Ok(frame)))
+                }
+
+                Err(LogReadError::Ahead) => {
+                    let mut notifier = self.logger.new_frame_notifier.subscribe();
+                    let max_available_frame_no = *notifier.borrow();
+                    // check in case value has already changed, otherwise we'll be notified later
+                    if max_available_frame_no > self.max_available_frame_no {
+                        self.max_available_frame_no = max_available_frame_no;
+                        self.transition_state_next_frame();
+                        self.poll_next(cx)
+                    } else {
+                        let fut = async move {
+                            notifier.changed().await?;
+                            Ok(*notifier.borrow())
+                        };
+                        self.state = FrameStreamState::WaitingFrameNo(Box::pin(fut));
+                        self.poll_next(cx)
+                    }
+                }
+                Err(e) => {
+                    self.state = FrameStreamState::Closed;
+                    Poll::Ready(Some(Err(e)))
+                }
+            },
+            FrameStreamState::Closed => Poll::Ready(None),
+        }
+    }
+}

--- a/crates/replication/src/primary/logger.rs
+++ b/crates/replication/src/primary/logger.rs
@@ -1,0 +1,913 @@
+use std::ffi::{c_int, c_void, CStr};
+use std::fs::{remove_dir_all, File, OpenOptions};
+use std::io::Write;
+use std::mem::size_of;
+use std::os::unix::prelude::FileExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{bail, ensure};
+use bytemuck::{bytes_of, pod_read_unaligned, Pod, Zeroable};
+use bytes::{Bytes, BytesMut};
+use libsql_sys::init_static_wal_method;
+use parking_lot::RwLock;
+use tokio::sync::watch;
+use uuid::Uuid;
+
+use crate::frame::{Frame, FrameHeader};
+use crate::snapshot::{find_snapshot_file, LogCompactor, SnapshotFile};
+use crate::{FrameNo, CRC_64_GO_ISO, WAL_MAGIC, WAL_PAGE_SIZE};
+use libsql_sys::wal_hook::WalHook;
+use libsql_sys::{
+    ffi::{sqlite3, PgHdr, SQLITE_IOERR, SQLITE_OK},
+    types::{PageHdrIter, Wal, XWalCheckpointFn, XWalFrameFn, XWalSavePointUndoFn, XWalUndoFn},
+};
+
+init_static_wal_method!(REPLICATION_METHODS, ReplicationLoggerHook);
+
+#[derive(PartialEq, Eq)]
+struct Version([u16; 4]);
+
+impl Version {
+    fn current() -> Self {
+        let major = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
+        let minor = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap();
+        let patch = env!("CARGO_PKG_VERSION_PATCH").parse().unwrap();
+        Self([0, major, minor, patch])
+    }
+}
+
+pub enum ReplicationLoggerHook {}
+
+#[derive(Clone)]
+pub struct ReplicationLoggerHookCtx {
+    buffer: Vec<WalPage>,
+    logger: Arc<ReplicationLogger>,
+}
+
+/// This implementation of WalHook intercepts calls to `on_frame`, and writes them to a
+/// shadow wal. Writing to the shadow wal is done in three steps:
+/// i. append the new pages at the offset pointed by header.start_frame_no + header.frame_count
+/// ii. call the underlying implementation of on_frames
+/// iii. if the call of the underlying method was successfull, update the log header to the new
+/// frame count.
+///
+/// If either writing to the database of to the shadow wal fails, it must be noop.
+unsafe impl WalHook for ReplicationLoggerHook {
+    type Context = ReplicationLoggerHookCtx;
+
+    fn name() -> &'static CStr {
+        CStr::from_bytes_with_nul(b"replication_logger_hook\0").unwrap()
+    }
+
+    fn on_frames(
+        wal: &mut Wal,
+        page_size: c_int,
+        page_headers: *mut PgHdr,
+        ntruncate: u32,
+        is_commit: c_int,
+        sync_flags: c_int,
+        orig: XWalFrameFn,
+    ) -> c_int {
+        assert_eq!(page_size, 4096);
+        let wal_ptr = wal as *mut _;
+
+        let ctx = Self::wal_extract_ctx(wal);
+
+        for (page_no, data) in PageHdrIter::new(page_headers, page_size as _) {
+            ctx.write_frame(page_no, data)
+        }
+        if let Err(e) = ctx.flush(ntruncate) {
+            tracing::error!("error writing to replication log: {e}");
+            // returning IO_ERR ensure that xUndo will be called by sqlite.
+            return SQLITE_IOERR as c_int;
+        }
+
+        let rc = unsafe {
+            orig(
+                wal_ptr,
+                page_size,
+                page_headers,
+                ntruncate,
+                is_commit,
+                sync_flags,
+            )
+        };
+
+        if is_commit != 0 && rc == 0 {
+            if let Err(e) = ctx.commit() {
+                // If we reach this point, it means that we have commited a transaction to sqlite wal,
+                // but failed to commit it to the shadow WAL, which leaves us in an inconsistent state.
+                tracing::error!(
+                    "fatal error: log failed to commit: inconsistent replication log: {e}"
+                );
+                std::process::abort();
+            }
+
+            if let Err(e) = ctx.logger.log_file.write().maybe_compact(
+                ctx.logger.compactor.clone(),
+                ntruncate,
+                &ctx.logger.db_path,
+            ) {
+                tracing::error!("fatal error: {e}, exiting");
+                std::process::abort()
+            }
+        }
+
+        rc
+    }
+
+    fn on_undo(
+        wal: &mut Wal,
+        func: Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>,
+        undo_ctx: *mut c_void,
+        orig: XWalUndoFn,
+    ) -> i32 {
+        let ctx = Self::wal_extract_ctx(wal);
+        ctx.rollback();
+
+        unsafe { orig(wal, func, undo_ctx) }
+    }
+
+    fn on_savepoint_undo(wal: &mut Wal, wal_data: *mut u32, orig: XWalSavePointUndoFn) -> i32 {
+        let rc = unsafe { orig(wal, wal_data) };
+        if rc != SQLITE_OK as c_int {
+            return rc;
+        };
+
+        rc
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn on_checkpoint(
+        wal: &mut Wal,
+        db: *mut sqlite3,
+        emode: i32,
+        busy_handler: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
+        busy_arg: *mut c_void,
+        sync_flags: i32,
+        n_buf: i32,
+        z_buf: *mut u8,
+        frames_in_wal: *mut i32,
+        backfilled_frames: *mut i32,
+        orig: XWalCheckpointFn,
+    ) -> i32 {
+        let rc = unsafe {
+            orig(
+                wal,
+                db,
+                emode,
+                busy_handler,
+                busy_arg,
+                sync_flags,
+                n_buf,
+                z_buf,
+                frames_in_wal,
+                backfilled_frames,
+            )
+        };
+
+        if rc != SQLITE_OK as c_int {
+            return rc;
+        }
+
+        SQLITE_OK as c_int
+    }
+}
+
+#[derive(Clone)]
+pub struct WalPage {
+    pub page_no: u32,
+    /// 0 for non-commit frames
+    pub size_after: u32,
+    pub data: Bytes,
+}
+
+impl ReplicationLoggerHookCtx {
+    pub fn new(
+        logger: Arc<ReplicationLogger>,
+        #[cfg(feature = "bottomless")] bottomless_replicator: Option<
+            Arc<std::sync::Mutex<bottomless::replicator::Replicator>>,
+        >,
+    ) -> Self {
+        Self {
+            buffer: Default::default(),
+            logger,
+        }
+    }
+
+    fn write_frame(&mut self, page_no: u32, data: &[u8]) {
+        let entry = WalPage {
+            page_no,
+            size_after: 0,
+            data: Bytes::copy_from_slice(data),
+        };
+        self.buffer.push(entry);
+    }
+
+    /// write buffered pages to the logger, without commiting.
+    fn flush(&mut self, size_after: u32) -> anyhow::Result<()> {
+        if !self.buffer.is_empty() {
+            self.buffer.last_mut().unwrap().size_after = size_after;
+            self.logger.write_pages(&self.buffer)?;
+            self.buffer.clear();
+        }
+
+        Ok(())
+    }
+
+    fn commit(&self) -> anyhow::Result<()> {
+        let new_frame_no = self.logger.commit()?;
+        let _ = self.logger.new_frame_notifier.send(new_frame_no);
+        Ok(())
+    }
+
+    fn rollback(&mut self) {
+        self.logger.log_file.write().rollback();
+        self.buffer.clear();
+    }
+}
+
+/// Represent a LogFile, and operations that can be performed on it.
+/// A log file must only ever be opened by a single instance of LogFile, since it caches the file
+/// header.
+#[derive(Debug)]
+pub struct LogFile {
+    file: File,
+    pub header: LogFileHeader,
+    /// the maximum number of frames this log is allowed to contain before it should be compacted.
+    max_log_frame_count: u64,
+    /// number of frames in the log that have not been commited yet. On commit the header's frame
+    /// count is incremented by that ammount. New pages are written after the last
+    /// header.frame_count + uncommit_frame_count.
+    /// On rollback, this is reset to 0, so that everything that was written after the previous
+    /// header.frame_count is ignored and can be overwritten
+    uncommitted_frame_count: u64,
+    uncommitted_checksum: u64,
+
+    /// checksum of the last commited frame
+    commited_checksum: u64,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LogReadError {
+    #[error("could not fetch log entry, snapshot required")]
+    SnapshotRequired,
+    #[error("requested entry is ahead of log")]
+    Ahead,
+    #[error(transparent)]
+    Error(#[from] anyhow::Error),
+}
+
+impl LogFile {
+    /// size of a single frame
+    pub const FRAME_SIZE: usize = size_of::<FrameHeader>() + WAL_PAGE_SIZE as usize;
+
+    pub fn new(file: File, max_log_frame_count: u64) -> anyhow::Result<Self> {
+        // FIXME: we should probably take a lock on this file, to prevent anybody else to write to
+        // it.
+        let file_end = file.metadata()?.len();
+
+        if file_end == 0 {
+            let db_id = Uuid::new_v4();
+            let header = LogFileHeader {
+                version: 2,
+                start_frame_no: 0,
+                magic: WAL_MAGIC,
+                page_size: WAL_PAGE_SIZE,
+                start_checksum: 0,
+                db_id: db_id.as_u128(),
+                frame_count: 0,
+                sqld_version: Version::current().0,
+            };
+
+            let mut this = Self {
+                file,
+                header,
+                max_log_frame_count,
+                uncommitted_frame_count: 0,
+                uncommitted_checksum: 0,
+                commited_checksum: 0,
+            };
+
+            this.write_header()?;
+
+            Ok(this)
+        } else {
+            let header = Self::read_header(&file)?;
+            let mut this = Self {
+                file,
+                header,
+                max_log_frame_count,
+                uncommitted_frame_count: 0,
+                uncommitted_checksum: 0,
+                commited_checksum: 0,
+            };
+
+            if let Some(last_commited) = this.last_commited_frame_no() {
+                // file is not empty, the starting checksum is the checksum from the last entry
+                let last_frame = this.frame(last_commited)?;
+                this.commited_checksum = last_frame.header().checksum;
+                this.uncommitted_checksum = last_frame.header().checksum;
+            } else {
+                // file contains no entry, start with the initial checksum from the file header.
+                this.commited_checksum = this.header.start_checksum;
+                this.uncommitted_checksum = this.header.start_checksum;
+            }
+
+            Ok(this)
+        }
+    }
+
+    pub fn read_header(file: &File) -> anyhow::Result<LogFileHeader> {
+        let mut buf = [0; size_of::<LogFileHeader>()];
+        file.read_exact_at(&mut buf, 0)?;
+        let header: LogFileHeader = pod_read_unaligned(&buf);
+        if header.magic != WAL_MAGIC {
+            bail!("invalid replication log header");
+        }
+
+        Ok(header)
+    }
+
+    pub fn header(&self) -> &LogFileHeader {
+        &self.header
+    }
+
+    pub fn commit(&mut self) -> anyhow::Result<()> {
+        self.header.frame_count += self.uncommitted_frame_count;
+        self.uncommitted_frame_count = 0;
+        self.commited_checksum = self.uncommitted_checksum;
+        self.write_header()?;
+
+        Ok(())
+    }
+
+    fn rollback(&mut self) {
+        self.uncommitted_frame_count = 0;
+        self.uncommitted_checksum = self.commited_checksum;
+    }
+
+    pub fn write_header(&mut self) -> anyhow::Result<()> {
+        self.file.write_all_at(bytes_of(&self.header), 0)?;
+        self.file.flush()?;
+
+        Ok(())
+    }
+
+    /// Returns an iterator over the WAL frame headers
+    #[allow(dead_code)]
+    fn frames_iter(&self) -> anyhow::Result<impl Iterator<Item = anyhow::Result<Frame>> + '_> {
+        let mut current_frame_offset = 0;
+        Ok(std::iter::from_fn(move || {
+            if current_frame_offset >= self.header.frame_count {
+                return None;
+            }
+            let read_byte_offset = Self::absolute_byte_offset(current_frame_offset);
+            current_frame_offset += 1;
+            Some(self.read_frame_byte_offset(read_byte_offset))
+        }))
+    }
+
+    /// Returns an iterator over the WAL frame headers
+    pub fn rev_frames_iter(
+        &self,
+    ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<Frame>> + '_> {
+        let mut current_frame_offset = self.header.frame_count;
+
+        Ok(std::iter::from_fn(move || {
+            if current_frame_offset == 0 {
+                return None;
+            }
+            current_frame_offset -= 1;
+            let read_byte_offset = Self::absolute_byte_offset(current_frame_offset);
+            let frame = self.read_frame_byte_offset(read_byte_offset);
+            Some(frame)
+        }))
+    }
+
+    fn compute_checksum(&self, page: &WalPage) -> u64 {
+        let mut digest = CRC_64_GO_ISO.digest_with_initial(self.uncommitted_checksum);
+        digest.update(&page.data);
+        digest.finalize()
+    }
+
+    pub fn push_page(&mut self, page: &WalPage) -> anyhow::Result<()> {
+        let checksum = self.compute_checksum(page);
+        let frame = Frame::from_parts(
+            &FrameHeader {
+                frame_no: self.next_frame_no(),
+                checksum,
+                page_no: page.page_no,
+                size_after: page.size_after,
+            },
+            &page.data,
+        );
+
+        let byte_offset = self.next_byte_offset();
+        tracing::trace!(
+            "writing frame {} at offset {byte_offset}",
+            frame.header().frame_no
+        );
+        self.file.write_all_at(frame.as_slice(), byte_offset)?;
+
+        self.uncommitted_frame_count += 1;
+        self.uncommitted_checksum = checksum;
+
+        Ok(())
+    }
+
+    /// offset in bytes at which to write the next frame
+    fn next_byte_offset(&self) -> u64 {
+        Self::absolute_byte_offset(self.header().frame_count + self.uncommitted_frame_count)
+    }
+
+    fn next_frame_no(&self) -> FrameNo {
+        self.header().start_frame_no + self.header().frame_count + self.uncommitted_frame_count
+    }
+
+    /// Returns the bytes position of the `nth` entry in the log
+    fn absolute_byte_offset(nth: u64) -> u64 {
+        std::mem::size_of::<LogFileHeader>() as u64 + nth * Self::FRAME_SIZE as u64
+    }
+
+    fn byte_offset(&self, id: FrameNo) -> anyhow::Result<Option<u64>> {
+        if id < self.header.start_frame_no
+            || id > self.header.start_frame_no + self.header.frame_count
+        {
+            return Ok(None);
+        }
+        Ok(Self::absolute_byte_offset(id - self.header.start_frame_no).into())
+    }
+
+    /// Returns bytes represening a WalFrame for frame `frame_no`
+    ///
+    /// If the requested frame is before the first frame in the log, or after the last frame,
+    /// Ok(None) is returned.
+    pub fn frame(&self, frame_no: FrameNo) -> std::result::Result<Frame, LogReadError> {
+        if frame_no < self.header.start_frame_no {
+            return Err(LogReadError::SnapshotRequired);
+        }
+
+        if frame_no >= self.header.start_frame_no + self.header.frame_count {
+            return Err(LogReadError::Ahead);
+        }
+
+        let frame = self.read_frame_byte_offset(self.byte_offset(frame_no)?.unwrap())?;
+
+        Ok(frame)
+    }
+
+    fn maybe_compact(
+        &mut self,
+        compactor: LogCompactor,
+        size_after: u32,
+        path: &Path,
+    ) -> anyhow::Result<()> {
+        if self.header.frame_count > self.max_log_frame_count {
+            return self.do_compaction(compactor, size_after, path);
+        }
+
+        Ok(())
+    }
+
+    fn do_compaction(
+        &mut self,
+        compactor: LogCompactor,
+        size_after: u32,
+        path: &Path,
+    ) -> anyhow::Result<()> {
+        tracing::info!("performing log compaction");
+        let temp_log_path = path.join("temp_log");
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&temp_log_path)?;
+        let mut new_log_file = LogFile::new(file, self.max_log_frame_count)?;
+        let new_header = LogFileHeader {
+            start_frame_no: self.header.start_frame_no + self.header.frame_count,
+            frame_count: 0,
+            start_checksum: self.commited_checksum,
+            ..self.header
+        };
+        new_log_file.header = new_header;
+        new_log_file.write_header().unwrap();
+        // swap old and new snapshot
+        atomic_rename(&temp_log_path, path.join("wallog")).unwrap();
+        let old_log_file = std::mem::replace(self, new_log_file);
+        compactor.compact(old_log_file, temp_log_path, size_after)?;
+
+        Ok(())
+    }
+
+    fn read_frame_byte_offset(&self, offset: u64) -> anyhow::Result<Frame> {
+        let mut buffer = BytesMut::zeroed(LogFile::FRAME_SIZE);
+        self.file.read_exact_at(&mut buffer, offset)?;
+        let buffer = buffer.freeze();
+
+        Frame::try_from_bytes(buffer)
+    }
+
+    fn last_commited_frame_no(&self) -> Option<FrameNo> {
+        if self.header.frame_count == 0 {
+            None
+        } else {
+            Some(self.header.start_frame_no + self.header.frame_count - 1)
+        }
+    }
+
+    fn reset(self) -> anyhow::Result<Self> {
+        let max_log_frame_count = self.max_log_frame_count;
+        // truncate file
+        self.file.set_len(0)?;
+        Self::new(self.file, max_log_frame_count)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn atomic_rename(p1: impl AsRef<Path>, p2: impl AsRef<Path>) -> anyhow::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::prelude::OsStrExt;
+
+    use nix::libc::renamex_np;
+    use nix::libc::RENAME_SWAP;
+
+    let p1 = CString::new(p1.as_ref().as_os_str().as_bytes())?;
+    let p2 = CString::new(p2.as_ref().as_os_str().as_bytes())?;
+    unsafe {
+        let ret = renamex_np(p1.as_ptr(), p2.as_ptr(), RENAME_SWAP);
+
+        if ret != 0 {
+            bail!(
+                "failed to perform snapshot file swap: {ret}, errno: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn atomic_rename(p1: impl AsRef<Path>, p2: impl AsRef<Path>) -> anyhow::Result<()> {
+    use anyhow::Context;
+    use nix::fcntl::{renameat2, RenameFlags};
+
+    renameat2(
+        None,
+        p1.as_ref(),
+        None,
+        p2.as_ref(),
+        RenameFlags::RENAME_EXCHANGE,
+    )
+    .context("failed to perform snapshot file swap")?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
+#[repr(C)]
+pub struct LogFileHeader {
+    /// magic number: b"SQLDWAL\0" as u64
+    pub magic: u64,
+    /// Initial checksum value for the rolling CRC checksum
+    /// computed with the 64 bits CRC_64_GO_ISO
+    pub start_checksum: u64,
+    /// Uuid of the database associated with this log.
+    pub db_id: u128,
+    /// Frame_no of the first frame in the log
+    pub start_frame_no: FrameNo,
+    /// entry count in file
+    pub frame_count: u64,
+    /// Wal file version number, currently: 2
+    pub version: u32,
+    /// page size: 4096
+    pub page_size: i32,
+    /// sqld version when creating this log
+    pub sqld_version: [u16; 4],
+}
+
+impl LogFileHeader {
+    pub fn last_frame_no(&self) -> FrameNo {
+        self.start_frame_no + self.frame_count
+    }
+
+    fn sqld_version(&self) -> Version {
+        Version(self.sqld_version)
+    }
+}
+
+pub struct Generation {
+    pub id: Uuid,
+    pub start_index: u64,
+}
+
+impl Generation {
+    fn new(start_index: u64) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            start_index,
+        }
+    }
+}
+
+pub struct ReplicationLogger {
+    pub generation: Generation,
+    pub log_file: RwLock<LogFile>,
+    compactor: LogCompactor,
+    db_path: PathBuf,
+    /// a notifier channel other tasks can subscribe to, and get notified when new frames become
+    /// available.
+    pub new_frame_notifier: watch::Sender<FrameNo>,
+}
+
+impl ReplicationLogger {
+    pub fn open(db_path: &Path, max_log_size: u64, dirty: bool) -> anyhow::Result<Self> {
+        let log_path = db_path.join("wallog");
+        let data_path = db_path.join("data");
+
+        let fresh = !log_path.exists();
+
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .read(true)
+            .open(log_path)?;
+
+        let max_log_frame_count = max_log_size * 1_000_000 / LogFile::FRAME_SIZE as u64;
+        let log_file = LogFile::new(file, max_log_frame_count)?;
+        let header = log_file.header();
+
+        let should_recover = if dirty {
+            tracing::info!("Replication log is dirty, recovering from database file.");
+            true
+        } else if header.version < 2 || header.sqld_version() != Version::current() {
+            tracing::info!("replication log version not compatible with current sqld version, recovering from database file.");
+            true
+        } else if fresh && data_path.exists() {
+            tracing::info!("replication log not found, recovering from database file.");
+            true
+        } else {
+            false
+        };
+
+        if should_recover {
+            Self::recover(log_file, data_path)
+        } else {
+            Self::from_log_file(db_path.to_path_buf(), log_file)
+        }
+    }
+
+    fn from_log_file(db_path: PathBuf, log_file: LogFile) -> anyhow::Result<Self> {
+        let header = log_file.header();
+        let generation_start_frame_no = header.start_frame_no + header.frame_count;
+
+        let (new_frame_notifier, _) = watch::channel(generation_start_frame_no);
+
+        Ok(Self {
+            generation: Generation::new(generation_start_frame_no),
+            compactor: LogCompactor::new(&db_path, log_file.header.db_id)?,
+            log_file: RwLock::new(log_file),
+            db_path,
+            new_frame_notifier,
+        })
+    }
+
+    fn recover(log_file: LogFile, mut data_path: PathBuf) -> anyhow::Result<Self> {
+        // It is necessary to checkpoint before we restore the replication log, since the WAL may
+        // contain pages that are not in the database file.
+        checkpoint_db(&data_path)?;
+        let mut log_file = log_file.reset()?;
+        let snapshot_path = data_path.parent().unwrap().join("snapshots");
+        // best effort, there may be no snapshots
+        let _ = remove_dir_all(snapshot_path);
+
+        let data_file = File::open(&data_path)?;
+        let size = data_path.metadata()?.len();
+        assert!(
+            size % WAL_PAGE_SIZE as u64 == 0,
+            "database file size is not a multiple of page size"
+        );
+        let num_page = size / WAL_PAGE_SIZE as u64;
+        let mut buf = [0; WAL_PAGE_SIZE as usize];
+        let mut page_no = 1; // page numbering starts at 1
+        for i in 0..num_page {
+            data_file.read_exact_at(&mut buf, i * WAL_PAGE_SIZE as u64)?;
+            log_file.push_page(&WalPage {
+                page_no,
+                size_after: if i == num_page - 1 { num_page as _ } else { 0 },
+                data: Bytes::copy_from_slice(&buf),
+            })?;
+            log_file.commit()?;
+
+            page_no += 1;
+        }
+
+        assert!(data_path.pop());
+
+        Self::from_log_file(data_path, log_file)
+    }
+
+    pub fn database_id(&self) -> anyhow::Result<Uuid> {
+        Ok(Uuid::from_u128((self.log_file.read()).header().db_id))
+    }
+
+    /// Write pages to the log, without updating the file header.
+    /// Returns the new frame count and checksum to commit
+    fn write_pages(&self, pages: &[WalPage]) -> anyhow::Result<()> {
+        let mut log_file = self.log_file.write();
+        for page in pages.iter() {
+            log_file.push_page(page)?;
+        }
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn compute_checksum(wal_header: &LogFileHeader, log_file: &LogFile) -> anyhow::Result<u64> {
+        tracing::debug!("computing WAL log running checksum...");
+        let mut iter = log_file.frames_iter()?;
+        iter.try_fold(wal_header.start_checksum, |sum, frame| {
+            let frame = frame?;
+            let mut digest = CRC_64_GO_ISO.digest_with_initial(sum);
+            digest.update(frame.page());
+            let cs = digest.finalize();
+            ensure!(
+                cs == frame.header().checksum,
+                "invalid WAL file: invalid checksum"
+            );
+            Ok(cs)
+        })
+    }
+
+    /// commit the current transaction and returns the new top frame number
+    fn commit(&self) -> anyhow::Result<FrameNo> {
+        let mut log_file = self.log_file.write();
+        log_file.commit()?;
+        Ok(log_file.header().last_frame_no())
+    }
+
+    pub fn get_snapshot_file(&self, from: FrameNo) -> anyhow::Result<Option<SnapshotFile>> {
+        find_snapshot_file(&self.db_path, from)
+    }
+
+    pub fn get_frame(&self, frame_no: FrameNo) -> Result<Frame, LogReadError> {
+        self.log_file.read().frame(frame_no)
+    }
+}
+
+fn checkpoint_db(data_path: &Path) -> anyhow::Result<()> {
+    unsafe {
+        let mut db: *mut libsql_sys::ffi::sqlite3 = std::ptr::null_mut();
+        let rc = libsql_sys::ffi::sqlite3_open(
+            data_path
+                .as_os_str()
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("invalid data path"))?
+                .as_ptr() as *const _,
+            &mut db as *mut _,
+        );
+        ensure!(
+            rc == libsql_sys::ffi::SQLITE_OK as i32,
+            "failed to open database file for checkpointing: {}",
+            rc
+        );
+        // FIXME: we used to verify PRAGMA page_size here as well
+        let rc = libsql_sys::ffi::sqlite3_exec(
+            db,
+            "PRAGMA wal_checkpoint(TRUNCATE)\0".as_ptr() as *const _,
+            None,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+
+        // TODO: ensure correct page size
+        ensure!(
+            rc == 0,
+            "failed to checkpoint database while recovering replication log"
+        );
+
+        let rc = libsql_sys::ffi::sqlite3_exec(
+            db,
+            "VACUUM\0".as_ptr() as *const _,
+            None,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        ensure!(
+            rc == 0,
+            "failed to vacuum database after checkpointing: {}",
+            rc
+        );
+
+        let rc = libsql_sys::ffi::sqlite3_close(db);
+        ensure!(
+            rc == libsql_sys::ffi::SQLITE_OK as i32,
+            "failed to close database file after checkpointing: {}",
+            rc
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn write_and_read_from_frame_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let logger = ReplicationLogger::open(dir.path(), 0, false).unwrap();
+
+        let frames = (0..10)
+            .map(|i| WalPage {
+                page_no: i,
+                size_after: 0,
+                data: Bytes::from(vec![i as _; 4096]),
+            })
+            .collect::<Vec<_>>();
+        logger.write_pages(&frames).unwrap();
+        logger.commit().unwrap();
+
+        let log_file = logger.log_file.write();
+        for i in 0..10 {
+            let frame = log_file.frame(i).unwrap();
+            assert_eq!(frame.header().page_no, i as u32);
+            assert!(frame.page().iter().all(|x| i as u8 == *x));
+        }
+
+        assert_eq!(
+            log_file.header.start_frame_no + log_file.header.frame_count,
+            10
+        );
+    }
+
+    #[test]
+    fn index_out_of_bounds() {
+        let dir = tempfile::tempdir().unwrap();
+        let logger = ReplicationLogger::open(dir.path(), 0, false).unwrap();
+        let log_file = logger.log_file.write();
+        assert!(matches!(log_file.frame(1), Err(LogReadError::Ahead)));
+    }
+
+    #[test]
+    #[should_panic]
+    fn incorrect_frame_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let logger = ReplicationLogger::open(dir.path(), 0, false).unwrap();
+        let entry = WalPage {
+            page_no: 0,
+            size_after: 0,
+            data: vec![0; 3].into(),
+        };
+
+        logger.write_pages(&[entry]).unwrap();
+        logger.commit().unwrap();
+    }
+
+    #[test]
+    fn log_file_test_rollback() {
+        let f = tempfile::tempfile().unwrap();
+        let mut log_file = LogFile::new(f, 100).unwrap();
+        (0..5)
+            .map(|i| WalPage {
+                page_no: i,
+                size_after: 5,
+                data: Bytes::from_static(&[1; 4096]),
+            })
+            .for_each(|p| {
+                log_file.push_page(&p).unwrap();
+            });
+
+        assert_eq!(log_file.frames_iter().unwrap().count(), 0);
+
+        log_file.commit().unwrap();
+
+        (0..5)
+            .map(|i| WalPage {
+                page_no: i,
+                size_after: 5,
+                data: Bytes::from_static(&[1; 4096]),
+            })
+            .for_each(|p| {
+                log_file.push_page(&p).unwrap();
+            });
+
+        log_file.rollback();
+        assert_eq!(log_file.frames_iter().unwrap().count(), 5);
+
+        log_file
+            .push_page(&WalPage {
+                page_no: 42,
+                size_after: 5,
+                data: Bytes::from_static(&[1; 4096]),
+            })
+            .unwrap();
+
+        assert_eq!(log_file.frames_iter().unwrap().count(), 5);
+        log_file.commit().unwrap();
+        assert_eq!(log_file.frames_iter().unwrap().count(), 6);
+    }
+}

--- a/crates/replication/src/primary/mod.rs
+++ b/crates/replication/src/primary/mod.rs
@@ -1,0 +1,2 @@
+pub mod frame_stream;
+pub mod logger;

--- a/crates/replication/src/replica/error.rs
+++ b/crates/replication/src/replica/error.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, thiserror::Error)]
+pub enum ReplicationError {
+    #[error("Replica is ahead of primary")]
+    Lagging,
+    #[error("Trying to replicate incompatible databases")]
+    DbIncompatible,
+    #[error("{0}")]
+    Other(#[from] anyhow::Error),
+}

--- a/crates/replication/src/replica/hook.rs
+++ b/crates/replication/src/replica/hook.rs
@@ -1,0 +1,256 @@
+use std::ffi::{c_int, CStr};
+use std::marker::PhantomData;
+
+use libsql_sys::ffi::{PgHdr, SQLITE_ERROR};
+use libsql_sys::init_static_wal_method;
+use libsql_sys::types::Wal;
+use libsql_sys::{types::XWalFrameFn, wal_hook::WalHook};
+
+use crate::frame::{Frame, FrameBorrowed};
+use crate::{FrameNo, WAL_PAGE_SIZE};
+
+use super::snapshot::TempSnapshot;
+
+// Those are custom error codes returned by the replicator hook.
+pub const LIBSQL_EXIT_REPLICATION: u32 = 200;
+pub const LIBSQL_CONTINUE_REPLICATION: u32 = 201;
+
+#[derive(Debug)]
+pub enum Frames {
+    Vec(Vec<Frame>),
+    Snapshot(TempSnapshot),
+}
+
+pub struct Headers<'a> {
+    ptr: *mut PgHdr,
+    _pth: PhantomData<&'a ()>,
+}
+
+impl<'a> Headers<'a> {
+    // safety: ptr is guaranteed to be valid for 'a
+    unsafe fn new(ptr: *mut PgHdr) -> Self {
+        Self {
+            ptr,
+            _pth: PhantomData,
+        }
+    }
+
+    fn as_ptr(&mut self) -> *mut PgHdr {
+        self.ptr
+    }
+
+    fn all_applied(&self) -> bool {
+        all_applied(self.ptr)
+    }
+}
+
+impl Drop for Headers<'_> {
+    fn drop(&mut self) {
+        let mut current = self.ptr;
+        while !current.is_null() {
+            let h: Box<PgHdr> = unsafe { Box::from_raw(current as _) };
+            current = h.pDirty;
+        }
+    }
+}
+
+impl Frames {
+    fn to_headers(&self) -> (Headers, u64, u32) {
+        match self {
+            Frames::Vec(frames) => make_page_header(frames.iter().map(|f| &**f)),
+            Frames::Snapshot(snap) => make_page_header(snap.iter()),
+        }
+    }
+}
+
+init_static_wal_method!(INJECTOR_METHODS, InjectorHook);
+
+/// The injector hook hijacks a call to xframes, and replace the content of the call with it's own
+/// frames.
+/// The Caller must first call `set_frames`, passing the frames to be injected, then trigger a call
+/// to xFrames from the libsql connection (see dummy write in `injector`), and can then collect the
+/// result on the injection with `take_result`
+pub enum InjectorHook {}
+
+pub struct InjectorHookCtx {
+    /// slot for the frames to be applied by the next call to xframe
+    receiver: tokio::sync::mpsc::Receiver<Frames>,
+    /// currently in a txn
+    pub is_txn: bool,
+    /// invoked before injecting frames
+    pre_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()>>,
+    /// invoked after injecting frames
+    post_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()>>,
+}
+
+impl InjectorHookCtx {
+    pub fn new(
+        receiver: tokio::sync::mpsc::Receiver<Frames>,
+        pre_commit: impl Fn(FrameNo) -> anyhow::Result<()> + 'static + Send,
+        post_commit: impl Fn(FrameNo) -> anyhow::Result<()> + 'static + Send,
+    ) -> Self {
+        Self {
+            receiver,
+            is_txn: false,
+            pre_commit: Box::new(pre_commit),
+            post_commit: Box::new(post_commit),
+        }
+    }
+
+    fn inject_pages(
+        &mut self,
+        mut page_headers: Headers,
+        last_frame_no: u64,
+        size_after: u32,
+        sync_flags: i32,
+        orig: XWalFrameFn,
+        wal: *mut Wal,
+    ) -> anyhow::Result<()> {
+        self.is_txn = true;
+        if size_after != 0 {
+            (self.pre_commit)(last_frame_no)?;
+        }
+
+        let ret = unsafe {
+            orig(
+                wal,
+                WAL_PAGE_SIZE,
+                page_headers.as_ptr(),
+                size_after,
+                (size_after != 0) as _,
+                sync_flags,
+            )
+        };
+
+        if ret == 0 {
+            debug_assert!(page_headers.all_applied());
+            if size_after != 0 {
+                (self.post_commit)(last_frame_no)?;
+                self.is_txn = false;
+            }
+            tracing::trace!("applied frame batch");
+
+            Ok(())
+        } else {
+            anyhow::bail!("failed to apply pages");
+        }
+    }
+}
+
+unsafe impl WalHook for InjectorHook {
+    type Context = InjectorHookCtx;
+
+    fn on_frames(
+        wal: &mut Wal,
+        _page_size: c_int,
+        _page_headers: *mut PgHdr,
+        _size_after: u32,
+        _is_commit: c_int,
+        sync_flags: c_int,
+        orig: XWalFrameFn,
+    ) -> c_int {
+        let wal_ptr = wal as *mut _;
+        let ctx = Self::wal_extract_ctx(wal);
+        loop {
+            match ctx.receiver.blocking_recv() {
+                Some(frames) => {
+                    let (headers, last_frame_no, size_after) = frames.to_headers();
+
+                    let ret = ctx.inject_pages(
+                        headers,
+                        last_frame_no,
+                        size_after,
+                        sync_flags,
+                        orig,
+                        wal_ptr,
+                    );
+
+                    if let Err(e) = ret {
+                        tracing::error!("replication error: {e}");
+                        return SQLITE_ERROR as c_int;
+                    }
+
+                    if !ctx.is_txn {
+                        return LIBSQL_CONTINUE_REPLICATION as c_int;
+                    }
+                }
+                None => {
+                    tracing::warn!("replication channel closed");
+                    return LIBSQL_EXIT_REPLICATION as c_int;
+                }
+            }
+        }
+    }
+
+    fn name() -> &'static CStr {
+        CStr::from_bytes_with_nul(b"frame_injector_hook\0").unwrap()
+    }
+}
+
+/// Turn a list of `WalFrame` into a list of PgHdr.
+/// The caller has the responsibility to free the returned headers.
+/// return (headers, last_frame_no, size_after)
+fn make_page_header<'a>(
+    frames: impl Iterator<Item = &'a FrameBorrowed>,
+) -> (Headers<'a>, u64, u32) {
+    let mut first_pg: *mut PgHdr = std::ptr::null_mut();
+    let mut current_pg;
+    let mut last_frame_no = 0;
+    let mut size_after = 0;
+
+    let mut headers_count = 0;
+    let mut prev_pg: *mut PgHdr = std::ptr::null_mut();
+    for frame in frames {
+        if frame.header().frame_no > last_frame_no {
+            last_frame_no = frame.header().frame_no;
+            size_after = frame.header().size_after;
+        }
+
+        let page = PgHdr {
+            pPage: std::ptr::null_mut(),
+            pData: frame.page().as_ptr() as _,
+            pExtra: std::ptr::null_mut(),
+            pCache: std::ptr::null_mut(),
+            pDirty: std::ptr::null_mut(),
+            pPager: std::ptr::null_mut(),
+            pgno: frame.header().page_no,
+            pageHash: 0,
+            flags: 0x02, // PGHDR_DIRTY - it works without the flag, but why risk it
+            nRef: 0,
+            pDirtyNext: std::ptr::null_mut(),
+            pDirtyPrev: std::ptr::null_mut(),
+        };
+        headers_count += 1;
+        current_pg = Box::into_raw(Box::new(page));
+        if first_pg.is_null() {
+            first_pg = current_pg;
+        }
+        if !prev_pg.is_null() {
+            unsafe {
+                (*prev_pg).pDirty = current_pg;
+            }
+        }
+        prev_pg = current_pg;
+    }
+
+    tracing::trace!("built {headers_count} page headers");
+
+    let headers = unsafe { Headers::new(first_pg) };
+    (headers, last_frame_no, size_after)
+}
+
+/// Debug assertion. Make sure that all the pages have been applied
+fn all_applied(headers: *const PgHdr) -> bool {
+    let mut current = headers;
+    while !current.is_null() {
+        unsafe {
+            // WAL appended
+            if (*current).flags & 0x040 == 0 {
+                return false;
+            }
+            current = (*current).pDirty;
+        }
+    }
+
+    true
+}

--- a/crates/replication/src/replica/injector.rs
+++ b/crates/replication/src/replica/injector.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use crate::replica::hook::{LIBSQL_CONTINUE_REPLICATION, LIBSQL_EXIT_REPLICATION};
+
+use super::hook::{InjectorHookCtx, INJECTOR_METHODS};
+
+pub struct FrameInjector<'a> {
+    conn: libsql_sys::Connection<'a>,
+}
+
+impl<'a> FrameInjector<'a> {
+    pub fn new(db_path: &Path, hook_ctx: &'a mut InjectorHookCtx) -> anyhow::Result<Self> {
+        let conn = libsql_sys::Connection::open(
+            db_path,
+            (libsql_sys::ffi::SQLITE_OPEN_READWRITE
+                | libsql_sys::ffi::SQLITE_OPEN_CREATE
+                | libsql_sys::ffi::SQLITE_OPEN_URI
+                | libsql_sys::ffi::SQLITE_OPEN_NOMUTEX) as std::ffi::c_int,
+            &INJECTOR_METHODS,
+            hook_ctx,
+        )
+        .map_err(|e| anyhow::anyhow!("Open failed: {e}"))?;
+
+        Ok(Self { conn })
+    }
+
+    pub fn step(&mut self) -> anyhow::Result<bool> {
+        // pragma writable_schema=on
+        unsafe {
+            libsql_sys::ffi::sqlite3_exec(
+                self.conn.conn,
+                "pragma writable_schema=on\0".as_ptr() as *const _,
+                None,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            );
+        }
+
+        let rc = unsafe {
+            libsql_sys::ffi::sqlite3_exec(
+                self.conn.conn,
+                "create table __dummy__ (dummy);\0".as_ptr() as *const _,
+                None,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+
+        match rc as u32 {
+            libsql_sys::ffi::SQLITE_OK => panic!("replication hook was not called"),
+            LIBSQL_EXIT_REPLICATION => {
+                // pragma writable_schema=off
+                unsafe {
+                    libsql_sys::ffi::sqlite3_exec(
+                        self.conn.conn,
+                        "pragma writable_schema=off\0".as_ptr() as *const _,
+                        None,
+                        std::ptr::null_mut(),
+                        std::ptr::null_mut(),
+                    );
+                }
+                return Ok(false);
+            }
+            LIBSQL_CONTINUE_REPLICATION => return Ok(true),
+            _ => panic!("unexpected error code: {}", rc),
+        }
+    }
+}

--- a/crates/replication/src/replica/injector.rs
+++ b/crates/replication/src/replica/injector.rs
@@ -45,7 +45,6 @@ impl<'a> FrameInjector<'a> {
                 std::ptr::null_mut(),
             )
         };
-
         match rc as u32 {
             libsql_sys::ffi::SQLITE_OK => panic!("replication hook was not called"),
             LIBSQL_EXIT_REPLICATION => {

--- a/crates/replication/src/replica/meta.rs
+++ b/crates/replication/src/replica/meta.rs
@@ -1,0 +1,100 @@
+use std::fs::{File, OpenOptions};
+use std::io::ErrorKind;
+use std::mem::size_of;
+use std::os::unix::prelude::FileExt;
+use std::path::Path;
+use std::str::FromStr;
+
+use anyhow::Context;
+use bytemuck::{try_pod_read_unaligned, Pod, Zeroable};
+use uuid::Uuid;
+
+use crate::{replication_log::rpc::HelloResponse, FrameNo};
+
+use super::error::ReplicationError;
+
+#[repr(C)]
+#[derive(Debug, Pod, Zeroable, Clone, Copy)]
+pub struct WalIndexMeta {
+    /// This is the anticipated next frame_no to request
+    pub pre_commit_frame_no: FrameNo,
+    /// After we have written the frames back to the wal, we set this value to the same value as
+    /// pre_commit_index
+    /// On startup we check this value against the pre-commit value to check for consistency
+    pub post_commit_frame_no: FrameNo,
+    /// Generation Uuid
+    /// This number is generated on each primary restart. This let's us know that the primary, and
+    /// we need to make sure that we are not ahead of the primary.
+    generation_id: u128,
+    /// Uuid of the database this instance is a replica of
+    database_id: u128,
+}
+
+impl WalIndexMeta {
+    pub fn read_from_path(db_path: &Path) -> anyhow::Result<(Option<Self>, File)> {
+        let path = db_path.join("client_wal_index");
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(path)?;
+
+        Ok((Self::read(&file)?, file))
+    }
+
+    fn read(file: &File) -> anyhow::Result<Option<Self>> {
+        let mut buf = [0; size_of::<WalIndexMeta>()];
+        let meta = match file.read_exact_at(&mut buf, 0) {
+            Ok(()) => {
+                file.read_exact_at(&mut buf, 0)?;
+                let meta: Self = try_pod_read_unaligned(&buf)
+                    .map_err(|_| anyhow::anyhow!("invalid index meta file"))?;
+                Some(meta)
+            }
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => None,
+            Err(e) => Err(e)?,
+        };
+
+        Ok(meta)
+    }
+
+    /// attempts to merge two meta files.
+    pub fn merge_from_hello(mut self, hello: HelloResponse) -> Result<Self, ReplicationError> {
+        let hello_db_id = Uuid::from_str(&hello.database_id)
+            .context("invalid database id from primary")?
+            .as_u128();
+        let hello_gen_id = Uuid::from_str(&hello.generation_id)
+            .context("invalid generation id from primary")?
+            .as_u128();
+
+        if hello_db_id != self.database_id {
+            return Err(ReplicationError::DbIncompatible);
+        }
+
+        if self.generation_id == hello_gen_id {
+            Ok(self)
+        } else if self.pre_commit_frame_no <= hello.generation_start_index {
+            // Ok: generation changed, but we aren't ahead of primary
+            self.generation_id = hello_gen_id;
+            Ok(self)
+        } else {
+            Err(ReplicationError::Lagging)
+        }
+    }
+
+    pub fn new_from_hello(hello: HelloResponse) -> anyhow::Result<WalIndexMeta> {
+        let database_id = Uuid::from_str(&hello.database_id)
+            .context("invalid database id from primary")?
+            .as_u128();
+        let generation_id = Uuid::from_str(&hello.generation_id)
+            .context("invalid generation id from primary")?
+            .as_u128();
+
+        Ok(Self {
+            pre_commit_frame_no: FrameNo::MAX,
+            post_commit_frame_no: FrameNo::MAX,
+            generation_id,
+            database_id,
+        })
+    }
+}

--- a/crates/replication/src/replica/mod.rs
+++ b/crates/replication/src/replica/mod.rs
@@ -1,0 +1,8 @@
+mod error;
+mod hook;
+mod injector;
+mod meta;
+mod replicator;
+mod snapshot;
+
+pub use replicator::Replicator;

--- a/crates/replication/src/replica/replicator.rs
+++ b/crates/replication/src/replica/replicator.rs
@@ -1,0 +1,241 @@
+use std::os::unix::prelude::FileExt;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::bail;
+use bytemuck::bytes_of;
+use futures::StreamExt;
+use parking_lot::Mutex;
+use tokio::sync::{mpsc, watch};
+use tonic::transport::Channel;
+
+use crate::frame::Frame;
+use crate::replica::error::ReplicationError;
+use crate::replica::snapshot::TempSnapshot;
+use crate::replication_log::rpc::{
+    replication_log_client::ReplicationLogClient, HelloRequest, LogOffset,
+};
+use crate::replication_log::NEED_SNAPSHOT_ERROR_MSG;
+use crate::FrameNo;
+use crate::HARD_RESET;
+
+use super::hook::{Frames, InjectorHookCtx};
+use super::injector::FrameInjector;
+use super::meta::WalIndexMeta;
+
+const HANDSHAKE_MAX_RETRIES: usize = 100;
+
+type Client = ReplicationLogClient<Channel>;
+
+/// The `Replicator` duty is to download frames from the primary, and pass them to the injector at
+/// transaction boundaries.
+pub struct Replicator {
+    client: Client,
+    db_path: PathBuf,
+    meta: Arc<Mutex<Option<WalIndexMeta>>>,
+    pub current_frame_no_notifier: watch::Receiver<FrameNo>,
+    allow_replica_overwrite: bool,
+    frames_sender: mpsc::Sender<Frames>,
+}
+
+impl Replicator {
+    pub fn new(
+        db_path: PathBuf,
+        channel: Channel,
+        uri: tonic::transport::Uri,
+        allow_replica_overwrite: bool,
+    ) -> anyhow::Result<Self> {
+        let client = Client::with_origin(channel, uri);
+        let (meta, meta_file) = WalIndexMeta::read_from_path(&db_path)?;
+        let meta_file = Arc::new(meta_file);
+        let (applied_frame_notifier, current_frame_no_notifier) =
+            watch::channel(meta.map(|m| m.post_commit_frame_no).unwrap_or(FrameNo::MAX));
+        let meta = Arc::new(Mutex::new(meta));
+        let (frames_sender, receiver) = tokio::sync::mpsc::channel(1);
+
+        let pre_commit = {
+            let meta = meta.clone();
+            let meta_file = meta_file.clone();
+            move |fno| {
+                let mut lock = meta.lock();
+                let meta = lock
+                    .as_mut()
+                    .expect("commit called before meta inialization");
+                meta.pre_commit_frame_no = fno;
+                meta_file.write_all_at(bytes_of(meta), 0)?;
+
+                Ok(())
+            }
+        };
+
+        let post_commit = {
+            let meta = meta.clone();
+            let meta_file = meta_file;
+            let notifier = applied_frame_notifier;
+            move |fno| {
+                let mut lock = meta.lock();
+                let meta = lock
+                    .as_mut()
+                    .expect("commit called before meta inialization");
+                assert_eq!(meta.pre_commit_frame_no, fno);
+                meta.post_commit_frame_no = fno;
+                meta_file.write_all_at(bytes_of(meta), 0)?;
+                let _ = notifier.send(fno);
+
+                Ok(())
+            }
+        };
+
+        tokio::task::spawn_blocking({
+            let db_path = db_path.clone();
+            move || -> anyhow::Result<()> {
+                let mut ctx = InjectorHookCtx::new(receiver, pre_commit, post_commit);
+                let mut injector = FrameInjector::new(&db_path, &mut ctx)?;
+
+                while injector.step()? {}
+
+                Ok(())
+            }
+        });
+
+        Ok(Self {
+            client,
+            db_path,
+            current_frame_no_notifier,
+            allow_replica_overwrite,
+            meta,
+            frames_sender,
+        })
+    }
+
+    pub async fn run(mut self) -> anyhow::Result<()> {
+        loop {
+            self.try_perform_handshake().await?;
+
+            if let Err(e) = self.replicate().await {
+                // Replication encountered an error. We log the error, and then shut down the
+                // injector and propagate a potential panic from there.
+                tracing::warn!("replication error: {e}");
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    async fn try_perform_handshake(&mut self) -> anyhow::Result<()> {
+        let mut error_printed = false;
+        for _ in 0..HANDSHAKE_MAX_RETRIES {
+            tracing::info!("Attempting to perform handshake with primary.");
+            match self.client.hello(HelloRequest {}).await {
+                Ok(resp) => {
+                    let hello = resp.into_inner();
+                    return tokio::task::block_in_place(|| {
+                        let mut lock = self.meta.lock();
+                        let meta = match *lock {
+                            Some(meta) => match meta.merge_from_hello(hello) {
+                                Ok(meta) => meta,
+                                Err(e @ ReplicationError::Lagging) => {
+                                    tracing::error!(
+                                        "Replica ahead of primary: hard-reseting replica"
+                                    );
+                                    HARD_RESET.notify_waiters();
+
+                                    anyhow::bail!(e);
+                                }
+                                Err(e @ ReplicationError::DbIncompatible)
+                                    if self.allow_replica_overwrite =>
+                                {
+                                    tracing::error!("Primary is attempting to replicate a different database, overwriting replica.");
+                                    HARD_RESET.notify_waiters();
+
+                                    anyhow::bail!(e);
+                                }
+                                Err(e) => anyhow::bail!(e),
+                            },
+                            None => WalIndexMeta::new_from_hello(hello)?,
+                        };
+
+                        *lock = Some(meta);
+
+                        Ok(())
+                    });
+                }
+                Err(e) if !error_printed => {
+                    tracing::error!("error connecting to primary. retrying. error: {e}");
+                    error_printed = true;
+                }
+                _ => (),
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+
+        bail!("couldn't connect to primary after {HANDSHAKE_MAX_RETRIES} tries.");
+    }
+
+    async fn replicate(&mut self) -> anyhow::Result<()> {
+        const MAX_REPLICA_REPLICATION_BUFFER_LEN: usize = 10_000_000 / 4096; // ~10MB
+        let offset = LogOffset {
+            // if current == FrameNo::Max then it means that we're starting fresh
+            next_offset: self.next_offset(),
+        };
+        let mut stream = self.client.log_entries(offset).await?.into_inner();
+
+        let mut buffer = Vec::new();
+        loop {
+            match stream.next().await {
+                Some(Ok(frame)) => {
+                    let frame = Frame::try_from_bytes(frame.data)?;
+                    buffer.push(frame.clone());
+                    if frame.header().size_after != 0
+                        || buffer.len() > MAX_REPLICA_REPLICATION_BUFFER_LEN
+                    {
+                        let _ = self
+                            .frames_sender
+                            .send(Frames::Vec(std::mem::take(&mut buffer)))
+                            .await;
+                    }
+                }
+                Some(Err(err))
+                    if err.code() == tonic::Code::FailedPrecondition
+                        && err.message() == NEED_SNAPSHOT_ERROR_MSG =>
+                {
+                    tracing::debug!("loading snapshot");
+                    // remove any outstanding frames in the buffer that are not part of a
+                    // transaction: they are now part of the snapshot.
+                    buffer.clear();
+                    self.load_snapshot().await?;
+                }
+                Some(Err(e)) => return Err(e.into()),
+                None => return Ok(()),
+            }
+        }
+    }
+
+    async fn load_snapshot(&mut self) -> anyhow::Result<()> {
+        let next_offset = self.next_offset();
+        let frames = self
+            .client
+            .snapshot(LogOffset { next_offset })
+            .await?
+            .into_inner();
+
+        let stream = frames.map(|data| match data {
+            Ok(frame) => Frame::try_from_bytes(frame.data),
+            Err(e) => anyhow::bail!(e),
+        });
+        let snap = TempSnapshot::from_stream(&self.db_path, stream).await?;
+
+        let _ = self.frames_sender.send(Frames::Snapshot(snap)).await;
+
+        Ok(())
+    }
+
+    fn next_offset(&mut self) -> FrameNo {
+        self.current_frame_no().map(|x| x + 1).unwrap_or(0)
+    }
+
+    fn current_frame_no(&mut self) -> Option<FrameNo> {
+        let current = *self.current_frame_no_notifier.borrow_and_update();
+        (current != FrameNo::MAX).then_some(current)
+    }
+}

--- a/crates/replication/src/replica/replicator.rs
+++ b/crates/replication/src/replica/replicator.rs
@@ -92,9 +92,7 @@ impl Replicator {
             move || -> anyhow::Result<()> {
                 let mut ctx = InjectorHookCtx::new(receiver, pre_commit, post_commit);
                 let mut injector = FrameInjector::new(&db_path, &mut ctx)?;
-
                 while injector.step()? {}
-
                 Ok(())
             }
         });

--- a/crates/replication/src/replica/snapshot.rs
+++ b/crates/replication/src/replica/snapshot.rs
@@ -1,0 +1,50 @@
+use std::path::{Path, PathBuf};
+
+use futures::{Stream, StreamExt};
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncWriteExt, BufWriter};
+
+use crate::frame::{Frame, FrameBorrowed};
+
+#[derive(Debug)]
+pub struct TempSnapshot {
+    path: PathBuf,
+    map: memmap::Mmap,
+}
+
+impl TempSnapshot {
+    pub async fn from_stream(
+        db_path: &Path,
+        mut s: impl Stream<Item = anyhow::Result<Frame>> + Unpin,
+    ) -> anyhow::Result<Self> {
+        let temp_dir = db_path.join("temp");
+        tokio::fs::create_dir_all(&temp_dir).await?;
+        let file = NamedTempFile::new_in(temp_dir)?;
+        let tokio_file = tokio::fs::File::from_std(file.as_file().try_clone()?);
+
+        let mut tokio_file = BufWriter::new(tokio_file);
+        while let Some(frame) = s.next().await {
+            let frame = frame?;
+            tokio_file.write_all(frame.as_slice()).await?;
+        }
+
+        tokio_file.flush().await?;
+
+        let (file, path) = file.keep()?;
+
+        let map = unsafe { memmap::Mmap::map(&file)? };
+
+        Ok(Self { path, map })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &FrameBorrowed> {
+        self.map.chunks(Frame::SIZE).map(FrameBorrowed::from_bytes)
+    }
+}
+
+impl Drop for TempSnapshot {
+    fn drop(&mut self) {
+        let path = std::mem::take(&mut self.path);
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/replication/src/replication_log.rs
+++ b/crates/replication/src/replication_log.rs
@@ -1,0 +1,140 @@
+pub mod rpc {
+    #![allow(clippy::all)]
+    tonic::include_proto!("wal_log");
+}
+
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::{Arc, RwLock};
+
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Status;
+
+use crate::primary::frame_stream::FrameStream;
+use crate::{LogReadError, ReplicationLogger};
+
+use self::rpc::replication_log_server::ReplicationLog;
+use self::rpc::{Frame, HelloRequest, HelloResponse, LogOffset};
+
+pub struct ReplicationLogService {
+    logger: Arc<ReplicationLogger>,
+    replicas_with_hello: RwLock<HashSet<SocketAddr>>,
+}
+
+pub const NO_HELLO_ERROR_MSG: &str = "NO_HELLO";
+pub const NEED_SNAPSHOT_ERROR_MSG: &str = "NEED_SNAPSHOT";
+
+impl ReplicationLogService {
+    pub fn new(logger: Arc<ReplicationLogger>) -> Self {
+        Self {
+            logger,
+            replicas_with_hello: RwLock::new(HashSet::<SocketAddr>::new()),
+        }
+    }
+}
+
+fn map_frame_stream_output(r: Result<crate::frame::Frame, LogReadError>) -> Result<Frame, Status> {
+    match r {
+        Ok(frame) => Ok(Frame {
+            data: frame.bytes(),
+        }),
+        Err(LogReadError::SnapshotRequired) => Err(Status::new(
+            tonic::Code::FailedPrecondition,
+            NEED_SNAPSHOT_ERROR_MSG,
+        )),
+        Err(LogReadError::Error(e)) => Err(Status::new(tonic::Code::Internal, e.to_string())),
+        // this error should be caught before, but we handle it nicely anyways
+        Err(LogReadError::Ahead) => Err(Status::new(
+            tonic::Code::OutOfRange,
+            "frame not yet available",
+        )),
+    }
+}
+
+#[tonic::async_trait]
+impl ReplicationLog for ReplicationLogService {
+    type LogEntriesStream = BoxStream<'static, Result<Frame, Status>>;
+    type SnapshotStream = BoxStream<'static, Result<Frame, Status>>;
+
+    async fn log_entries(
+        &self,
+        req: tonic::Request<LogOffset>,
+    ) -> Result<tonic::Response<Self::LogEntriesStream>, Status> {
+        let replica_addr = req
+            .remote_addr()
+            .ok_or(Status::internal("No remote RPC address"))?;
+        {
+            let guard = self.replicas_with_hello.read().unwrap();
+            if !guard.contains(&replica_addr) {
+                return Err(Status::failed_precondition(NO_HELLO_ERROR_MSG));
+            }
+        }
+
+        let stream = FrameStream::new(self.logger.clone(), req.into_inner().next_offset)
+            .map(map_frame_stream_output)
+            .boxed();
+
+        Ok(tonic::Response::new(stream))
+    }
+
+    async fn hello(
+        &self,
+        req: tonic::Request<HelloRequest>,
+    ) -> Result<tonic::Response<HelloResponse>, Status> {
+        let replica_addr = req
+            .remote_addr()
+            .ok_or(Status::internal("No remote RPC address"))?;
+        {
+            let mut guard = self.replicas_with_hello.write().unwrap();
+            guard.insert(replica_addr);
+        }
+        let response = HelloResponse {
+            database_id: self.logger.database_id().unwrap().to_string(),
+            generation_start_index: self.logger.generation.start_index,
+            generation_id: self.logger.generation.id.to_string(),
+        };
+
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn snapshot(
+        &self,
+        req: tonic::Request<LogOffset>,
+    ) -> Result<tonic::Response<Self::SnapshotStream>, Status> {
+        let (sender, receiver) = mpsc::channel(10);
+        let logger = self.logger.clone();
+        let offset = req.into_inner().next_offset;
+        match tokio::task::spawn_blocking(move || logger.get_snapshot_file(offset)).await {
+            Ok(Ok(Some(snapshot))) => {
+                tokio::task::spawn_blocking(move || {
+                    let mut frames = snapshot.frames_iter_from(offset);
+                    loop {
+                        match frames.next() {
+                            Some(Ok(data)) => {
+                                let _ = sender.blocking_send(Ok(Frame { data }));
+                            }
+                            Some(Err(e)) => {
+                                let _ = sender.blocking_send(Err(Status::new(
+                                    tonic::Code::Internal,
+                                    e.to_string(),
+                                )));
+                                break;
+                            }
+                            None => {
+                                break;
+                            }
+                        }
+                    }
+                });
+
+                Ok(tonic::Response::new(ReceiverStream::new(receiver).boxed()))
+            }
+            Ok(Ok(None)) => Err(Status::new(tonic::Code::Unavailable, "snapshot not found")),
+            Err(e) => Err(Status::new(tonic::Code::Internal, e.to_string())),
+            Ok(Err(e)) => Err(Status::new(tonic::Code::Internal, e.to_string())),
+        }
+    }
+}

--- a/crates/replication/src/replication_log.rs
+++ b/crates/replication/src/replication_log.rs
@@ -138,3 +138,15 @@ impl ReplicationLog for ReplicationLogService {
         }
     }
 }
+
+// TODO: original code accepted a config file and a bunch of TLS params, we need that here as well
+pub fn configure_rpc(writer_rpc_addr: impl Into<String>) -> anyhow::Result<(tonic::transport::Channel, tonic::transport::Uri)> {
+    let writer_rpc_addr = writer_rpc_addr.into();
+    let endpoint = tonic::transport::Channel::from_shared(writer_rpc_addr.clone())?;
+
+    let channel = endpoint.connect_lazy();
+    let uri = tonic::transport::Uri::from_maybe_shared(writer_rpc_addr)?;
+
+    Ok((channel, uri))
+}
+

--- a/crates/replication/src/snapshot.rs
+++ b/crates/replication/src/snapshot.rs
@@ -1,0 +1,535 @@
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::BufWriter;
+use std::io::Write;
+use std::mem::size_of;
+use std::os::unix::prelude::FileExt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+use anyhow::Context;
+use bytemuck::{bytes_of, pod_read_unaligned, Pod, Zeroable};
+use bytes::{Bytes, BytesMut};
+use crossbeam::channel::bounded;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use tempfile::NamedTempFile;
+use uuid::Uuid;
+
+use super::frame::Frame;
+use super::primary::logger::LogFile;
+use super::FrameNo;
+
+/// This is the ratio of the space required to store snapshot vs size of the actual database.
+/// When this ratio is exceeded, compaction is triggered.
+const SNAPHOT_SPACE_AMPLIFICATION_FACTOR: u64 = 2;
+/// The maximum amount of snapshot allowed before a compaction is required
+const MAX_SNAPSHOT_NUMBER: usize = 32;
+
+#[derive(Debug, Copy, Clone, Zeroable, Pod, PartialEq, Eq)]
+#[repr(C)]
+pub struct SnapshotFileHeader {
+    /// id of the database
+    pub db_id: u128,
+    /// first frame in the snapshot
+    pub start_frame_no: u64,
+    /// end frame in the snapshot
+    pub end_frame_no: u64,
+    /// number of frames in the snapshot
+    pub frame_count: u64,
+    /// safe of the database after applying the snapshot
+    pub size_after: u32,
+    pub _pad: u32,
+}
+
+pub struct SnapshotFile {
+    file: File,
+    header: SnapshotFileHeader,
+}
+
+/// returns (db_id, start_frame_no, end_frame_no) for the given snapshot name
+fn parse_snapshot_name(name: &str) -> Option<(Uuid, u64, u64)> {
+    static SNAPSHOT_FILE_MATCHER: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r#"(?x)
+            # match database id
+            (\w{8}-\w{4}-\w{4}-\w{4}-\w{12})-
+            # match start frame_no
+            (\d*)-
+            # match end frame_no
+            (\d*).snap"#,
+        )
+        .unwrap()
+    });
+    let Some(captures) = SNAPSHOT_FILE_MATCHER.captures(name) else { return None};
+    let db_id = captures.get(1).unwrap();
+    let start_index: u64 = captures.get(2).unwrap().as_str().parse().unwrap();
+    let end_index: u64 = captures.get(3).unwrap().as_str().parse().unwrap();
+
+    Some((
+        Uuid::from_str(db_id.as_str()).unwrap(),
+        start_index,
+        end_index,
+    ))
+}
+
+fn snapshot_list(db_path: &Path) -> anyhow::Result<impl Iterator<Item = String>> {
+    let mut entries = std::fs::read_dir(snapshot_dir_path(db_path))?;
+    Ok(std::iter::from_fn(move || {
+        for entry in entries.by_ref() {
+            let Ok(entry) = entry else { continue; };
+            let path = entry.path();
+            let Some(name) = path.file_name() else {continue;};
+            let Some(name_str) = name.to_str() else { continue;};
+
+            return Some(name_str.to_string());
+        }
+        None
+    }))
+}
+
+/// Return snapshot file containing "logically" frame_no
+pub fn find_snapshot_file(
+    db_path: &Path,
+    frame_no: FrameNo,
+) -> anyhow::Result<Option<SnapshotFile>> {
+    let snapshot_dir_path = snapshot_dir_path(db_path);
+    for name in snapshot_list(db_path)? {
+        let Some((_, start_frame_no, end_frame_no)) = parse_snapshot_name(&name) else { continue; };
+        // we're looking for the frame right after the last applied frame on the replica
+        if (start_frame_no..=end_frame_no).contains(&frame_no) {
+            let snapshot_path = snapshot_dir_path.join(&name);
+            tracing::debug!("found snapshot for frame {frame_no} at {snapshot_path:?}");
+            let snapshot_file = SnapshotFile::open(&snapshot_path)?;
+            return Ok(Some(snapshot_file));
+        }
+    }
+
+    Ok(None)
+}
+
+impl SnapshotFile {
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        let file = File::open(path)?;
+        let mut header_buf = [0; size_of::<SnapshotFileHeader>()];
+        file.read_exact_at(&mut header_buf, 0)?;
+        let header: SnapshotFileHeader = pod_read_unaligned(&header_buf);
+
+        Ok(Self { file, header })
+    }
+
+    /// Iterator on the frames contained in the snapshot file, in reverse frame_no order.
+    pub fn frames_iter(&self) -> impl Iterator<Item = anyhow::Result<Bytes>> + '_ {
+        let mut current_offset = 0;
+        std::iter::from_fn(move || {
+            if current_offset >= self.header.frame_count {
+                return None;
+            }
+            let read_offset = size_of::<SnapshotFileHeader>() as u64
+                + current_offset * LogFile::FRAME_SIZE as u64;
+            current_offset += 1;
+            let mut buf = BytesMut::zeroed(LogFile::FRAME_SIZE);
+            match self.file.read_exact_at(&mut buf, read_offset as _) {
+                Ok(_) => Some(Ok(buf.freeze())),
+                Err(e) => Some(Err(e.into())),
+            }
+        })
+    }
+
+    /// Like `frames_iter`, but stops as soon as a frame with frame_no <= `frame_no` is reached
+    pub fn frames_iter_from(
+        &self,
+        frame_no: u64,
+    ) -> impl Iterator<Item = anyhow::Result<Bytes>> + '_ {
+        let mut iter = self.frames_iter();
+        std::iter::from_fn(move || match iter.next() {
+            Some(Ok(bytes)) => match Frame::try_from_bytes(bytes.clone()) {
+                Ok(frame) => {
+                    if frame.header().frame_no < frame_no {
+                        None
+                    } else {
+                        Some(Ok(bytes))
+                    }
+                }
+                Err(e) => Some(Err(e)),
+            },
+            other => other,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct LogCompactor {
+    sender: crossbeam::channel::Sender<(LogFile, PathBuf, u32)>,
+}
+
+impl LogCompactor {
+    pub fn new(db_path: &Path, db_id: u128) -> anyhow::Result<Self> {
+        // we create a 0 sized channel, in order to create backpressure when we can't
+        // keep up with snapshop creation: if there isn't any ongoind comptaction task processing,
+        // the compact does not block, and the log is compacted in the background. Otherwise, the
+        // block until there is a free slot to perform compaction.
+        let (sender, receiver) = bounded::<(LogFile, PathBuf, u32)>(0);
+        let mut merger = SnapshotMerger::new(db_path, db_id)?;
+        let db_path = db_path.to_path_buf();
+        let _handle = std::thread::spawn(move || {
+            while let Ok((file, log_path, size_after)) = receiver.recv() {
+                match perform_compaction(&db_path, file, db_id) {
+                    Ok((snapshot_name, snapshot_frame_count)) => {
+                        tracing::info!("snapshot `{snapshot_name}` successfully created");
+                        if let Err(e) = merger.register_snapshot(
+                            snapshot_name,
+                            snapshot_frame_count,
+                            size_after,
+                        ) {
+                            tracing::error!(
+                                "failed to register snapshot with snapshot merger: {e}"
+                            );
+                            break;
+                        }
+
+                        if let Err(e) = std::fs::remove_file(&log_path) {
+                            tracing::error!(
+                                "failed to remove old log file `{}`: {e}",
+                                log_path.display()
+                            );
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("fatal error creating snapshot: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(Self { sender })
+    }
+
+    /// Sends a compaction task to the background compaction thread. Blocks if a compaction task is
+    /// already ongoing.
+    pub fn compact(&self, file: LogFile, path: PathBuf, size_after: u32) -> anyhow::Result<()> {
+        self.sender
+            .send((file, path, size_after))
+            .context("failed to compact log: log compactor thread exited")?;
+
+        Ok(())
+    }
+}
+
+struct SnapshotMerger {
+    /// Sending part of a channel of (snapshot_name, snapshot_frame_count, db_page_count) to the merger thread
+    sender: mpsc::Sender<(String, u64, u32)>,
+    handle: Option<JoinHandle<anyhow::Result<()>>>,
+}
+
+impl SnapshotMerger {
+    fn new(db_path: &Path, db_id: u128) -> anyhow::Result<Self> {
+        let (sender, receiver) = mpsc::channel();
+
+        let db_path = db_path.to_path_buf();
+        let handle =
+            std::thread::spawn(move || Self::run_snapshot_merger_loop(receiver, &db_path, db_id));
+
+        Ok(Self {
+            sender,
+            handle: Some(handle),
+        })
+    }
+
+    fn should_compact(snapshots: &[(String, u64)], db_page_count: u32) -> bool {
+        let snapshots_size: u64 = snapshots.iter().map(|(_, s)| *s).sum();
+        snapshots_size >= SNAPHOT_SPACE_AMPLIFICATION_FACTOR * db_page_count as u64
+            || snapshots.len() > MAX_SNAPSHOT_NUMBER
+    }
+
+    fn run_snapshot_merger_loop(
+        receiver: mpsc::Receiver<(String, u64, u32)>,
+        db_path: &Path,
+        db_id: u128,
+    ) -> anyhow::Result<()> {
+        let mut snapshots = Self::init_snapshot_info_list(db_path)?;
+        while let Ok((name, size, db_page_count)) = receiver.recv() {
+            snapshots.push((name, size));
+            if Self::should_compact(&snapshots, db_page_count) {
+                let compacted_snapshot_info = Self::merge_snapshots(&snapshots, db_path, db_id)?;
+                snapshots.clear();
+                snapshots.push(compacted_snapshot_info);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reads the snapshot dir and returns the list of snapshots along with their size, sorted in
+    /// chronological order.
+    ///
+    /// TODO: if the process was kill in the midst of merging snapshot, then the compacted snapshot
+    /// can exist alongside the snapshots it's supposed to have compacted. This is the place to
+    /// perform the cleanup.
+    fn init_snapshot_info_list(db_path: &Path) -> anyhow::Result<Vec<(String, u64)>> {
+        let snapshot_dir_path = snapshot_dir_path(db_path);
+        if !snapshot_dir_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut temp = Vec::new();
+        for snapshot_name in snapshot_list(db_path)? {
+            let snapshot_path = snapshot_dir_path.join(&snapshot_name);
+            let snapshot = SnapshotFile::open(&snapshot_path)?;
+            temp.push((
+                snapshot_name,
+                snapshot.header.frame_count,
+                snapshot.header.start_frame_no,
+            ))
+        }
+
+        temp.sort_by_key(|(_, _, id)| *id);
+
+        Ok(temp
+            .into_iter()
+            .map(|(name, count, _)| (name, count))
+            .collect())
+    }
+
+    fn merge_snapshots(
+        snapshots: &[(String, u64)],
+        db_path: &Path,
+        db_id: u128,
+    ) -> anyhow::Result<(String, u64)> {
+        let mut builder = SnapshotBuilder::new(db_path, db_id)?;
+        let snapshot_dir_path = snapshot_dir_path(db_path);
+        for (name, _) in snapshots.iter().rev() {
+            let snapshot = SnapshotFile::open(&snapshot_dir_path.join(name))?;
+            let iter = snapshot.frames_iter().map(|b| Frame::try_from_bytes(b?));
+            builder.append_frames(iter)?;
+        }
+
+        let (_, start_frame_no, _) = parse_snapshot_name(&snapshots[0].0).unwrap();
+        let (_, _, end_frame_no) = parse_snapshot_name(&snapshots.last().unwrap().0).unwrap();
+
+        builder.header.start_frame_no = start_frame_no;
+        builder.header.end_frame_no = end_frame_no;
+
+        let compacted_snapshot_infos = builder.finish()?;
+
+        for (name, _) in snapshots.iter() {
+            std::fs::remove_file(&snapshot_dir_path.join(name))?;
+        }
+
+        Ok(compacted_snapshot_infos)
+    }
+
+    fn register_snapshot(
+        &mut self,
+        snapshot_name: String,
+        snapshot_frame_count: u64,
+        db_page_count: u32,
+    ) -> anyhow::Result<()> {
+        if self
+            .sender
+            .send((snapshot_name, snapshot_frame_count, db_page_count))
+            .is_err()
+        {
+            if let Some(handle) = self.handle.take() {
+                handle
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("snapshot merger thread panicked"))??;
+            }
+
+            anyhow::bail!("failed to register snapshot with log merger: thread exited");
+        }
+
+        Ok(())
+    }
+}
+
+/// An utility to build a snapshots from log frames
+struct SnapshotBuilder {
+    seen_pages: HashSet<u32>,
+    header: SnapshotFileHeader,
+    snapshot_file: BufWriter<NamedTempFile>,
+    db_path: PathBuf,
+    last_seen_frame_no: u64,
+}
+
+fn snapshot_dir_path(db_path: &Path) -> PathBuf {
+    db_path.join("snapshots")
+}
+
+impl SnapshotBuilder {
+    fn new(db_path: &Path, db_id: u128) -> anyhow::Result<Self> {
+        let snapshot_dir_path = snapshot_dir_path(db_path);
+        std::fs::create_dir_all(&snapshot_dir_path)?;
+        let mut target = BufWriter::new(NamedTempFile::new_in(&snapshot_dir_path)?);
+        // reserve header space
+        target.write_all(&[0; size_of::<SnapshotFileHeader>()])?;
+
+        Ok(Self {
+            seen_pages: HashSet::new(),
+            header: SnapshotFileHeader {
+                db_id,
+                start_frame_no: u64::MAX,
+                end_frame_no: u64::MIN,
+                frame_count: 0,
+                size_after: 0,
+                _pad: 0,
+            },
+            snapshot_file: target,
+            db_path: db_path.to_path_buf(),
+            last_seen_frame_no: u64::MAX,
+        })
+    }
+
+    /// append frames to the snapshot. Frames must be in decreasing frame_no order.
+    fn append_frames(
+        &mut self,
+        frames: impl Iterator<Item = anyhow::Result<Frame>>,
+    ) -> anyhow::Result<()> {
+        // We iterate on the frames starting from the end of the log and working our way backward. We
+        // make sure that only the most recent version of each file is present in the resulting
+        // snapshot.
+        //
+        // The snapshot file contains the most recent version of each page, in descending frame
+        // number order. That last part is important for when we read it later on.
+        for frame in frames {
+            let frame = frame?;
+            assert!(frame.header().frame_no < self.last_seen_frame_no);
+            self.last_seen_frame_no = frame.header().frame_no;
+            if frame.header().frame_no < self.header.start_frame_no {
+                self.header.start_frame_no = frame.header().frame_no;
+            }
+
+            if frame.header().frame_no > self.header.end_frame_no {
+                self.header.end_frame_no = frame.header().frame_no;
+                self.header.size_after = frame.header().size_after;
+            }
+
+            if !self.seen_pages.contains(&frame.header().page_no) {
+                self.seen_pages.insert(frame.header().page_no);
+                self.snapshot_file.write_all(frame.as_slice())?;
+                self.header.frame_count += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Persist the snapshot, and returns the name and size is frame on the snapshot.
+    fn finish(mut self) -> anyhow::Result<(String, u64)> {
+        self.snapshot_file.flush()?;
+        let file = self.snapshot_file.into_inner()?;
+        file.as_file().write_all_at(bytes_of(&self.header), 0)?;
+        let snapshot_name = format!(
+            "{}-{}-{}.snap",
+            Uuid::from_u128(self.header.db_id),
+            self.header.start_frame_no,
+            self.header.end_frame_no,
+        );
+
+        file.persist(snapshot_dir_path(&self.db_path).join(&snapshot_name))?;
+
+        Ok((snapshot_name, self.header.frame_count))
+    }
+}
+
+fn perform_compaction(
+    db_path: &Path,
+    file_to_compact: LogFile,
+    db_id: u128,
+) -> anyhow::Result<(String, u64)> {
+    let mut builder = SnapshotBuilder::new(db_path, db_id)?;
+    builder.append_frames(file_to_compact.rev_frames_iter()?)?;
+    builder.finish()
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::read;
+    use std::{thread, time::Duration};
+
+    use bytemuck::pod_read_unaligned;
+    use bytes::Bytes;
+    use tempfile::tempdir;
+
+    use crate::frame::FrameHeader;
+    use crate::primary::logger::WalPage;
+    use crate::snapshot::SnapshotFile;
+
+    use super::*;
+
+    #[test]
+    fn compact_file_create_snapshot() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let mut log_file = LogFile::new(temp.as_file().try_clone().unwrap(), 0).unwrap();
+        let db_id = Uuid::new_v4();
+        log_file.header.db_id = db_id.as_u128();
+        log_file.write_header().unwrap();
+
+        // add 50 pages, each one in two versions
+        for _ in 0..2 {
+            for i in 0..25 {
+                let data = std::iter::repeat(0).take(4096).collect::<Bytes>();
+                let page = WalPage {
+                    page_no: i,
+                    size_after: i + 1,
+                    data,
+                };
+                log_file.push_page(&page).unwrap();
+            }
+        }
+
+        log_file.commit().unwrap();
+
+        let dump_dir = tempdir().unwrap();
+        let compactor = LogCompactor::new(dump_dir.path(), db_id.as_u128()).unwrap();
+        compactor
+            .compact(log_file, temp.path().to_path_buf(), 25)
+            .unwrap();
+
+        thread::sleep(Duration::from_secs(1));
+
+        let snapshot_path =
+            snapshot_dir_path(dump_dir.path()).join(format!("{}-{}-{}.snap", db_id, 0, 49));
+        let snapshot = read(&snapshot_path).unwrap();
+        let header: SnapshotFileHeader =
+            pod_read_unaligned(&snapshot[..std::mem::size_of::<SnapshotFileHeader>()]);
+
+        assert_eq!(header.start_frame_no, 0);
+        assert_eq!(header.end_frame_no, 49);
+        assert_eq!(header.frame_count, 25);
+        assert_eq!(header.db_id, db_id.as_u128());
+        assert_eq!(header.size_after, 25);
+
+        let mut seen_frames = HashSet::new();
+        let mut seen_page_no = HashSet::new();
+        let data = &snapshot[std::mem::size_of::<SnapshotFileHeader>()..];
+        data.chunks(LogFile::FRAME_SIZE).for_each(|f| {
+            let frame = Frame::try_from_bytes(Bytes::copy_from_slice(f)).unwrap();
+            assert!(!seen_frames.contains(&frame.header().frame_no));
+            assert!(!seen_page_no.contains(&frame.header().page_no));
+            seen_page_no.insert(frame.header().page_no);
+            seen_frames.insert(frame.header().frame_no);
+            assert!(frame.header().frame_no >= 25);
+        });
+
+        assert_eq!(seen_frames.len(), 25);
+        assert_eq!(seen_page_no.len(), 25);
+
+        let snapshot_file = SnapshotFile::open(&snapshot_path).unwrap();
+
+        let frames = snapshot_file.frames_iter_from(0);
+        let mut expected_frame_no = 49;
+        for frame in frames {
+            let frame = frame.unwrap();
+            let header: FrameHeader = pod_read_unaligned(&frame[..size_of::<FrameHeader>()]);
+            assert_eq!(header.frame_no, expected_frame_no);
+            expected_frame_no -= 1;
+        }
+
+        assert_eq!(expected_frame_no, 24);
+    }
+}


### PR DESCRIPTION
This **draft** transplants our replication code from libsql/sqld to here. It's a draft, because it's a blatant copy-paste, which should first be carefully reviewed and considered, before we merge it upstream. Also, the replication API includes a dependency on tokio, which we want to either not be there at all, or at least be opt-in. Tokio is here because the transplanted `Replicator` class includes a fiber which periodically pulls frames from the primary node, while we only need lower level API, that allows pulling changes whenever we want.