### PR TITLE
libsql/core: Add Statement::reset() method

### DIFF
--- a/crates/core/benches/benchmark.rs
+++ b/crates/core/benches/benchmark.rs
@@ -27,6 +27,7 @@ fn bench(c: &mut Criterion) {
             let rows = stmt.execute(&Params::None).unwrap();
             let row = rows.next().unwrap().unwrap();
             assert_eq!(row.get::<i32>(0).unwrap(), 1);
+            stmt.reset();
         });
     });
 
@@ -43,6 +44,7 @@ fn bench(c: &mut Criterion) {
             let rows = stmt.execute(&Params::None).unwrap();
             let row = rows.next().unwrap().unwrap();
             assert_eq!(row.get::<i32>(0).unwrap(), 1);
+            stmt.reset();
         });
     });
 
@@ -52,6 +54,7 @@ fn bench(c: &mut Criterion) {
             let rows = stmt.execute(&Params::None).unwrap();
             let row = rows.next().unwrap().unwrap();
             assert_eq!(row.get::<i32>(0).unwrap(), 1);
+            stmt.reset();
         });
     });
 }

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -72,7 +72,6 @@ impl Statement {
     }
 
     pub fn execute(&self, params: &Params) -> Option<Rows> {
-        unsafe { libsql_sys::ffi::sqlite3_reset(self.raw_stmt) };
         self.bind(params);
         let err = unsafe { libsql_sys::ffi::sqlite3_step(self.raw_stmt) };
         match err as u32 {
@@ -84,5 +83,10 @@ impl Statement {
                 err: RefCell::new(Some(err)),
             }),
         }
+    }
+
+    /// Reset the prepared statement to initial state for reuse.
+    pub fn reset(&self) {
+        unsafe { libsql_sys::ffi::sqlite3_reset(self.raw_stmt) };
     }
 }


### PR DESCRIPTION
Lift the unconditional call to `sqlite3_reset()` to its own method to avoid calling it for single-shot queries.