### PR TITLE
Add raw API to libSQL core

### DIFF
--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -12,11 +12,6 @@ pub enum Error {
     NullValue,
 }
 
-pub(crate) fn sqlite_error_message(raw: *mut libsql_sys::ffi::sqlite3) -> String {
-    let errmsg = unsafe { libsql_sys::ffi::sqlite3_errmsg(raw) };
-    sqlite_errmsg_to_string(errmsg)
-}
-
 pub(crate) fn sqlite_code_to_error(code: i32) -> String {
     let errmsg = unsafe { libsql_sys::ffi::sqlite3_errstr(code) };
     sqlite_errmsg_to_string(errmsg)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod connection;
 pub mod database;
 pub mod errors;
 pub mod params;
+pub mod raw;
 pub mod rows;
 pub mod statement;
 

--- a/crates/core/src/raw.rs
+++ b/crates/core/src/raw.rs
@@ -69,6 +69,10 @@ impl Statement {
     pub fn reset(&self) -> Error {
         unsafe { libsql_sys::ffi::sqlite3_reset(self.raw_stmt) }
     }
+
+    pub fn column_count(&self) -> i32 {
+        unsafe { libsql_sys::ffi::sqlite3_column_count(self.raw_stmt) }
+    }
 }
 
 pub unsafe fn prepare_stmt(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {

--- a/crates/core/src/raw.rs
+++ b/crates/core/src/raw.rs
@@ -1,3 +1,9 @@
+#![allow(clippy::missing_safety_doc)]
+
+pub type Error = i32;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
 pub struct Statement {
     pub(crate) raw_stmt: *mut libsql_sys::ffi::sqlite3_stmt,
 }
@@ -9,5 +15,22 @@ impl Drop for Statement {
                 libsql_sys::ffi::sqlite3_finalize(self.raw_stmt);
             }
         }
+    }
+}
+
+pub unsafe fn prepare_stmt(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {
+    let mut raw_stmt = std::ptr::null_mut();
+    let err = unsafe {
+        libsql_sys::ffi::sqlite3_prepare_v2(
+            raw,
+            sql.as_ptr() as *const i8,
+            sql.len() as i32,
+            &mut raw_stmt,
+            std::ptr::null_mut(),
+        )
+    };
+    match err as u32 {
+        libsql_sys::ffi::SQLITE_OK => Ok(Statement { raw_stmt }),
+        _ => Err(err),
     }
 }

--- a/crates/core/src/raw.rs
+++ b/crates/core/src/raw.rs
@@ -61,6 +61,10 @@ impl Statement {
             );
         }
     }
+
+    pub fn step(&self) -> Error {
+        unsafe { libsql_sys::ffi::sqlite3_step(self.raw_stmt) }
+    }
 }
 
 pub unsafe fn prepare_stmt(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {

--- a/crates/core/src/raw.rs
+++ b/crates/core/src/raw.rs
@@ -65,6 +65,10 @@ impl Statement {
     pub fn step(&self) -> Error {
         unsafe { libsql_sys::ffi::sqlite3_step(self.raw_stmt) }
     }
+
+    pub fn reset(&self) -> Error {
+        unsafe { libsql_sys::ffi::sqlite3_reset(self.raw_stmt) }
+    }
 }
 
 pub unsafe fn prepare_stmt(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {

--- a/crates/core/src/raw.rs
+++ b/crates/core/src/raw.rs
@@ -18,6 +18,51 @@ impl Drop for Statement {
     }
 }
 
+impl Statement {
+    pub fn bind_null(&self, idx: i32) {
+        unsafe {
+            libsql_sys::ffi::sqlite3_bind_null(self.raw_stmt, idx);
+        }
+    }
+
+    pub fn bind_int64(&self, idx: i32, value: i64) {
+        unsafe {
+            libsql_sys::ffi::sqlite3_bind_int64(self.raw_stmt, idx, value);
+        }
+    }
+
+    pub fn bind_double(&self, idx: i32, value: f64) {
+        unsafe {
+            libsql_sys::ffi::sqlite3_bind_double(self.raw_stmt, idx, value);
+        }
+    }
+
+    pub fn bind_text(&self, idx: i32, value: &str) {
+        unsafe {
+            let value = value.as_bytes();
+            libsql_sys::ffi::sqlite3_bind_text(
+                self.raw_stmt,
+                idx,
+                value.as_ptr() as *const i8,
+                value.len() as i32,
+                None,
+            );
+        }
+    }
+
+    pub fn bind_blob(&self, idx: i32, value: &[u8]) {
+        unsafe {
+            libsql_sys::ffi::sqlite3_bind_blob(
+                self.raw_stmt,
+                idx,
+                value.as_ptr() as *const std::ffi::c_void,
+                value.len() as i32,
+                None,
+            );
+        }
+    }
+}
+
 pub unsafe fn prepare_stmt(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {
     let mut raw_stmt = std::ptr::null_mut();
     let err = unsafe {

--- a/crates/core/src/raw.rs
+++ b/crates/core/src/raw.rs
@@ -1,0 +1,13 @@
+pub struct Statement {
+    pub(crate) raw_stmt: *mut libsql_sys::ffi::sqlite3_stmt,
+}
+
+impl Drop for Statement {
+    fn drop(&mut self) {
+        if !self.raw_stmt.is_null() {
+            unsafe {
+                libsql_sys::ffi::sqlite3_finalize(self.raw_stmt);
+            }
+        }
+    }
+}

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -15,7 +15,7 @@ impl Rows {
     pub fn next(&self) -> Result<Option<Row>> {
         let err = match self.err.take() {
             Some(err) => err,
-            None => unsafe { libsql_sys::ffi::sqlite3_step(self.stmt.raw_stmt) },
+            None => self.stmt.step(),
         };
         match err as u32 {
             libsql_sys::ffi::SQLITE_OK => Ok(None),

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -28,7 +28,7 @@ impl Rows {
     }
 
     pub fn column_count(&self) -> i32 {
-        unsafe { libsql_sys::ffi::sqlite3_column_count(self.stmt.raw_stmt) }
+        self.stmt.column_count()
     }
 }
 

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -1,12 +1,11 @@
-use crate::statement::StatementInner;
-use crate::{errors, Error, Params, Result, Statement};
+use crate::{errors, raw, Error, Params, Result, Statement};
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
 /// Query result rows.
 pub struct Rows {
-    pub(crate) stmt: Rc<StatementInner>,
+    pub(crate) stmt: Rc<raw::Statement>,
     pub(crate) err: RefCell<Option<i32>>,
 }
 

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -64,6 +64,6 @@ impl Statement {
 
     /// Reset the prepared statement to initial state for reuse.
     pub fn reset(&self) {
-        unsafe { libsql_sys::ffi::sqlite3_reset(self.inner.raw_stmt) };
+        self.inner.reset();
     }
 }

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -51,7 +51,7 @@ impl Statement {
 
     pub fn execute(&self, params: &Params) -> Option<Rows> {
         self.bind(params);
-        let err = unsafe { libsql_sys::ffi::sqlite3_step(self.inner.raw_stmt) };
+        let err = self.inner.step();
         match err as u32 {
             libsql_sys::ffi::SQLITE_OK => None,
             libsql_sys::ffi::SQLITE_DONE => None,

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -1,25 +1,11 @@
-use crate::{errors, Error, Params, Result, Rows, Value};
+use crate::{errors, raw, Error, Params, Result, Rows, Value};
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
 /// A prepared statement.
 pub struct Statement {
-    inner: Rc<StatementInner>,
-}
-
-pub(crate) struct StatementInner {
-    pub(crate) raw_stmt: *mut libsql_sys::ffi::sqlite3_stmt,
-}
-
-impl Drop for StatementInner {
-    fn drop(&mut self) {
-        if !self.raw_stmt.is_null() {
-            unsafe {
-                libsql_sys::ffi::sqlite3_finalize(self.raw_stmt);
-            }
-        }
-    }
+    inner: Rc<raw::Statement>,
 }
 
 impl Statement {
@@ -36,7 +22,7 @@ impl Statement {
         };
         match err as u32 {
             libsql_sys::ffi::SQLITE_OK => Ok(Statement {
-                inner: Rc::new(StatementInner { raw_stmt }),
+                inner: Rc::new(raw::Statement { raw_stmt }),
             }),
             _ => Err(Error::PrepareFailed(
                 sql.to_string(),

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -10,23 +10,13 @@ pub struct Statement {
 
 impl Statement {
     pub(crate) fn prepare(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {
-        let mut raw_stmt = std::ptr::null_mut();
-        let err = unsafe {
-            libsql_sys::ffi::sqlite3_prepare_v2(
-                raw,
-                sql.as_ptr() as *const i8,
-                sql.len() as i32,
-                &mut raw_stmt,
-                std::ptr::null_mut(),
-            )
-        };
-        match err as u32 {
-            libsql_sys::ffi::SQLITE_OK => Ok(Statement {
-                inner: Rc::new(raw::Statement { raw_stmt }),
+        match unsafe { raw::prepare_stmt(raw, sql) } {
+            Ok(stmt) => Ok(Statement {
+                inner: Rc::new(stmt),
             }),
-            _ => Err(Error::PrepareFailed(
+            Err(err) => Err(Error::PrepareFailed(
                 sql.to_string(),
-                errors::sqlite_error_message(raw),
+                errors::sqlite_code_to_error(err),
             )),
         }
     }

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -28,34 +28,21 @@ impl Statement {
                 for (i, param) in params.iter().enumerate() {
                     let i = i as i32 + 1;
                     match param {
-                        Value::Null => unsafe {
-                            libsql_sys::ffi::sqlite3_bind_null(self.inner.raw_stmt, i);
-                        },
-                        Value::Integer(value) => unsafe {
-                            libsql_sys::ffi::sqlite3_bind_int64(self.inner.raw_stmt, i, *value);
-                        },
-                        Value::Float(value) => unsafe {
-                            libsql_sys::ffi::sqlite3_bind_double(self.inner.raw_stmt, i, *value);
-                        },
-                        Value::Text(value) => unsafe {
-                            let value = value.as_bytes();
-                            libsql_sys::ffi::sqlite3_bind_text(
-                                self.inner.raw_stmt,
-                                i,
-                                value.as_ptr() as *const i8,
-                                value.len() as i32,
-                                None,
-                            );
-                        },
-                        Value::Blob(value) => unsafe {
-                            libsql_sys::ffi::sqlite3_bind_blob(
-                                self.inner.raw_stmt,
-                                i,
-                                value.as_ptr() as *const std::ffi::c_void,
-                                value.len() as i32,
-                                None,
-                            );
-                        },
+                        Value::Null => {
+                            self.inner.bind_null(i);
+                        }
+                        Value::Integer(value) => {
+                            self.inner.bind_int64(i, *value);
+                        }
+                        Value::Float(value) => {
+                            self.inner.bind_double(i, *value);
+                        }
+                        Value::Text(value) => {
+                            self.inner.bind_text(i, value);
+                        }
+                        Value::Blob(value) => {
+                            self.inner.bind_blob(i, &value[..]);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Let's avoid using the libsql_sys wrappers everywhere and instead add a raw API layer between the high-level API and the FFI bindings. I am exposing this as a public interface too so applications that want more control can just use it.