### PR TITLE
Replication: iteration 2

### DIFF
--- a/crates/.gitignore
+++ b/crates/.gitignore
@@ -2,3 +2,5 @@ Cargo.lock
 target
 data.libsql
 test.db
+test.db-shm
+test.db-wal

--- a/crates/.gitignore
+++ b/crates/.gitignore
@@ -1,4 +1,4 @@
 Cargo.lock
 target
 data.libsql
-
+test.db

--- a/crates/core/examples/from_snapshot.rs
+++ b/crates/core/examples/from_snapshot.rs
@@ -1,13 +1,12 @@
 use libsql_core::Database;
-use libsql_replication::{Frames, Replicator, TempSnapshot};
+use libsql_replication::{Frames, TempSnapshot};
 
 fn main() {
     tracing_subscriber::fmt::init();
 
-    //    std::fs::create_dir("data.libsql").ok();
-    //    std::fs::copy("tests/template.db", "data.libsql/data").unwrap();
+    std::fs::create_dir("data.libsql").ok();
 
-    let db = Database::open("data.libsql/data");
+    let mut db = Database::with_replicator("data.libsql/data");
     let conn = db.connect().unwrap();
 
     let args = std::env::args().collect::<Vec<String>>();
@@ -16,10 +15,9 @@ fn main() {
         return;
     }
     let snapshot_path = args.get(1).unwrap();
-    let mut replicator = Replicator::new("data.libsql").unwrap();
     let snapshot = TempSnapshot::from_snapshot_file(snapshot_path.as_ref()).unwrap();
 
-    replicator.sync(Frames::Snapshot(snapshot)).unwrap();
+    db.sync(Frames::Snapshot(snapshot)).unwrap();
 
     let rows = conn
         .execute("SELECT * FROM sqlite_master", ())

--- a/crates/core/examples/from_snapshot.rs
+++ b/crates/core/examples/from_snapshot.rs
@@ -4,9 +4,7 @@ use libsql_replication::{Frames, TempSnapshot};
 fn main() {
     tracing_subscriber::fmt::init();
 
-    std::fs::create_dir("data.libsql").ok();
-
-    let mut db = Database::with_replicator("data.libsql/data");
+    let mut db = Database::with_replicator("test.db");
     let conn = db.connect().unwrap();
 
     let args = std::env::args().collect::<Vec<String>>();

--- a/crates/core/examples/from_snapshot.rs
+++ b/crates/core/examples/from_snapshot.rs
@@ -1,0 +1,37 @@
+use libsql_core::Database;
+use libsql_replication::{Frames, Replicator, TempSnapshot};
+
+fn main() {
+    tracing_subscriber::fmt::init();
+
+    //    std::fs::create_dir("data.libsql").ok();
+    //    std::fs::copy("tests/template.db", "data.libsql/data").unwrap();
+
+    let db = Database::open("data.libsql/data");
+    let conn = db.connect().unwrap();
+
+    let args = std::env::args().collect::<Vec<String>>();
+    if args.len() < 2 {
+        println!("Usage: {} <snapshot path>", args[0]);
+        return;
+    }
+    let snapshot_path = args.get(1).unwrap();
+    let mut replicator = Replicator::new("data.libsql").unwrap();
+    let snapshot = TempSnapshot::from_snapshot_file(snapshot_path.as_ref()).unwrap();
+
+    replicator.sync(Frames::Snapshot(snapshot)).unwrap();
+
+    let rows = conn
+        .execute("SELECT * FROM sqlite_master", ())
+        .unwrap()
+        .unwrap();
+    while let Ok(Some(row)) = rows.next() {
+        println!(
+            "| {:024} | {:024} | {:024} | {:024} |",
+            row.get::<&str>(0).unwrap(),
+            row.get::<&str>(1).unwrap(),
+            row.get::<&str>(2).unwrap(),
+            row.get::<&str>(3).unwrap(),
+        );
+    }
+}

--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -1,5 +1,5 @@
 use libsql_core::Database;
-use libsql_replication::{Frame, FrameHeader, Frames, Replicator};
+use libsql_replication::{Frame, FrameHeader, Frames};
 
 fn frame_data_offset(frame_no: u64) -> u64 {
     tracing::debug!(

--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -36,12 +36,10 @@ fn main() {
     std::fs::create_dir("data.libsql").ok();
     std::fs::copy("tests/template.db", "data.libsql/data").unwrap();
 
-    let db = Database::open("data.libsql/data");
+    let mut db = Database::with_replicator("data.libsql/data");
     let conn = db.connect().unwrap();
 
-    let mut replicator = Replicator::new("data.libsql").unwrap();
-
-    let sync_result = replicator.sync(Frames::Vec(vec![test_frame(1), test_frame(2)]));
+    let sync_result = db.sync(Frames::Vec(vec![test_frame(1), test_frame(2)]));
     println!("sync result: {:?}", sync_result);
     let rows = conn
         .execute("SELECT * FROM sqlite_master", ())

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -29,11 +29,9 @@ impl Database {
     }
 
     pub fn with_replicator(url: impl Into<String>) -> Database {
-        Database {
-            url: url.into(),
-            // FIXME: we probably shouldn't hardcode this part
-            replicator: Some(Replicator::new("data.libsql").unwrap()),
-        }
+        let url = url.into();
+        let replicator = Some(Replicator::new(&url).unwrap());
+        Database { url, replicator }
     }
 
     pub fn close(&self) {}

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -1,8 +1,11 @@
 use crate::{connection::Connection, Result};
+use libsql_replication::Replicator;
+pub use libsql_replication::{Frames, TempSnapshot};
 
 // A libSQL database.
 pub struct Database {
     pub url: String,
+    pub replicator: Option<Replicator>,
 }
 
 impl Database {
@@ -19,12 +22,36 @@ impl Database {
     }
 
     pub fn new(url: String) -> Database {
-        Database { url }
+        Database {
+            url,
+            replicator: None,
+        }
+    }
+
+    pub fn with_replicator(url: impl Into<String>) -> Database {
+        Database {
+            url: url.into(),
+            // FIXME: we probably shouldn't hardcode this part
+            replicator: Some(Replicator::new("data.libsql").unwrap()),
+        }
     }
 
     pub fn close(&self) {}
 
     pub fn connect(&self) -> Result<Connection> {
         Connection::connect(self)
+    }
+
+    pub fn sync(&mut self, frames: Frames) -> Result<()> {
+        if let Some(replicator) = &mut self.replicator {
+            replicator
+                .sync(frames)
+                .map_err(|e| crate::errors::Error::ConnectionFailed(format!("{e}")))
+        } else {
+            Err(crate::errors::Error::Misuse(
+                "No replicator available. Use Database::with_replicator() to enable replication"
+                    .to_string(),
+            ))
+        }
     }
 }

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -10,6 +10,8 @@ pub enum Error {
     UnknownColumnType(i32, i32),
     #[error("The value is NULL")]
     NullValue,
+    #[error("Library misuse: `{0}`")]
+    Misuse(String),
 }
 
 pub(crate) fn sqlite_code_to_error(code: i32) -> String {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,17 +22,16 @@
 //! Embedded replica is libSQL database that's running in your application process, which keeps a local copy of a remote database.
 //! They are useful if you want to move data in the memory space of your application for fast access.
 //!
-//! You can open an embedded read-only replica by instantiating a [`Replicator`] and setting it up to replicate a remote database:
+//! You can open an embedded read-only replica by using the [`Database::with_replicator`] constructor:
 //!
 //! ```rust,no_run
 //! use libsql_core::Database;
 //! use libsql_replication::{Frame, Frames, Replicator};
 //!
-//! let db = Database::open("/tmp/test.db");
+//! let mut db = Database::with_replicator("/tmp/test.db");
 //!
-//! let mut replicator = libsql_replication::Replicator::new("data.libsql").unwrap();
 //! let frames: Frames = Frames::Vec(vec![]);
-//! replicator.sync(frames).unwrap();
+//! db.sync(frames).unwrap();
 //! let conn = db.connect().unwrap();
 //! conn.execute("SELECT * FROM users", ()).unwrap();
 //! ```

--- a/crates/libsql-sys/src/connection.rs
+++ b/crates/libsql-sys/src/connection.rs
@@ -22,7 +22,7 @@ impl<'a> Connection<'a> {
         }
     }
 
-    /// Opens a database with the regular wal methods in the directory pointed to by path
+    /// Opens a database with the regular wal methods, given a path to the database file.
     pub fn open<W: WalHook>(
         path: impl AsRef<std::path::Path>,
         flags: c_int,
@@ -31,7 +31,7 @@ impl<'a> Connection<'a> {
         _wal_hook: &'static WalMethodsHook<W>,
         hook_ctx: &'a mut W::Context,
     ) -> Result<Self, crate::Error> {
-        let path = path.as_ref().join("data");
+        let path = path.as_ref();
         tracing::trace!(
             "Opening a connection with regular WAL at {}",
             path.display()


### PR DESCRIPTION
Two things are now possible:
1. Syncing frames from a snapshot file produced by sqld, e.g. with `cargo run -- --max-log-duration 1`
2. Using `let mut db = Database::with_replicator(path)` in order to create a database, on which you can then call `sync(frames)` to load new frames. No need to instantiate a separate `Replicator` anymore