### PR TITLE
libsql/replication: Fix InjectorHook {pre,post}_commit types

### DIFF
--- a/crates/replication/src/replica/hook.rs
+++ b/crates/replication/src/replica/hook.rs
@@ -78,9 +78,9 @@ pub struct InjectorHookCtx {
     /// currently in a txn
     pub is_txn: bool,
     /// invoked before injecting frames
-    pre_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()>>,
+    pre_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()> + Send>,
     /// invoked after injecting frames
-    post_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()>>,
+    post_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()> + Send>,
 }
 
 impl InjectorHookCtx {


### PR DESCRIPTION
The pre and post commit hooks are already Send in
InjectorHookCtx::new(), but let's not lose the types when we store them in the struct.