### PR TITLE
libsql: Add wasm bindings scaffolding

### DIFF
--- a/.github/workflows/maketest.yml
+++ b/.github/workflows/maketest.yml
@@ -21,6 +21,11 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v2
 
+    - name: Install Wasmpack
+      uses: jetli/wasm-pack-action@v0.4.0
+      with:
+      version: 'latest'
+
     - name: configure
       run: ./configure
       
@@ -32,3 +37,6 @@ jobs:
 
     - name: Run API tests
       run: make libsqlapi
+
+    - name: Build libSQL API wasm bindings
+      run: cd crates/bindings/wasm && wasm-pack build --target nodejs

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "bindings/c",
   "bindings/js",
   "bindings/python",
+  "bindings/wasm",
   "replication",
   "libsql-sys",
   "libsql-shell",

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "libsql-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+js-sys = "0.3.64"
+libsql = { path = "../../core", default_features = false }
+wasm-bindgen = "0.2"

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -1,0 +1,8 @@
+# LibSQL JavaScript bindings
+
+## Developing
+
+```
+wasm-pack build --target nodejs
+node example.js
+```

--- a/crates/bindings/wasm/example.js
+++ b/crates/bindings/wasm/example.js
@@ -1,0 +1,10 @@
+var libsql = require('./pkg');
+
+var db = new libsql.Database('libsql://penberg.turso.io');
+
+db.all('SELECT 1', function(err, res) {
+  if (err) {
+    throw err;
+  }
+  console.log(res[0])
+});

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -1,0 +1,20 @@
+use wasm_bindgen::prelude::*;
+use libsql;
+
+#[wasm_bindgen]
+pub struct Database {
+    inner: libsql::Database,
+}
+
+#[wasm_bindgen]
+impl Database {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Database {
+        Database { inner: libsql::Database::open(":memory:") }
+    }
+
+    pub fn all(&self, sql: String, f: &js_sys::Function) {
+        let this = JsValue::null();
+        let _ = f.call0(&this);
+    }
+}


### PR DESCRIPTION
We want to be able to build libSQL API as wasm module for serverless deployments. Let's add enough wasm binding scaffolding to avoid painting ourselves into a corner.