### PR TITLE
replication: add gRPC-based replication

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,10 +14,12 @@ libsql_replication = { version = "0", path = "../replication", optional = true }
 tokio = { version = "1.29.1", features = ["macros"] }
 tracing-subscriber = "0.3.17"
 tracing = "0.1.37"
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports", "async", "async_futures"] }
 pprof = { version = "0.11.1", features = ["criterion", "flamegraph"] }
+tokio = { version = "1.29.1", features = ["full"] }
 
 [features]
 default = ["replication"]

--- a/crates/core/examples/from_snapshot.rs
+++ b/crates/core/examples/from_snapshot.rs
@@ -1,10 +1,13 @@
 use libsql::Database;
 use libsql_replication::{Frames, TempSnapshot};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     tracing_subscriber::fmt::init();
 
-    let mut db = Database::with_replicator("test.db");
+    let mut db = Database::with_replicator("http://localhost:5001", "test.db")
+        .await
+        .unwrap();
     let conn = db.connect().unwrap();
 
     let args = std::env::args().collect::<Vec<String>>();
@@ -15,7 +18,7 @@ fn main() {
     let snapshot_path = args.get(1).unwrap();
     let snapshot = TempSnapshot::from_snapshot_file(snapshot_path.as_ref()).unwrap();
 
-    db.sync(Frames::Snapshot(snapshot)).unwrap();
+    db.sync_frames(Frames::Snapshot(snapshot)).unwrap();
 
     let rows = conn
         .execute("SELECT * FROM sqlite_master", ())

--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -1,57 +1,44 @@
 use libsql::Database;
-use libsql_replication::{Frame, FrameHeader, Frames};
 
-fn frame_data_offset(frame_no: u64) -> u64 {
-    tracing::debug!(
-        "WAL offset: {frame_no}->{}",
-        32 + (frame_no - 1) * (24 + 4096) + 24
-    );
-    32 + (frame_no - 1) * (24 + 4096) + 24
-}
-
-fn test_frame(frame_no: u64) -> Frame {
-    let header = FrameHeader {
-        frame_no,
-        checksum: 0xdeadc0de,
-        page_no: frame_no as u32,
-        size_after: frame_no as u32,
-    };
-
-    let loaded = {
-        use std::io::{Read, Seek};
-        let mut f = std::fs::File::open("tests/template.db-wal").unwrap();
-        f.seek(std::io::SeekFrom::Start(frame_data_offset(frame_no)))
-            .unwrap();
-        let mut buf = vec![0; 4096];
-        f.read_exact(&mut buf).unwrap();
-        buf
-    };
-
-    Frame::from_parts(&header, &loaded)
-}
-
-fn main() {
+#[tokio::main]
+async fn main() {
     tracing_subscriber::fmt::init();
 
     std::fs::create_dir("data.libsql").ok();
     std::fs::copy("tests/template.db", "data.libsql/data").unwrap();
 
-    let mut db = Database::with_replicator("data.libsql/data");
+    let db = Database::with_replicator("http://localhost:5001", "test.db")
+        .await
+        .unwrap();
     let conn = db.connect().unwrap();
 
-    let sync_result = db.sync(Frames::Vec(vec![test_frame(1), test_frame(2)]));
-    println!("sync result: {:?}", sync_result);
-    let rows = conn
-        .execute("SELECT * FROM sqlite_master", ())
-        .unwrap()
-        .unwrap();
-    while let Ok(Some(row)) = rows.next() {
-        println!(
-            "| {:024} | {:024} | {:024} | {:024} |",
-            row.get::<&str>(0).unwrap(),
-            row.get::<&str>(1).unwrap(),
-            row.get::<&str>(2).unwrap(),
-            row.get::<&str>(3).unwrap(),
-        );
+    let db = std::sync::Arc::new(parking_lot::Mutex::new(db));
+    loop {
+        if let Err(e) = tokio::task::spawn_blocking({
+            let db = db.clone();
+            move || db.lock().sync()
+        })
+        .await
+        {
+            println!("Error: {e}");
+            break;
+        };
+        let response = conn.execute("SELECT * FROM sqlite_master", ()).unwrap();
+        let rows = match response {
+            Some(rows) => rows,
+            None => {
+                println!("No rows");
+                continue;
+            }
+        };
+        while let Ok(Some(row)) = rows.next() {
+            println!(
+                "| {:024} | {:024} | {:024} | {:024} |",
+                row.get::<&str>(0).unwrap(),
+                row.get::<&str>(1).unwrap(),
+                row.get::<&str>(2).unwrap(),
+                row.get::<&str>(3).unwrap(),
+            );
+        }
     }
 }

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -1,23 +1,27 @@
-use crate::{connection::Connection, Result};
+use crate::{connection::Connection, errors::Error::ConnectionFailed, Result};
 #[cfg(feature = "replication")]
 use libsql_replication::Replicator;
 #[cfg(feature = "replication")]
-pub use libsql_replication::{Frames, TempSnapshot};
+pub use libsql_replication::{rpc, Client, Frames, TempSnapshot};
+
+pub struct ReplicationContext {
+    pub replicator: Replicator,
+    pub client: Client,
+}
 
 // A libSQL database.
 pub struct Database {
     pub url: String,
     #[cfg(feature = "replication")]
-    pub replicator: Option<Replicator>,
+    pub replication_ctx: Option<ReplicationContext>,
 }
 
 impl Database {
     pub fn open<S: Into<String>>(url: S) -> Database {
         let url = url.into();
-        if url.starts_with("libsql:") {
-            let url = url.replace("libsql:", "http:");
-            tracing::info!("Absolutely ignoring libsql URL: {url}");
-            let filename = "data.libsql/data".to_string();
+        if url.starts_with("libsql:") || url.starts_with("http:") {
+            tracing::warn!("Ignoring {url} in Database::open() and opening a local db");
+            let filename = "libsql_tmp.db".to_string();
             Database::new(filename)
         } else {
             Database::new(url)
@@ -28,15 +32,28 @@ impl Database {
         Database {
             url,
             #[cfg(feature = "replication")]
-            replicator: None,
+            replication_ctx: None,
         }
     }
 
     #[cfg(feature = "replication")]
-    pub fn with_replicator(url: impl Into<String>) -> Database {
+    pub async fn with_replicator(
+        url: impl Into<String>,
+        db_path: impl Into<String>,
+    ) -> Result<Database> {
         let url = url.into();
-        let replicator = Some(Replicator::new(&url).unwrap());
-        Database { url, replicator }
+        let db_path = db_path.into();
+        let mut db = Database::open(&db_path);
+        let replicator = Replicator::new(db_path).map_err(|e| ConnectionFailed(format!("{e}")))?;
+        let (client, meta) = Replicator::connect_to_rpc(
+            rpc::Endpoint::from_shared(url.clone())
+                .map_err(|e| ConnectionFailed(format!("{e}")))?,
+        )
+        .await
+        .map_err(|e| ConnectionFailed(format!("{e}")))?;
+        *replicator.meta.lock() = Some(meta);
+        db.replication_ctx = Some(ReplicationContext { replicator, client });
+        Ok(db)
     }
 
     pub fn close(&self) {}
@@ -46,11 +63,25 @@ impl Database {
     }
 
     #[cfg(feature = "replication")]
-    pub fn sync(&mut self, frames: Frames) -> Result<()> {
-        if let Some(replicator) = &mut self.replicator {
-            replicator
+    pub fn sync(&mut self) -> Result<()> {
+        if let Some(ctx) = &mut self.replication_ctx {
+            ctx.replicator
+                .sync_from_rpc(&mut ctx.client)
+                .map_err(|e| ConnectionFailed(format!("{e}")))
+        } else {
+            Err(crate::errors::Error::Misuse(
+                "No replicator available. Use Database::with_replicator() to enable replication"
+                    .to_string(),
+            ))
+        }
+    }
+
+    #[cfg(feature = "replication")]
+    pub fn sync_frames(&mut self, frames: Frames) -> Result<()> {
+        if let Some(ctx) = &mut self.replication_ctx {
+            ctx.replicator
                 .sync(frames)
-                .map_err(|e| crate::errors::Error::ConnectionFailed(format!("{e}")))
+                .map_err(|e| ConnectionFailed(format!("{e}")))
         } else {
             Err(crate::errors::Error::Misuse(
                 "No replicator available. Use Database::with_replicator() to enable replication"

--- a/crates/replication/src/replica/hook.rs
+++ b/crates/replication/src/replica/hook.rs
@@ -21,6 +21,7 @@ pub enum Frames {
     Snapshot(TempSnapshot),
 }
 
+#[derive(Debug)]
 pub struct Headers<'a> {
     ptr: *mut PgHdr,
     _pth: PhantomData<&'a ()>,
@@ -152,10 +153,10 @@ unsafe impl WalHook for InjectorHook {
         let wal_ptr = wal as *mut _;
         let ctx = Self::wal_extract_ctx(wal);
         loop {
+            tracing::trace!("Waiting for a frame");
             match ctx.receiver.blocking_recv() {
                 Some(frames) => {
                     let (headers, last_frame_no, size_after) = frames.to_headers();
-
                     let ret = ctx.inject_pages(
                         headers,
                         last_frame_no,


### PR DESCRIPTION
This very crude draft hooks gRPC replication into the replication crate. The underlying interface is asynchronous, so we're likely to end up relying on Tokio for replication anyway.