### PR TITLE
libsql: Fix Python package name

### DIFF
--- a/crates/bindings/python/Cargo.toml
+++ b/crates/bindings/python/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "libsql_python"
+name = "libsql"
 crate-type = ["cdylib"]
 
 [dependencies]


### PR DESCRIPTION
We want developers to `import libsql` in Python, so fix up `Cargo.toml` to reflect that.