### PR TITLE
libsql: Remove external `protoc` dependency

### DIFF
--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -29,4 +29,5 @@ regex = "1.9.0"
 
 [build-dependencies]
 prost-build = "0.11.4"
+protobuf-src = "1.1.0"
 tonic-build = "0.8.4"

--- a/crates/replication/build.rs
+++ b/crates/replication/build.rs
@@ -1,6 +1,8 @@
 use prost_build::Config;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut config = Config::new();
     config.bytes([".wal_log"]);
     tonic_build::configure()


### PR DESCRIPTION
Let's use the `protobuf-src` crate to remove the dependency to external `protoc` to simplify the build process.