### PR TITLE
add sqlite3_close_hook

### DIFF
--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -10366,6 +10366,22 @@ int sqlite3_preupdate_blobwrite(sqlite3 *);
 #endif
 
 /*
+** CAPI3REF: The close hook.
+** METHOD: sqlite3
+**
+** ^The [libsql_close_hook()] interface registers a callback function
+** that is invoked prior to closing the database connection.
+** ^At most one close hook may be registered at a time on a single
+** [database connection]; each call to [libsql_close_hook()] overrides
+** the previous setting.
+** ^The close hook is disabled by invoking [libsql_close_hook()]
+** with a NULL pointer as the second parameter.
+** ^The third parameter to [libsql_close_hook()] is passed through as
+** the first parameter to callbacks.
+*/
+void *libsql_close_hook(sqlite3 *db, void (*xClose)(void *pCtx, sqlite3 *db), void *arg);
+
+/*
 ** CAPI3REF: Low-level system error code
 ** METHOD: sqlite3
 **

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -1746,6 +1746,10 @@ struct sqlite3 {
 #endif
   libsql_wal_methods* pWalMethods; /* Custom WAL methods */
   void* pWalMethodsData;           /* optional data for WAL methods */
+  void *pCloseArg;                 /* First argument to xCloseCallback */
+  void (*xCloseCallback)(          /* Registered using sqlite3_close_hook() */
+    void*, sqlite3*
+  );
 };
 
 /*

--- a/test/rust_suite/src/user_defined_functions_src.rs
+++ b/test/rust_suite/src/user_defined_functions_src.rs
@@ -66,7 +66,7 @@ pub fn fib_src() -> String {
 }
 
 pub fn contains_src() -> String {
-  const CONTAINS_SRC: &[u8] = include_bytes!("./wasm/contains.wasm");
+    const CONTAINS_SRC: &[u8] = include_bytes!("./wasm/contains.wasm");
     hex::encode(CONTAINS_SRC)
 }
 


### PR DESCRIPTION
The callback allows registering a custom close hook, which gets called prior to closing the connection, allowing users to perform custom cleanups.

Fixes #62 