### PR TITLE
libsql/core: Improve error handling

### DIFF
--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -14,7 +14,12 @@ pub enum Error {
     Misuse(String),
 }
 
-pub(crate) fn sqlite_code_to_error(code: i32) -> String {
+pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {
+    let errmsg = unsafe { libsql_sys::ffi::sqlite3_errmsg(raw) };
+    sqlite_errmsg_to_string(errmsg)
+}
+
+pub(crate) fn error_from_code(code: i32) -> String {
     let errmsg = unsafe { libsql_sys::ffi::sqlite3_errstr(code) };
     sqlite_errmsg_to_string(errmsg)
 }

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -25,7 +25,7 @@ impl Rows {
             libsql_sys::ffi::SQLITE_ROW => Ok(Some(Row {
                 stmt: self.stmt.clone(),
             })),
-            _ => Err(Error::FetchRowFailed(errors::sqlite_code_to_error(err))),
+            _ => Err(Error::FetchRowFailed(errors::error_from_code(err))),
         }
     }
 

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -14,9 +14,9 @@ impl Statement {
             Ok(stmt) => Ok(Statement {
                 inner: Arc::new(stmt),
             }),
-            Err(libsql_sys::Error::LibError(err)) => Err(Error::PrepareFailed(
+            Err(libsql_sys::Error::LibError(_err)) => Err(Error::PrepareFailed(
                 sql.to_string(),
-                errors::sqlite_code_to_error(err),
+                errors::error_from_handle(raw),
             )),
             Err(err) => Err(Error::Misuse(format!(
                 "Unexpected error while preparing statement: {err}"


### PR DESCRIPTION
We need to return the human-readable error message in `Error::PrepareFailed` so that language bindings can show it.