### PR TITLE
replication: move to rustls

### DIFF
--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -24,6 +24,6 @@ once_cell = "1.18.0"
 nix = "0.26.2"
 tokio-stream = "0.1.14"
 regex = "1.9.0"
-reqwest = "0.11.18"
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 serde_json = "1.0.103"
 serde = { version = "1.0.173", features = ["serde_derive"] }


### PR DESCRIPTION
That makes a transient dependency of openssl-sys go away. openssl-sys is great and battle tested, but also less portable.