### PR TITLE
libsql/core: Add named parameter support

### DIFF
--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+
 use libsql_sys::ValueType;
 
 pub enum Params {
     None,
     Positional(Vec<Value>),
+    Named(Vec<(String, Value)>),
 }
 
 #[macro_export]
@@ -15,6 +18,16 @@ macro_rules! params {
     };
 }
 
+#[macro_export]
+macro_rules! named_params {
+    () => {
+        Params::None
+    };
+    ($($param_name:literal: $value:expr),* $(,)?) => {
+        Params::Named(vec![$(($param_name.to_string(), crate::params::Value::from($value))),*])
+    };
+}
+
 impl From<()> for Params {
     fn from(_: ()) -> Params {
         Params::None
@@ -24,6 +37,12 @@ impl From<()> for Params {
 impl From<Vec<Value>> for Params {
     fn from(values: Vec<Value>) -> Params {
         Params::Positional(values)
+    }
+}
+
+impl From<Vec<(String, Value)>> for Params {
+    fn from(values: Vec<(String, Value)>) -> Params {
+        Params::Named(values)
     }
 }
 

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use libsql_sys::ValueType;
 
 pub enum Params {

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -30,23 +30,16 @@ impl Statement {
             Params::Positional(params) => {
                 for (i, param) in params.iter().enumerate() {
                     let i = i as i32 + 1;
-                    match param {
-                        Value::Null => {
-                            self.inner.bind_null(i);
-                        }
-                        Value::Integer(value) => {
-                            self.inner.bind_int64(i, *value);
-                        }
-                        Value::Float(value) => {
-                            self.inner.bind_double(i, *value);
-                        }
-                        Value::Text(value) => {
-                            self.inner.bind_text(i, value);
-                        }
-                        Value::Blob(value) => {
-                            self.inner.bind_blob(i, &value[..]);
-                        }
-                    }
+
+                    self.bind_value(i, param);
+                }
+            }
+
+            Params::Named(params) => {
+                for (name, param) in params {
+                    let i = self.inner.bind_parameter_index(&name);
+
+                    self.bind_value(i, param);
                 }
             }
         }
@@ -68,5 +61,25 @@ impl Statement {
     /// Reset the prepared statement to initial state for reuse.
     pub fn reset(&self) {
         self.inner.reset();
+    }
+
+    fn bind_value(&self, i: i32, param: &Value) {
+        match param {
+            Value::Null => {
+                self.inner.bind_null(i);
+            }
+            Value::Integer(value) => {
+                self.inner.bind_int64(i, *value);
+            }
+            Value::Float(value) => {
+                self.inner.bind_double(i, *value);
+            }
+            Value::Text(value) => {
+                self.inner.bind_text(i, value);
+            }
+            Value::Blob(value) => {
+                self.inner.bind_blob(i, &value[..]);
+            }
+        }
     }
 }

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -94,6 +94,12 @@ impl Statement {
         let raw_name = raw_name.to_str().unwrap();
         raw_name
     }
+
+    pub fn bind_parameter_index(&self, name: &str) -> i32 {
+        let raw_name = std::ffi::CString::new(name).unwrap();
+
+        unsafe { crate::ffi::sqlite3_bind_parameter_index(self.raw_stmt, raw_name.as_ptr()) }
+    }
 }
 
 pub unsafe fn prepare_stmt(raw: *mut crate::ffi::sqlite3, sql: &str) -> Result<Statement> {


### PR DESCRIPTION
This adds basic named parameter support via `Vec<(String, Value)>`.

Ref #187