### PR TITLE
libsql/core: Add blob type support

### DIFF
--- a/crates/bindings/c/include/libsql.h
+++ b/crates/bindings/c/include/libsql.h
@@ -35,7 +35,7 @@ void libsql_execute(libsql_connection_t conn, const char *sql);
 
 void libsql_free_rows(libsql_rows_t res);
 
-libsql_rows_future_t libsql_execute_async(libsql_connection_t conn, const char *sql);
+libsql_rows_future_t libsql_execute_async(const libsql_connection_t *conn, const char *sql);
 
 void libsql_free_rows_future(libsql_rows_future_t res);
 

--- a/crates/bindings/c/src/lib.rs
+++ b/crates/bindings/c/src/lib.rs
@@ -77,10 +77,10 @@ pub unsafe extern "C" fn libsql_free_rows(res: libsql_rows_t) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn libsql_execute_async(
-    conn: libsql_connection_t,
+pub unsafe extern "C" fn libsql_execute_async<'a>(
+    conn: &'a libsql_connection_t,
     sql: *const std::ffi::c_char,
-) -> libsql_rows_future_t {
+) -> libsql_rows_future_t<'a> {
     let sql = unsafe { std::ffi::CStr::from_ptr(sql) };
     let sql = match sql.to_str() {
         Ok(sql) => sql,

--- a/crates/bindings/c/src/types.rs
+++ b/crates/bindings/c/src/types.rs
@@ -136,8 +136,8 @@ impl From<&mut libsql_rows> for libsql_rows_t {
     }
 }
 
-pub struct libsql_rows_future {
-    pub(crate) result: libsql::RowsFuture,
+pub struct libsql_rows_future<'a> {
+    pub(crate) result: libsql::RowsFuture<'a>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/bindings/c/src/types.rs
+++ b/crates/bindings/c/src/types.rs
@@ -142,12 +142,12 @@ pub struct libsql_rows_future<'a> {
 
 #[derive(Clone, Debug)]
 #[repr(transparent)]
-pub struct libsql_rows_future_t {
-    ptr: *const libsql_rows_future,
+pub struct libsql_rows_future_t<'a> {
+    ptr: *const libsql_rows_future<'a>,
 }
 
-impl libsql_rows_future_t {
-    pub fn null() -> libsql_rows_future_t {
+impl libsql_rows_future_t<'_> {
+    pub fn null<'a>() -> libsql_rows_future_t<'a> {
         libsql_rows_future_t {
             ptr: std::ptr::null(),
         }
@@ -169,15 +169,15 @@ impl libsql_rows_future_t {
 }
 
 #[allow(clippy::from_over_into)]
-impl From<&libsql_rows_future> for libsql_rows_future_t {
-    fn from(value: &libsql_rows_future) -> Self {
+impl<'a> From<&'a libsql_rows_future<'a>> for libsql_rows_future_t<'a> {
+    fn from(value: &'a libsql_rows_future) -> Self {
         Self { ptr: value }
     }
 }
 
 #[allow(clippy::from_over_into)]
-impl From<&mut libsql_rows_future> for libsql_rows_future_t {
-    fn from(value: &mut libsql_rows_future) -> Self {
+impl<'a> From<&'a mut libsql_rows_future<'a>> for libsql_rows_future_t<'a> {
+    fn from(value: &'a mut libsql_rows_future) -> Self {
         Self { ptr: value }
     }
 }

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -1,4 +1,4 @@
-use crate::{errors, Error, Params, Result, Statement, Value};
+use crate::{errors, Connection, Error, Params, Result, Value};
 use libsql_sys::ValueType;
 
 use std::cell::RefCell;
@@ -38,26 +38,26 @@ impl Rows {
     }
 }
 
-pub struct RowsFuture {
-    pub(crate) raw: *mut libsql_sys::ffi::sqlite3,
+pub struct RowsFuture<'a> {
+    pub(crate) conn: &'a Connection,
     pub(crate) sql: String,
     pub(crate) params: Params,
 }
 
-impl RowsFuture {
+impl RowsFuture<'_> {
     pub fn wait(&mut self) -> Result<Option<Rows>> {
         futures::executor::block_on(self)
     }
 }
 
-impl futures::Future for RowsFuture {
+impl futures::Future for RowsFuture<'_> {
     type Output = Result<Option<Rows>>;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        let stmt = Statement::prepare(self.raw, &self.sql)?;
+        let stmt = self.conn.prepare(&self.sql)?;
         let ret = stmt.execute(&self.params);
         std::task::Poll::Ready(Ok(ret))
     }

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -1,18 +1,24 @@
-use crate::{errors, Error, Params, Result, Rows, Value, ValueRef};
+use crate::{errors, Connection, Error, Params, Result, Rows, Value, ValueRef};
 
 use std::cell::RefCell;
 use std::ffi::c_int;
 use std::sync::Arc;
 
 /// A prepared statement.
-pub struct Statement {
+pub struct Statement<'a> {
+    _conn: &'a Connection,
     inner: Arc<libsql_sys::Statement>,
 }
 
-impl Statement {
-    pub(crate) fn prepare(raw: *mut libsql_sys::ffi::sqlite3, sql: &str) -> Result<Statement> {
+impl Statement<'_> {
+    pub(crate) fn prepare<'a>(
+        conn: &'a Connection,
+        raw: *mut libsql_sys::ffi::sqlite3,
+        sql: &str,
+    ) -> Result<Statement<'a>> {
         match unsafe { libsql_sys::prepare_stmt(raw, sql) } {
             Ok(stmt) => Ok(Statement {
+                _conn: conn,
                 inner: Arc::new(stmt),
             }),
             Err(libsql_sys::Error::LibError(_err)) => Err(Error::PrepareFailed(
@@ -182,7 +188,7 @@ impl Column<'_> {
     }
 }
 
-impl Statement {
+impl Statement<'_> {
     /// Get all the column names in the result set of the prepared statement.
     ///
     /// If associated DB schema can be altered concurrently, you should make


### PR DESCRIPTION
This adds blob type support and ensures the lifetime handed out from statements is valid.

Ref #187