### PR TITLE
libsql: Fix SIGSEGV when `Connection` is dropped before statements

### DIFF
--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -9,6 +9,14 @@ fn setup() -> Connection {
 }
 
 #[test]
+fn connection_drops_before_statements() {
+    let db = Database::open(":memory:").unwrap();
+    let conn = db.connect().unwrap();
+    let _stmt = conn.prepare("SELECT 1").unwrap();
+    drop(conn);
+}
+
+#[test]
 fn execute() {
     let conn = setup();
     conn.execute("INSERT INTO users (id, name) VALUES (2, 'Alice')", ())


### PR DESCRIPTION
We already clean up after dangling statements in `libsql_sys::Statement` by implementing `Drop`. However, in cases where `Connection` drops before the statements, we will SIGSEGV because statements don't know about the auto-closing.