### PR TITLE
Add ALTER TABLE ALTER COLUMN statement

### DIFF
--- a/doc/libsql_extensions.md
+++ b/doc/libsql_extensions.md
@@ -40,7 +40,7 @@ libsql> CREATE TABLE emails (user_id INT, email TEXT);
 and add a foreign key constraint from the `user_id` column to the `id` column of the `users` table:
 
 ```sql
-libsql> ALTER TABLE emails UPDATE COLUMN user_id TO user_id INT REFERENCES users(id);
+libsql> ALTER TABLE emails ALTER COLUMN user_id TO user_id INT REFERENCES users(id);
 ```
 
 and now you have the following schema in your database:
@@ -54,7 +54,7 @@ CREATE TABLE emails (user_id INT REFERENCES users(id), email TEXT);
 To **remove a foreign constraint**, you do the following:
 
 ```console
-libsql> ALTER TABLE emails UPDATE COLUMN user_id TO user_id INT;
+libsql> ALTER TABLE emails ALTER COLUMN user_id TO user_id INT;
 libsql> .schema
 CREATE TABLE users (id INT PRIMARY KEY);
 CREATE TABLE emails (user_id INT, email TEXT);
@@ -63,30 +63,30 @@ CREATE TABLE emails (user_id INT, email TEXT);
 ### Other attributes
 
 All kind of column attributes, like type affinity, CHECK constraints, DEFAULT values, and so on,
-can be amended with `ALTER TABLE UPDATE COLUMN` as well:
+can be amended with `ALTER TABLE ALTER COLUMN` as well:
 
 ```sql
 libsql> CREATE TABLE t(id, v);
 ```
 ```sql
-libsql> ALTER TABLE t UPDATE COLUMN v TO v NOT NULL CHECK(v < 42);
+libsql> ALTER TABLE t ALTER COLUMN v TO v NOT NULL CHECK(v < 42);
 libsql> .schema t
 CREATE TABLE t(id, v NOT NULL CHECK(v < 42));
 ```
 ```sql
-libsql> ALTER TABLE t UPDATE COLUMN v TO v TEXT DEFAULT 'hai';
+libsql> ALTER TABLE t ALTER COLUMN v TO v TEXT DEFAULT 'hai';
 libsql> .schema t
 CREATE TABLE t(id, v TEXT DEFAULT 'hai');
 ```
 ```sql
-libsql> ALTER TABLE t UPDATE COLUMN v TO v;
+libsql> ALTER TABLE t ALTER COLUMN v TO v;
 libsql> .schema t
 CREATE TABLE t(id, v);
 ```
 
 ### Caveats
 
-Please note that altering constraints via ALTER TABLE UPDATE COLUMN only applies
+Please note that altering constraints via ALTER TABLE ALTER COLUMN only applies
 to newly inserted or updated data - existing rows are not rewritten or revalidated.
 
 It's also important to notice that foreign key constraints are disabled by default,

--- a/doc/libsql_extensions.md
+++ b/doc/libsql_extensions.md
@@ -19,6 +19,54 @@ void *libsql_close_hook(
 );
 ```
 
+## Altering columns
+
+### Foreign keys
+
+Foreign keys in SQLite and libSQL requires a primary key column in one table and a foreign key constraint on another table.
+
+For example, if you have the following table:
+
+```console
+libsql> CREATE TABLE users (id INT);
+```
+
+To **add a foreign key constraint**, you first need to make the `id` column be the primary key:
+
+```
+libsql> ALTER TABLE users UPDATE COLUMN id TO id INT PRIMARY KEY;
+```
+
+You can then create another table:
+
+```
+libsql> CREATE TABLE emails (user_id INT, email TEXT);
+```
+
+and add a foreign key constraint from the `user_id` column to the `id` column of the `users` table:
+
+```
+libsql> ALTER TABLE emails UPDATE COLUMN user_id TO user_id INT REFERENCES users(id);
+```
+
+and now you have the following schema in your database:
+
+```
+libsql> .schema
+CREATE TABLE users (id INT PRIMARY KEY);
+CREATE TABLE emails (user_id INT REFERENCES users(id), email TEXT);
+```
+
+To **remove a foreign constraint**, you do the following:
+
+```console
+libsql> ALTER TABLE emails UPDATE COLUMN user_id TO user_id INT;
+libsql> ALTER TABLE users UPDATE COLUMN id TO id INT;
+libsql> .schema
+CREATE TABLE users (id INT);
+CREATE TABLE emails (user_id INT, email TEXT);
+```
+
 ## RANDOM ROWID
 
 Regular tables use an implicitly defined, unique, 64-bit rowid column as its primary key.

--- a/src/alter.c
+++ b/src/alter.c
@@ -761,13 +761,6 @@ void libsqlAlterAlterColumn(
       pTab->zName
   );
 
-  sqlite3NestedParse(pParse, 
-      "UPDATE temp." LEGACY_SCHEMA_TABLE " SET "
-      "sql = libsql_alter_column(sql, %Q, %Q, %d, %Q, %d, 1, %d) "
-      "WHERE type IN ('trigger', 'view')",
-      zDb, pTab->zName, iCol, zNew, bQuote, pTab->aCol[iCol].colFlags
-  );
-
   /* Drop and reload the database schema. */
   renameReloadSchema(pParse, iSchema, INITFLAG_AlterRename);
   renameTestSchema(pParse, zDb, iSchema==1, "after update", 1);

--- a/src/alter.c
+++ b/src/alter.c
@@ -1844,12 +1844,17 @@ static void alterColumnFunc(
         }
       }
     } else {
-      // FIXME: only applicable to tables
-    }
-  }else if( sParse.pNewIndex ){
-    // FIXME: not applicable to indexes
-  }else{
-    // FIXME: not applicable to triggers
+      rc = SQLITE_ERROR;
+      sParse.zErrMsg = sqlite3MPrintf(sParse.db, "Only ordinary tables can be altered, not ", IsView(sParse.pNewTable) ? "views" : "virtual tables");
+      goto alterColumnFunc_done;    }
+  } else if (sParse.pNewIndex) {
+    rc = SQLITE_ERROR;
+    sParse.zErrMsg = sqlite3MPrintf(sParse.db, "Only ordinary tables can be altered, not indexes");
+    goto alterColumnFunc_done;
+  } else {
+    rc = SQLITE_ERROR;
+    sParse.zErrMsg = sqlite3MPrintf(sParse.db, "Only ordinary tables can be altered");
+    goto alterColumnFunc_done;
   }
 
   assert( rc==SQLITE_OK );

--- a/src/alter.c
+++ b/src/alter.c
@@ -754,8 +754,7 @@ void libsqlAlterAlterColumn(
   sqlite3NestedParse(pParse, 
       "UPDATE \"%w\"." LEGACY_SCHEMA_TABLE " SET "
       "sql = libsql_alter_column(sql, %Q, %Q, %d, %Q, %d, %d, %d) "
-      "WHERE name NOT LIKE 'sqliteX_%%' ESCAPE 'X' "
-      " AND (type != 'index' OR tbl_name = %Q)",
+      "WHERE tbl_name = %Q",
       zDb,
       zDb, pTab->zName, iCol, zNew, bQuote, iSchema==1, pTab->aCol[iCol].colFlags,
       pTab->zName

--- a/src/alter.c
+++ b/src/alter.c
@@ -679,7 +679,7 @@ void sqlite3AlterRenameColumn(
 /*
 ** Handles the following parser reduction:
 **
-**  cmd ::= ALTER TABLE pSrc UPDATE COLUMN pOld TO pNew
+**  cmd ::= ALTER TABLE pSrc ALTER COLUMN pOld TO pNew
 */
 void libsqlAlterUpdateColumn(
   Parse *pParse,                  /* Parsing context */
@@ -741,7 +741,7 @@ void libsqlAlterUpdateColumn(
     sqlite3ErrorMsg(pParse, "UPDATE cannot also rename column: \"%T\" to \"%T\". Use ALTER TABLE RENAME instead", pOld, pNew);
     goto exit_update_column;
   }
-  // NOTICE: this is the main difference in UPDATE COLUMN compared to RENAME COLUMN,
+  // NOTICE: this is the main difference in ALTER COLUMN compared to RENAME COLUMN,
   // we just take the whole new column declaration as it is.
   // FIXME: the semicolon can also appear in the middle of the declaration when it's quoted,
   // so we should check from the end.
@@ -1762,12 +1762,12 @@ renameColumnFunc_done:
 **   5. bQuote:   Non-zero if the new column name should be quoted.
 **   6. bTemp:    True if zSql comes from temp schema
 **
-** Do a ALTER TABLE UPDATE COLUMN operation on the CREATE statement given in zSql.
+** Do a ALTER TABLE ALTER COLUMN operation on the CREATE statement given in zSql.
 ** The iCol-th column (left-most is 0) of table zTable is translated from zCol
 ** into zNew definition, which the new constraints.
 ** The name should be quoted if bQuote is true.
 **
-** This function is used internally by the ALTER TABLE UPDATE COLUMN command.
+** This function is used internally by the ALTER TABLE ALTER COLUMN command.
 ** It is only accessible to SQL created using sqlite3NestedParse().  It is
 ** not reachable from ordinary SQL passed into sqlite3_prepare() unless the
 ** SQLITE_TESTCTRL_INTERNAL_FUNCTIONS test setting is enabled.

--- a/src/parse.y
+++ b/src/parse.y
@@ -1719,7 +1719,7 @@ add_column_fullname ::= fullname(X). {
   sqlite3AlterBeginAddColumn(pParse, X);
 }
 cmd ::= ALTER TABLE fullname(X) RENAME kwcolumn_opt nm(Y) TO nm(Z). {
-  libsqlAlterUpdateColumn(pParse, X, &Y, &Z);
+  sqlite3AlterRenameColumn(pParse, X, &Y, &Z);
 }
 
 cmd ::= ALTER TABLE fullname(X) UPDATE COLUMNKW columnname(Y) TO columnname(Z) carglist. {

--- a/src/parse.y
+++ b/src/parse.y
@@ -1719,7 +1719,11 @@ add_column_fullname ::= fullname(X). {
   sqlite3AlterBeginAddColumn(pParse, X);
 }
 cmd ::= ALTER TABLE fullname(X) RENAME kwcolumn_opt nm(Y) TO nm(Z). {
-  sqlite3AlterRenameColumn(pParse, X, &Y, &Z);
+  libsqlAlterUpdateColumn(pParse, X, &Y, &Z);
+}
+
+cmd ::= ALTER TABLE fullname(X) UPDATE COLUMNKW columnname(Y) TO columnname(Z) carglist. {
+  libsqlAlterUpdateColumn(pParse, X, &Y, &Z);
 }
 
 kwcolumn_opt ::= .

--- a/src/parse.y
+++ b/src/parse.y
@@ -1722,7 +1722,7 @@ cmd ::= ALTER TABLE fullname(X) RENAME kwcolumn_opt nm(Y) TO nm(Z). {
   sqlite3AlterRenameColumn(pParse, X, &Y, &Z);
 }
 
-cmd ::= ALTER TABLE fullname(X) UPDATE COLUMNKW columnname(Y) TO columnname(Z) carglist. {
+cmd ::= ALTER TABLE fullname(X) ALTER COLUMNKW columnname(Y) TO columnname(Z) carglist. {
   libsqlAlterUpdateColumn(pParse, X, &Y, &Z);
 }
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -1723,7 +1723,7 @@ cmd ::= ALTER TABLE fullname(X) RENAME kwcolumn_opt nm(Y) TO nm(Z). {
 }
 
 cmd ::= ALTER TABLE fullname(X) ALTER COLUMNKW columnname(Y) TO columnname(Z) carglist. {
-  libsqlAlterUpdateColumn(pParse, X, &Y, &Z);
+  libsqlAlterAlterColumn(pParse, X, &Y, &Z);
 }
 
 kwcolumn_opt ::= .

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -5196,6 +5196,7 @@ void sqlite3Reindex(Parse*, Token*, Token*);
 void sqlite3AlterFunctions(void);
 void sqlite3AlterRenameTable(Parse*, SrcList*, Token*);
 void sqlite3AlterRenameColumn(Parse*, SrcList*, Token*, Token*);
+void libsqlAlterUpdateColumn(Parse*, SrcList*, Token*, Token*);
 int sqlite3GetToken(const unsigned char *, int *);
 void sqlite3NestedParse(Parse*, const char*, ...);
 void sqlite3ExpirePreparedStatements(sqlite3*, int);

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -5196,7 +5196,7 @@ void sqlite3Reindex(Parse*, Token*, Token*);
 void sqlite3AlterFunctions(void);
 void sqlite3AlterRenameTable(Parse*, SrcList*, Token*);
 void sqlite3AlterRenameColumn(Parse*, SrcList*, Token*, Token*);
-void libsqlAlterUpdateColumn(Parse*, SrcList*, Token*, Token*);
+void libsqlAlterAlterColumn(Parse*, SrcList*, Token*, Token*);
 int sqlite3GetToken(const unsigned char *, int *);
 void sqlite3NestedParse(Parse*, const char*, ...);
 void sqlite3ExpirePreparedStatements(sqlite3*, int);

--- a/test/rust_suite/src/alter_column.rs
+++ b/test/rust_suite/src/alter_column.rs
@@ -178,3 +178,15 @@ fn test_update_forbidden() {
         .execute("ALTER TABLE t6 ALTER COLUMN id TO id GENERATED ALWAYS", ())
         .is_ok());
 }
+
+#[test]
+fn test_update_view_forbidden() {
+    let conn = Connection::open_in_memory().unwrap();
+
+    conn.execute("CREATE TABLE t(id)", ()).unwrap();
+    conn.execute("CREATE VIEW v AS SELECT * FROM t", ())
+        .unwrap();
+    assert!(conn
+        .execute("ALTER TABLE v ALTER COLUMN id TO id", ())
+        .is_err());
+}

--- a/test/rust_suite/src/alter_column.rs
+++ b/test/rust_suite/src/alter_column.rs
@@ -6,7 +6,7 @@ fn test_update_column_check() {
 
     conn.execute("CREATE TABLE t(id)", ()).unwrap();
     conn.execute("INSERT INTO t VALUES (10)", ()).unwrap();
-    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id CHECK(id < 5)", ())
+    conn.execute("ALTER TABLE t ALTER COLUMN id TO id CHECK(id < 5)", ())
         .unwrap();
     assert!(conn.execute("INSERT INTO t VALUES (10)", ()).is_err());
     assert!(conn.execute("INSERT INTO t VALUES (4)", ()).is_ok());
@@ -16,7 +16,7 @@ fn test_update_column_check() {
     assert!(conn
         .execute("UPDATE t SET id = 4 WHERE id = 10", ())
         .is_ok());
-    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id", ())
+    conn.execute("ALTER TABLE t ALTER COLUMN id TO id", ())
         .unwrap();
     assert!(conn.execute("INSERT INTO t VALUES (10)", ()).is_ok());
 }
@@ -36,7 +36,7 @@ fn test_update_default_constraint() {
         .query_row("SELECT id FROM t WHERE id = 42", (), |_| Ok(()))
         .is_err());
 
-    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id DEFAULT 42", ())
+    conn.execute("ALTER TABLE t ALTER COLUMN id TO id DEFAULT 42", ())
         .unwrap();
     assert!(conn.execute("INSERT INTO t DEFAULT VALUES", ()).is_ok());
     let row: Result<i64, _> =
@@ -50,7 +50,7 @@ fn test_update_not_null_constraint() {
 
     conn.execute("CREATE TABLE t(id)", ()).unwrap();
     assert!(conn.execute("INSERT INTO t VALUES (NULL)", ()).is_ok());
-    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id INT NOT NULL", ())
+    conn.execute("ALTER TABLE t ALTER COLUMN id TO id INT NOT NULL", ())
         .unwrap();
     assert!(conn.execute("INSERT INTO t VALUES (NULL)", ()).is_err());
     assert!(conn.execute("INSERT INTO t DEFAULT VALUES", ()).is_err());
@@ -66,7 +66,7 @@ fn test_update_references_foreign_key() {
         .unwrap();
     conn.execute("INSERT INTO t1 VALUES (1)", ()).unwrap();
     conn.execute(
-        "ALTER TABLE t2 UPDATE COLUMN t1_id TO t1_id REFERENCES t1(id)",
+        "ALTER TABLE t2 ALTER COLUMN t1_id TO t1_id REFERENCES t1(id)",
         (),
     )
     .unwrap();
@@ -85,7 +85,7 @@ fn test_update_references_foreign_key() {
     assert!(conn
         .execute("UPDATE t1 SET t1_id = 42 WHERE t1_id = 1", ())
         .is_err());
-    conn.execute("ALTER TABLE t2 UPDATE COLUMN t1_id TO t1_id", ())
+    conn.execute("ALTER TABLE t2 ALTER COLUMN t1_id TO t1_id", ())
         .unwrap();
     // It's again ok to insert a row with a non-existent foreign key
     assert!(conn
@@ -98,21 +98,21 @@ fn test_update_syntax_validation() {
     let conn = Connection::open_in_memory().unwrap();
 
     assert!(conn
-        .execute("ALTER TABLE t UPDATE COLUMN id TO id", ())
+        .execute("ALTER TABLE t ALTER COLUMN id TO id", ())
         .is_err());
     conn.execute("CREATE TABLE t(id)", ()).unwrap();
     assert!(conn
-        .execute("ALTER TABLE t UPDATE COLUMN id TO id", ())
+        .execute("ALTER TABLE t ALTER COLUMN id TO id", ())
         .is_ok());
     assert!(conn
-        .execute("ALTER TABLE t UPDATE COLUMN id TO id 1 2 3", ())
+        .execute("ALTER TABLE t ALTER COLUMN id TO id 1 2 3", ())
         .is_err());
     assert!(conn
-        .execute("ALTER TABLE t UPDATE COLUMN id TO id2", ())
+        .execute("ALTER TABLE t ALTER COLUMN id TO id2", ())
         .is_err());
     assert!(conn
         .execute(
-            "ALTER TABLE t UPDATE COLUMN id TO id REFERENCES x(y) TEXT",
+            "ALTER TABLE t ALTER COLUMN id TO id REFERENCES x(y) TEXT",
             ()
         ) // type affinity should go before REFERENCES
         .is_err());
@@ -121,11 +121,11 @@ fn test_update_syntax_validation() {
         .unwrap();
     assert!(conn
         .execute(
-            "ALTER TABLE \";;)),\" UPDATE COLUMN \"v,);\" TO \"v,);\" float",
+            "ALTER TABLE \";;)),\" ALTER COLUMN \"v,);\" TO \"v,);\" float",
             ()
         )
         .is_ok());
     assert!(conn
-        .execute("ALTER TABLE \";;)),\" UPDATE COLUMN \"v,);\" TO \"v,);\" REFERENCES \"x;;,)\"(\"y;,,,,\")", ())
+        .execute("ALTER TABLE \";;)),\" ALTER COLUMN \"v,);\" TO \"v,);\" REFERENCES \"x;;,)\"(\"y;,,,,\")", ())
         .is_ok());
 }

--- a/test/rust_suite/src/alter_column.rs
+++ b/test/rust_suite/src/alter_column.rs
@@ -154,7 +154,7 @@ fn test_update_forbidden() {
     assert!(conn
         .execute("ALTER TABLE t3 ALTER COLUMN id TO id UNIQUE", ())
         .is_err());
-    conn.execute("CREATE TABLE t4(id int PRIMARY KEY UNIQUE)", ())
+    conn.execute("CREATE TABLE t4(id int UNIQUE)", ())
         .unwrap();
     assert!(conn
         .execute("ALTER TABLE t4 ALTER COLUMN id TO id", ())
@@ -169,14 +169,6 @@ fn test_update_forbidden() {
     assert!(conn
         .execute("ALTER TABLE t5 ALTER COLUMN id TO id GENERATED ALWAYS", ())
         .is_err());
-    conn.execute("CREATE TABLE t6(id int PRIMARY KEY GENERATED ALWAYS)", ())
-        .unwrap();
-    assert!(conn
-        .execute("ALTER TABLE t6 ALTER COLUMN id TO id", ())
-        .is_err());
-    assert!(conn
-        .execute("ALTER TABLE t6 ALTER COLUMN id TO id GENERATED ALWAYS", ())
-        .is_ok());
 }
 
 #[test]

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -1,4 +1,6 @@
 mod random_rowid;
+#[cfg(test)]
+mod update_column;
 mod virtual_wal;
 
 #[cfg(all(test, feature = "udf"))]

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -1,6 +1,6 @@
-mod random_rowid;
 #[cfg(test)]
-mod update_column;
+mod alter_column;
+mod random_rowid;
 mod virtual_wal;
 
 #[cfg(all(test, feature = "udf"))]

--- a/test/rust_suite/src/update_column.rs
+++ b/test/rust_suite/src/update_column.rs
@@ -1,0 +1,94 @@
+use rusqlite::Connection;
+
+#[test]
+fn test_update_column_check() {
+    let conn = Connection::open_in_memory().unwrap();
+
+    conn.execute("CREATE TABLE t(id)", ()).unwrap();
+    conn.execute("INSERT INTO t VALUES (10)", ()).unwrap();
+    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id CHECK(id < 5)", ())
+        .unwrap();
+    assert!(conn.execute("INSERT INTO t VALUES (10)", ()).is_err());
+    assert!(conn.execute("INSERT INTO t VALUES (4)", ()).is_ok());
+    assert!(conn
+        .execute("UPDATE t SET id = 10 WHERE id = 10", ())
+        .is_err());
+    assert!(conn
+        .execute("UPDATE t SET id = 4 WHERE id = 10", ())
+        .is_ok());
+    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id", ())
+        .unwrap();
+    assert!(conn.execute("INSERT INTO t VALUES (10)", ()).is_ok());
+}
+
+#[test]
+fn test_update_default_constraint() {
+    let conn = Connection::open_in_memory().unwrap();
+
+    conn.execute("CREATE TABLE t(id)", ()).unwrap();
+    assert!(conn.execute("INSERT INTO t VALUES (10)", ()).is_ok());
+
+    let row: Result<i64, _> = conn.query_row("SELECT id FROM t", [], |row| row.get(0));
+    assert_eq!(row.unwrap(), 10);
+
+    assert!(conn.execute("INSERT INTO t DEFAULT VALUES", ()).is_ok());
+    assert!(conn
+        .query_row("SELECT id FROM t WHERE id = 42", (), |_| Ok(()))
+        .is_err());
+
+    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id DEFAULT 42", ())
+        .unwrap();
+    assert!(conn.execute("INSERT INTO t DEFAULT VALUES", ()).is_ok());
+    let row: Result<i64, _> =
+        conn.query_row("SELECT id FROM t WHERE id = 42", [], |row| row.get(0));
+    assert_eq!(row.unwrap(), 42);
+}
+
+#[test]
+fn test_update_not_null_constraint() {
+    let conn = Connection::open_in_memory().unwrap();
+
+    conn.execute("CREATE TABLE t(id)", ()).unwrap();
+    assert!(conn.execute("INSERT INTO t VALUES (NULL)", ()).is_ok());
+    conn.execute("ALTER TABLE t UPDATE COLUMN id TO id INT NOT NULL", ())
+        .unwrap();
+    assert!(conn.execute("INSERT INTO t VALUES (NULL)", ()).is_err());
+    assert!(conn.execute("INSERT INTO t DEFAULT VALUES", ()).is_err());
+}
+
+#[test]
+fn test_update_references_foreign_key() {
+    let conn = Connection::open_in_memory().unwrap();
+
+    conn.execute("CREATE TABLE t1(id int primary key)", ())
+        .unwrap();
+    conn.execute("CREATE TABLE t2(id int primary key, v text, t1_id)", ())
+        .unwrap();
+    conn.execute("INSERT INTO t1 VALUES (1)", ()).unwrap();
+    conn.execute(
+        "ALTER TABLE t2 UPDATE COLUMN t1_id TO t1_id REFERENCES t1(id)",
+        (),
+    )
+    .unwrap();
+    // Inserting a row with a non-existent foreign key is ok, because those are not validated by default
+    assert!(conn
+        .execute("INSERT INTO t2 VALUES (1, 'a', 42)", ())
+        .is_ok());
+    // Now they should be validated
+    conn.execute("PRAGMA foreign_keys = ON", ()).unwrap();
+    assert!(conn
+        .execute("INSERT INTO t2 VALUES (2, 'b', 42)", ())
+        .is_err());
+    assert!(conn
+        .execute("INSERT INTO t2 VALUES (2, 'b', 1)", ())
+        .is_ok());
+    assert!(conn
+        .execute("UPDATE t1 SET t1_id = 42 WHERE t1_id = 1", ())
+        .is_err());
+    conn.execute("ALTER TABLE t2 UPDATE COLUMN t1_id TO t1_id", ())
+        .unwrap();
+    // It's again ok to insert a row with a non-existent foreign key
+    assert!(conn
+        .execute("INSERT INTO t2 VALUES (3, 'c', 42)", ())
+        .is_ok());
+}


### PR DESCRIPTION
This draft extends SQL syntax in libSQL by allowing one to redefine a column declaration, e.g. by adding/removing a constraint, or changing the type affinity.

Examples:
```sql
libsql> CREATE TABLE t(id, v);
```
```sql
libsql> ALTER TABLE t ALTER COLUMN v TO v NOT NULL CHECK(v < 42);
libsql> .schema t
CREATE TABLE t(id, v NOT NULL CHECK(v < 42));
```
```sql
libsql> ALTER TABLE t ALTER COLUMN v TO v TEXT DEFAULT 'hai';
libsql> .schema t
CREATE TABLE t(id, v TEXT DEFAULT 'hai');
```
```sql
libsql> ALTER TABLE t ALTER COLUMN v TO v;
libsql> .schema t
CREATE TABLE t(id, v);
```

Fixes #43 