### PR TITLE
libsql/replication: Move to gRPC based endpoints

### DIFF
--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -7,7 +7,7 @@ async fn main() {
     let db_file = tempfile::NamedTempFile::new().unwrap();
     println!("Database {}", db_file.path().display());
 
-    let opts = libsql::Opts::with_http_sync("http://localhost:8081".to_owned());
+    let opts = libsql::Opts::with_http_sync("http://localhost:8080".to_owned());
     let db = Database::open_with_opts(db_file.path().to_str().unwrap(), opts)
         .await
         .unwrap();
@@ -18,7 +18,8 @@ async fn main() {
             Ok(frames_applied) => {
                 if frames_applied == 0 {
                     println!("No more frames at the moment! See you later");
-                    break;
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    continue;
                 }
                 println!("Applied {frames_applied} frames");
             }

--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -24,6 +24,15 @@ once_cell = "1.18.0"
 nix = "0.26.2"
 tokio-stream = "0.1.14"
 regex = "1.9.0"
-reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 serde_json = "1.0.103"
 serde = { version = "1.0.173", features = ["serde_derive"] }
+tonic = { version = "0.9", features = ["tls", "tls-roots", "tls-webpki-roots"] }
+prost = "0.11"
+hyper = "0.14"
+hyper-rustls = { version = "0.24", features = ["webpki-roots"] }
+http = "0.2"
+tower = "0.4"
+
+[dev-dependencies]
+tonic-build = "0.9"
+prost-build = "0.11"

--- a/crates/replication/proto/replication_log.proto
+++ b/crates/replication/proto/replication_log.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+package wal_log;
+
+message LogOffset {
+    uint64 next_offset = 1;
+}
+
+message HelloRequest { }
+
+message HelloResponse {
+    /// Uuid of the current generation
+    string generation_id = 1;
+    /// First frame_no in the current generation
+    uint64 generation_start_index = 2;
+    /// Uuid of the database being replicated
+    string database_id = 3;
+}
+
+message Frame {
+    bytes data = 1;
+}
+
+service ReplicationLog {
+    rpc Hello(HelloRequest) returns (HelloResponse) {}
+    rpc LogEntries(LogOffset) returns (stream Frame) {}
+    rpc Snapshot(LogOffset) returns (stream Frame) {}
+}

--- a/crates/replication/src/client.rs
+++ b/crates/replication/src/client.rs
@@ -1,0 +1,101 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use hyper::{
+    client::{conn::SendRequest, HttpConnector},
+    Client,
+};
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
+use tokio::sync::Mutex;
+use tonic::body::BoxBody;
+use tower::Service;
+
+#[derive(Debug, Clone)]
+pub struct H2cChannel {
+    client: Client<HttpsConnector<HttpConnector>>,
+    h2_client: Arc<Mutex<Option<SendRequest<BoxBody>>>>,
+}
+
+impl H2cChannel {
+    pub fn new() -> Self {
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client = Client::builder().build(https);
+        let h2_client = Arc::new(Mutex::new(None));
+
+        Self { client, h2_client }
+    }
+}
+
+impl Service<http::Request<BoxBody>> for H2cChannel {
+    type Response = http::Response<hyper::Body>;
+    type Error = anyhow::Error;
+    type Future =
+        Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: http::Request<BoxBody>) -> Self::Future {
+        let client = self.client.clone();
+        let h2_client_lock = self.h2_client.clone();
+
+        Box::pin(async move {
+            let mut lock = h2_client_lock.lock().await;
+
+            if let Some(client) = &mut *lock {
+                let res = client.send_request(req).await;
+
+                // If we get an error from the request then we should throw away
+                // the client so that it can recreate. Most normal operational
+                // errors go through the response type and the Err's returned
+                // from hyper are for more fatal style errors.
+                if let Err(e) = &res {
+                    tracing::debug!("Client error: {}, throwing it away", e);
+                    *lock = None;
+                }
+
+                res.map_err(Into::into)
+            } else {
+                let origin = req.uri();
+
+                let h2c_req = hyper::Request::builder()
+                    .uri(origin)
+                    .header(http::header::UPGRADE, "h2c")
+                    .body(hyper::Body::empty())
+                    .unwrap();
+
+                let res = client.request(h2c_req).await?;
+
+                if res.status() != http::StatusCode::SWITCHING_PROTOCOLS {
+                    anyhow::bail!("We did not get an http2 upgrade, status: {}", res.status());
+                }
+
+                let upgraded_io = hyper::upgrade::on(res).await?;
+
+                tracing::debug!("Upgraded connection to h2");
+
+                let (mut h2_client, conn) = hyper::client::conn::Builder::new()
+                    .http2_only(true)
+                    .http2_keep_alive_interval(std::time::Duration::from_secs(10))
+                    .http2_keep_alive_while_idle(true)
+                    .handshake(upgraded_io)
+                    .await?;
+                tokio::spawn(conn);
+
+                let fut = h2_client.send_request(req);
+                *lock = Some(h2_client);
+
+                fut.await.map_err(Into::into)
+            }
+        })
+    }
+}

--- a/crates/replication/src/generated/wal_log.rs
+++ b/crates/replication/src/generated/wal_log.rs
@@ -1,0 +1,472 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogOffset {
+    #[prost(uint64, tag = "1")]
+    pub next_offset: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HelloRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HelloResponse {
+    /// / Uuid of the current generation
+    #[prost(string, tag = "1")]
+    pub generation_id: ::prost::alloc::string::String,
+    /// / First frame_no in the current generation
+    #[prost(uint64, tag = "2")]
+    pub generation_start_index: u64,
+    /// / Uuid of the database being replicated
+    #[prost(string, tag = "3")]
+    pub database_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Frame {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub data: ::prost::bytes::Bytes,
+}
+/// Generated client implementations.
+pub mod replication_log_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct ReplicationLogClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ReplicationLogClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ReplicationLogClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ReplicationLogClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            ReplicationLogClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn hello(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HelloRequest>,
+        ) -> std::result::Result<tonic::Response<super::HelloResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/wal_log.ReplicationLog/Hello",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("wal_log.ReplicationLog", "Hello"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn log_entries(
+            &mut self,
+            request: impl tonic::IntoRequest<super::LogOffset>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::Frame>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/wal_log.ReplicationLog/LogEntries",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("wal_log.ReplicationLog", "LogEntries"));
+            self.inner.server_streaming(req, path, codec).await
+        }
+        pub async fn snapshot(
+            &mut self,
+            request: impl tonic::IntoRequest<super::LogOffset>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::Frame>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/wal_log.ReplicationLog/Snapshot",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("wal_log.ReplicationLog", "Snapshot"));
+            self.inner.server_streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod replication_log_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ReplicationLogServer.
+    #[async_trait]
+    pub trait ReplicationLog: Send + Sync + 'static {
+        async fn hello(
+            &self,
+            request: tonic::Request<super::HelloRequest>,
+        ) -> std::result::Result<tonic::Response<super::HelloResponse>, tonic::Status>;
+        /// Server streaming response type for the LogEntries method.
+        type LogEntriesStream: futures_core::Stream<
+                Item = std::result::Result<super::Frame, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        async fn log_entries(
+            &self,
+            request: tonic::Request<super::LogOffset>,
+        ) -> std::result::Result<tonic::Response<Self::LogEntriesStream>, tonic::Status>;
+        /// Server streaming response type for the Snapshot method.
+        type SnapshotStream: futures_core::Stream<
+                Item = std::result::Result<super::Frame, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        async fn snapshot(
+            &self,
+            request: tonic::Request<super::LogOffset>,
+        ) -> std::result::Result<tonic::Response<Self::SnapshotStream>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct ReplicationLogServer<T: ReplicationLog> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: ReplicationLog> ReplicationLogServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ReplicationLogServer<T>
+    where
+        T: ReplicationLog,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/wal_log.ReplicationLog/Hello" => {
+                    #[allow(non_camel_case_types)]
+                    struct HelloSvc<T: ReplicationLog>(pub Arc<T>);
+                    impl<
+                        T: ReplicationLog,
+                    > tonic::server::UnaryService<super::HelloRequest> for HelloSvc<T> {
+                        type Response = super::HelloResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::HelloRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).hello(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = HelloSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/wal_log.ReplicationLog/LogEntries" => {
+                    #[allow(non_camel_case_types)]
+                    struct LogEntriesSvc<T: ReplicationLog>(pub Arc<T>);
+                    impl<
+                        T: ReplicationLog,
+                    > tonic::server::ServerStreamingService<super::LogOffset>
+                    for LogEntriesSvc<T> {
+                        type Response = super::Frame;
+                        type ResponseStream = T::LogEntriesStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::LogOffset>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).log_entries(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = LogEntriesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/wal_log.ReplicationLog/Snapshot" => {
+                    #[allow(non_camel_case_types)]
+                    struct SnapshotSvc<T: ReplicationLog>(pub Arc<T>);
+                    impl<
+                        T: ReplicationLog,
+                    > tonic::server::ServerStreamingService<super::LogOffset>
+                    for SnapshotSvc<T> {
+                        type Response = super::Frame;
+                        type ResponseStream = T::SnapshotStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::LogOffset>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).snapshot(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SnapshotSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: ReplicationLog> Clone for ReplicationLogServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: ReplicationLog> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: ReplicationLog> tonic::server::NamedService for ReplicationLogServer<T> {
+        const NAME: &'static str = "wal_log.ReplicationLog";
+    }
+}

--- a/crates/replication/tests/bootstrap.rs
+++ b/crates/replication/tests/bootstrap.rs
@@ -1,0 +1,32 @@
+use std::{path::PathBuf, process::Command};
+
+#[test]
+fn bootstrap() {
+    let iface_files = &["proto/replication_log.proto"];
+    let dirs = &["proto"];
+
+    let out_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("generated");
+
+    let mut config = prost_build::Config::new();
+    config.bytes(&[".wal_log.Frame"]);
+
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .build_transport(true)
+        .out_dir(&out_dir)
+        .compile_with_config(config, iface_files, dirs)
+        .unwrap();
+
+    let status = Command::new("git")
+        .arg("diff")
+        .arg("--exit-code")
+        .arg("--")
+        .arg(&out_dir)
+        .status()
+        .unwrap();
+
+    assert!(status.success(), "You should commit the protobuf files");
+}


### PR DESCRIPTION
This commit moves us from http based replication endpoints to gRPC based ones.

This also includes `h2c` upgrade code due to our hosting not doing proper ALPN negotiation.