### PR TITLE
connection: drop the lifetime parameter

### DIFF
--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -4,6 +4,7 @@ use libsql_sys::ffi;
 use std::ffi::c_int;
 
 /// A connection to a libSQL database.
+#[derive(Clone, Debug)]
 pub struct Connection {
     pub(crate) raw: *mut ffi::sqlite3,
 }
@@ -55,7 +56,7 @@ impl Connection {
 
     /// Prepare the SQL statement.
     pub fn prepare<S: Into<String>>(&self, sql: S) -> Result<Statement> {
-        Statement::prepare(self, self.raw, sql.into().as_str())
+        Statement::prepare(self.clone(), self.raw, sql.into().as_str())
     }
 
     /// Execute the SQL statement synchronously.
@@ -73,7 +74,7 @@ impl Connection {
         S: Into<String>,
         P: Into<Params>,
     {
-        let stmt = Statement::prepare(&self, self.raw, sql.into().as_str())?;
+        let stmt = Statement::prepare(self.clone(), self.raw, sql.into().as_str())?;
         let params = params.into();
         Ok(stmt.execute(&params))
     }
@@ -89,7 +90,7 @@ impl Connection {
         P: Into<Params>,
     {
         RowsFuture {
-            conn: &self,
+            conn: self.clone(),
             sql: sql.into(),
             params: params.into(),
         }

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -49,19 +49,19 @@ impl Rows {
     }
 }
 
-pub struct RowsFuture<'a> {
-    pub(crate) conn: &'a Connection,
+pub struct RowsFuture {
+    pub(crate) conn: Connection,
     pub(crate) sql: String,
     pub(crate) params: Params,
 }
 
-impl RowsFuture<'_> {
+impl RowsFuture {
     pub fn wait(&mut self) -> Result<Option<Rows>> {
         futures::executor::block_on(self)
     }
 }
 
-impl futures::Future for RowsFuture<'_> {
+impl futures::Future for RowsFuture {
     type Output = Result<Option<Rows>>;
 
     fn poll(

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -6,17 +6,17 @@ use std::ffi::c_int;
 use std::sync::Arc;
 
 /// A prepared statement.
-pub struct Statement<'a> {
-    _conn: &'a Connection,
+pub struct Statement {
+    _conn: Connection,
     inner: Arc<libsql_sys::Statement>,
 }
 
-impl Statement<'_> {
-    pub(crate) fn prepare<'a>(
-        conn: &'a Connection,
+impl Statement {
+    pub(crate) fn prepare(
+        conn: Connection,
         raw: *mut libsql_sys::ffi::sqlite3,
         sql: &str,
-    ) -> Result<Statement<'a>> {
+    ) -> Result<Statement> {
         match unsafe { libsql_sys::prepare_stmt(raw, sql) } {
             Ok(stmt) => Ok(Statement {
                 _conn: conn,
@@ -212,7 +212,7 @@ impl Column<'_> {
     }
 }
 
-impl Statement<'_> {
+impl Statement {
     /// Get all the column names in the result set of the prepared statement.
     ///
     /// If associated DB schema can be altered concurrently, you should make


### PR DESCRIPTION
The parameter was really redundant, given that Connection just wraps over an already thread-safe pointer.

Important: what we "lose" here is that statement lifetimes are no longer tied to the connection, but they in fact never were, because nobody prevented calling a `disconnect()` on a connection, which will just free the underlying pointer.

Note that if/when we decide that a `Connection` should clean up after itself and close the raw connection it points to, we'll need to wrap the pointer in an internal `Arc`.