### PR TITLE
replication: fix off-by-one error

### DIFF
--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -122,7 +122,7 @@ impl Replicator {
             meta,
             injector,
             client: None,
-            next_offset: AtomicU64::new(1),
+            next_offset: AtomicU64::new(0),
         })
     }
 


### PR DESCRIPTION
We should start asking for offset 0, not 1. Our internal numbering for frames starts with 0 (and SQLite's starts with 1, hence the confusion).