### PR TITLE
Fix build

### DIFF
--- a/crates/bindings/c/src/lib.rs
+++ b/crates/bindings/c/src/lib.rs
@@ -128,10 +128,10 @@ pub unsafe extern "C" fn libsql_free_rows(res: libsql_rows_t) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn libsql_execute_async<'a>(
-    conn: &'a libsql_connection_t,
+pub unsafe extern "C" fn libsql_execute_async(
+    conn: &libsql_connection_t,
     sql: *const std::ffi::c_char,
-) -> libsql_rows_future_t<'a> {
+) -> libsql_rows_future_t {
     let sql = unsafe { std::ffi::CStr::from_ptr(sql) };
     let sql = match sql.to_str() {
         Ok(sql) => sql,

--- a/crates/bindings/c/src/types.rs
+++ b/crates/bindings/c/src/types.rs
@@ -143,18 +143,18 @@ impl From<&mut libsql_rows> for libsql_rows_t {
     }
 }
 
-pub struct libsql_rows_future<'a> {
-    pub(crate) result: libsql::RowsFuture<'a>,
+pub struct libsql_rows_future {
+    pub(crate) result: libsql::RowsFuture,
 }
 
 #[derive(Clone, Debug)]
 #[repr(transparent)]
-pub struct libsql_rows_future_t<'a> {
-    ptr: *const libsql_rows_future<'a>,
+pub struct libsql_rows_future_t {
+    ptr: *const libsql_rows_future,
 }
 
-impl libsql_rows_future_t<'_> {
-    pub fn null<'a>() -> libsql_rows_future_t<'a> {
+impl libsql_rows_future_t {
+    pub fn null() -> libsql_rows_future_t {
         libsql_rows_future_t {
             ptr: std::ptr::null(),
         }
@@ -176,15 +176,15 @@ impl libsql_rows_future_t<'_> {
 }
 
 #[allow(clippy::from_over_into)]
-impl<'a> From<&'a libsql_rows_future<'a>> for libsql_rows_future_t<'a> {
-    fn from(value: &'a libsql_rows_future) -> Self {
+impl From<&libsql_rows_future> for libsql_rows_future_t {
+    fn from(value: &libsql_rows_future) -> Self {
         Self { ptr: value }
     }
 }
 
 #[allow(clippy::from_over_into)]
-impl<'a> From<&'a mut libsql_rows_future<'a>> for libsql_rows_future_t<'a> {
-    fn from(value: &'a mut libsql_rows_future) -> Self {
+impl From<&mut libsql_rows_future> for libsql_rows_future_t {
+    fn from(value: &mut libsql_rows_future) -> Self {
         Self { ptr: value }
     }
 }


### PR DESCRIPTION
f442c5c2071a12031d37e39885999458ccf83306 broke the build of bindings/ crate by removing lifetime parameter and not propagating it to that crate.