### PR TITLE
libsql/replication: Switch to BatchLogEntries RPC

### DIFF
--- a/crates/replication/proto/replication_log.proto
+++ b/crates/replication/proto/replication_log.proto
@@ -20,8 +20,13 @@ message Frame {
     bytes data = 1;
 }
 
+message Frames {
+    repeated Frame frames = 1;
+}
+
 service ReplicationLog {
     rpc Hello(HelloRequest) returns (HelloResponse) {}
     rpc LogEntries(LogOffset) returns (stream Frame) {}
+    rpc BatchLogEntries(LogOffset) returns (Frames) {}
     rpc Snapshot(LogOffset) returns (stream Frame) {}
 }

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -20,7 +20,6 @@ pub use frame::{Frame, FrameHeader};
 pub use replica::hook::{Frames, InjectorHookCtx};
 use replica::snapshot::SnapshotFileHeader;
 pub use replica::snapshot::TempSnapshot;
-use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -272,21 +271,18 @@ impl Replicator {
         }
 
         let frames = client
-            .log_entries(pb::LogOffset {
+            .batch_log_entries(pb::LogOffset {
                 next_offset: self.next_offset.load(Ordering::Relaxed),
             })
             .await
             .context("Failed to fetch log entries")?
             .into_inner();
-
-        let frames = frames
-            .map(|r| {
-                r.context("frame stream")
-                    .and_then(|f| Frame::try_from_bytes(f.data.into()))
+        let frames = frames.frames.iter()
+            .map(|f| {
+                Frame::try_from_bytes(f.data.clone())
             })
             .collect::<Result<Vec<_>, _>>()
-            .await
-            .context("frames stream")?;
+            .context("frames batch")?;
 
         Ok(frames)
     }


### PR DESCRIPTION
The LogEntries RPC is stream-based, which doesn't really work for the `sync()` API we have. Switch to the new BatchLogEntries RPC introduced by Lucio.