### PR TITLE
libsql/core: Fix Statement::execute() signature

### DIFF
--- a/crates/bindings/c/src/lib.rs
+++ b/crates/bindings/c/src/lib.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn libsql_execute(
         }
     };
     let conn = conn.get_ref();
-    match conn.execute(sql.to_string(), ()) {
+    match conn.query(sql.to_string(), ()) {
         Ok(rows_opt) => {
             if let Some(rows) = rows_opt {
                 let rows = Box::leak(Box::new(libsql_rows { result: rows }));

--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -59,24 +59,31 @@ impl Connection {
         Statement::prepare(self.clone(), self.raw, sql.into().as_str())
     }
 
-    /// Execute the SQL statement synchronously.
-    ///
-    /// If you execute a SQL query statement (e.g. `SELECT` statement) that
-    /// returns rows, then this method returns `Some(Rows)`on success; otherwise
-    /// this method returns `None`.
-    ///
-    /// This method blocks the thread until the SQL statement is executed.
-    /// However, for SQL query statements, the method blocks only until the
-    /// first row is available. To fetch all rows, you need to call `Rows::next()`
-    /// consecutively.
-    pub fn execute<S, P>(&self, sql: S, params: P) -> Result<Option<Rows>>
+    pub fn query<S, P>(&self, sql: S, params: P) -> Result<Option<Rows>>
     where
         S: Into<String>,
         P: Into<Params>,
     {
         let stmt = Statement::prepare(self.clone(), self.raw, sql.into().as_str())?;
         let params = params.into();
-        Ok(stmt.execute(&params))
+        let ret = stmt.query(&params)?;
+        Ok(Some(ret))
+    }
+
+    /// Execute the SQL statement synchronously.
+    ///
+    /// If you execute a SQL query statement (e.g. `SELECT` statement) that
+    /// returns the number of rows changed.
+    ///
+    /// This method blocks the thread until the SQL statement is executed.
+    pub fn execute<S, P>(&self, sql: S, params: P) -> Result<u64>
+    where
+        S: Into<String>,
+        P: Into<Params>,
+    {
+        let stmt = Statement::prepare(self.clone(), self.raw, sql.into().as_str())?;
+        let params = params.into();
+        stmt.execute(&params)
     }
 
     /// Execute the SQL statement synchronously.

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -18,6 +18,8 @@ pub enum Error {
     LibError(std::ffi::c_int),
     #[error("Query returned no rows")]
     QueryReturnedNoRows,
+    #[error("Execute returned rows")]
+    ExecuteReturnedRows,
 }
 
 pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -69,8 +69,8 @@ impl futures::Future for RowsFuture {
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
         let stmt = self.conn.prepare(&self.sql)?;
-        let ret = stmt.execute(&self.params);
-        std::task::Poll::Ready(Ok(ret))
+        let ret = stmt.query(&self.params)?;
+        std::task::Poll::Ready(Ok(Some(ret)))
     }
 }
 


### PR DESCRIPTION
The JavaScript language bindings, for example, need a function for executing a SQL statement and getting the number of changed rows back. The rusqlite `execute()` function does just that so let's fix our function signature to be compatible.

Fixes #246