### PR TITLE
libsql/replication: Add gRPC auth

### DIFF
--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -7,7 +7,9 @@ async fn main() {
     let db_file = tempfile::NamedTempFile::new().unwrap();
     println!("Database {}", db_file.path().display());
 
-    let opts = libsql::Opts::with_http_sync("http://localhost:8080".to_owned());
+    let auth_token = std::env::var("TURSO_AUTH_TOKEN").expect("Expected a TURSO_AUTH_TOKEN");
+
+    let opts = libsql::Opts::with_http_sync("https://localhost:8080".to_owned(), auth_token);
     let db = Database::open_with_opts(db_file.path().to_str().unwrap(), opts)
         .await
         .unwrap();
@@ -28,7 +30,7 @@ async fn main() {
                 break;
             }
         }
-        let response = conn.execute("SELECT * FROM sqlite_master", ()).unwrap();
+        let response = conn.query("SELECT * FROM sqlite_master", ()).unwrap();
         let rows = match response {
             Some(rows) => rows,
             None => {

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -32,7 +32,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
-//use crate::client::H2cChannel;
+// use crate::client::H2cChannel;
 use crate::pb::HelloRequest;
 
 type RpcClient = pb::ReplicationLogClient<InterceptedService<Channel, AuthInterceptor>>;
@@ -295,8 +295,7 @@ impl Replicator {
             .frames
             .into_iter()
             .map(|f| Frame::try_from_bytes(f.data))
-            .collect::<Result<Vec<_>, _>>()
-            .await?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(frames)
     }

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -31,7 +31,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
-use crate::client::H2cChannel;
+//use crate::client::H2cChannel;
 use crate::pb::HelloRequest;
 
 type RpcClient = pb::ReplicationLogClient<InterceptedService<Channel, AuthInterceptor>>;
@@ -137,8 +137,7 @@ impl Replicator {
         endpoint: impl AsRef<str>,
         auth_token: impl AsRef<str>,
     ) -> anyhow::Result<replica::meta::WalIndexMeta> {
-        let auth_token = auth_token
-            .as_ref()
+        let auth_token = format!("Bearer {}", auth_token.as_ref())
             .try_into()
             .context("Invalid auth token must be ascii")?;
 
@@ -165,8 +164,7 @@ impl Replicator {
 
         let response = client
             .hello(pb::HelloRequest::default())
-            .await
-            .context("Unable to fetch wal metadata")?
+            .await?
             .into_inner();
 
         let generation_id =
@@ -299,8 +297,7 @@ impl Replicator {
                     .and_then(|f| Frame::try_from_bytes(f.data.into()))
             })
             .collect::<Result<Vec<_>, _>>()
-            .await
-            .context("frames stream")?;
+            .await?;
 
         Ok(frames)
     }

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -21,6 +21,10 @@ pub use replica::hook::{Frames, InjectorHookCtx};
 use replica::snapshot::SnapshotFileHeader;
 pub use replica::snapshot::TempSnapshot;
 use tokio_stream::StreamExt;
+use tonic::codegen::InterceptedService;
+use tonic::metadata::{Ascii, MetadataValue};
+use tonic::service::Interceptor;
+use tonic::transport::Channel;
 use uuid::Uuid;
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -30,6 +34,8 @@ use tokio::sync::mpsc::Sender;
 use crate::client::H2cChannel;
 use crate::pb::HelloRequest;
 
+type RpcClient = pb::ReplicationLogClient<InterceptedService<Channel, AuthInterceptor>>;
+
 pub struct Replicator {
     pub frames_sender: Sender<Frames>,
     pub current_frame_no_notifier: tokio::sync::watch::Receiver<FrameNo>,
@@ -38,7 +44,7 @@ pub struct Replicator {
     _hook_ctx: Arc<parking_lot::Mutex<InjectorHookCtx>>,
     pub meta: Arc<parking_lot::Mutex<Option<replica::meta::WalIndexMeta>>>,
     pub injector: replica::injector::FrameInjector<'static>,
-    pub client: Option<pb::ReplicationLogClient<H2cChannel>>,
+    pub client: Option<RpcClient>,
     pub next_offset: AtomicU64,
 }
 
@@ -129,23 +135,31 @@ impl Replicator {
     pub async fn init_metadata(
         &mut self,
         endpoint: impl AsRef<str>,
+        auth_token: impl AsRef<str>,
     ) -> anyhow::Result<replica::meta::WalIndexMeta> {
+        let auth_token = auth_token
+            .as_ref()
+            .try_into()
+            .context("Invalid auth token must be ascii")?;
+
         // TODO: Once fly fixes their proxy to correctly accept h2 we can drop
         // the h2c client but for now lets keep this commented.
         //
-        // let channel = Channel::builder(
-        //     endpoint
-        //         .as_ref()
-        //         .try_into()
-        //         .context("Unable to convert endpoint into a Uri")?,
-        // )
-        // .tls_config(ClientTlsConfig::new())?
-        // .connect_lazy();
+        let channel = Channel::builder(
+            endpoint
+                .as_ref()
+                .try_into()
+                .context("Unable to convert endpoint into a Uri")?,
+        )
+        .http2_keep_alive_interval(std::time::Duration::from_secs(5))
+        .keep_alive_while_idle(true)
+        .tls_config(tonic::transport::ClientTlsConfig::new())?
+        .connect_lazy();
 
-        let channel = H2cChannel::new();
+        // let channel = H2cChannel::new();
 
         let mut client = pb::ReplicationLogClient::with_origin(
-            channel,
+            InterceptedService::new(channel, AuthInterceptor(auth_token)),
             http::Uri::try_from(endpoint.as_ref()).unwrap(),
         );
 
@@ -289,5 +303,15 @@ impl Replicator {
             .context("frames stream")?;
 
         Ok(frames)
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthInterceptor(MetadataValue<Ascii>);
+
+impl Interceptor for AuthInterceptor {
+    fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        req.metadata_mut().insert("x-authorization", self.0.clone());
+        Ok(req)
     }
 }


### PR DESCRIPTION
This commit adds gRPC auth for replication based endpoints by using `x-authorization` header.