### PR TITLE
libsql/core: Add `Connection::execute_batch`

### DIFF
--- a/.github/workflows/maketest.yml
+++ b/.github/workflows/maketest.yml
@@ -35,4 +35,4 @@ jobs:
     # Rust tests are run under maketestwasm
 
     - name: Run API tests
-      run: make libsqlapi
+      run: make testlibsql

--- a/Makefile.in
+++ b/Makefile.in
@@ -834,6 +834,10 @@ rust_bindings: sqlite3.h
 libsqlapi: sqlite3.h
 	cd $(APITOP) && LIBSQL_SRC_DIR=$(TOP) cargo test --all --release --lib
 
+testlibsql: sqlite3.h
+	cd $(APITOP) && LIBSQL_SRC_DIR=$(TOP) cargo test --all --all-targets --all-features &&\
+		cargo test --all --doc --all-features
+
 sqlite3.c:	.target_source $(TOP)/tool/mksqlite3c.tcl
 	$(TCLSH_CMD) $(TOP)/tool/mksqlite3c.tcl $(AMALGAMATION_LINE_MACROS)
 	cp tsrc/sqlite3ext.h .

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
+#[allow(unused)]
 pub struct Database {
     inner: libsql::Database,
 }

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -191,6 +191,16 @@ impl Statement {
             _ => unreachable!("sqlite3_column_type returned invalid value"),
         }
     }
+
+    pub(crate) fn step(&self) -> Result<()> {
+        // TODO(lucio): Handle error from step
+        self.inner.step();
+        Ok(())
+    }
+
+    pub(crate) fn tail(&self) -> usize {
+        self.inner.tail()
+    }
 }
 
 // NOTICE: Column is blatantly copy-pasted from rusqlite

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::missing_safety_doc)]
 
+use std::ffi::{c_char, c_int};
+
 use crate::error::Result;
 
 #[derive(Debug)]
 pub struct Statement {
     pub raw_stmt: *mut crate::ffi::sqlite3_stmt,
+    tail: usize,
 }
 
 // Safety: works as long as libSQL is compiled and set up with SERIALIZABLE threading model, which is the default.
@@ -127,21 +130,73 @@ impl Statement {
     pub fn readonly(&self) -> bool {
         unsafe { crate::ffi::sqlite3_stmt_readonly(self.raw_stmt) != 0 }
     }
+
+    pub fn tail(&self) -> usize {
+        self.tail
+    }
 }
 
 pub unsafe fn prepare_stmt(raw: *mut crate::ffi::sqlite3, sql: &str) -> Result<Statement> {
     let mut raw_stmt = std::ptr::null_mut();
+    let (c_sql, len) = str_for_sqlite(sql.as_bytes())?;
+    let mut c_tail: *const c_char = std::ptr::null_mut();
+
     let err = unsafe {
         crate::ffi::sqlite3_prepare_v2(
             raw,
             sql.as_ptr() as *const i8,
             sql.len() as i32,
             &mut raw_stmt,
-            std::ptr::null_mut(),
+            &mut c_tail,
         )
     };
+
+    // If the input text contains no SQL (if the input is an empty string or a
+    // comment) then *ppStmt is set to NULL.
+    let tail = if c_tail.is_null() {
+        0
+    } else {
+        let n = (c_tail as isize) - (c_sql as isize);
+        if n <= 0 || n >= len as isize {
+            0
+        } else {
+            n as usize
+        }
+    };
+
     match err as u32 {
-        crate::ffi::SQLITE_OK => Ok(Statement { raw_stmt }),
+        crate::ffi::SQLITE_OK => Ok(Statement { raw_stmt, tail }),
         _ => Err(err.into()),
+    }
+}
+
+/// Returns `Ok((string ptr, len as c_int, SQLITE_STATIC | SQLITE_TRANSIENT))`
+/// normally.
+/// Returns error if the string is too large for sqlite.
+/// The `sqlite3_destructor_type` item is always `SQLITE_TRANSIENT` unless
+/// the string was empty (in which case it's `SQLITE_STATIC`, and the ptr is
+/// static).
+fn str_for_sqlite(s: &[u8]) -> Result<(*const c_char, c_int)> {
+    let len = len_as_c_int(s.len())?;
+    let ptr = if len != 0 {
+        s.as_ptr().cast::<c_char>()
+    } else {
+        // Return a pointer guaranteed to live forever
+        "".as_ptr().cast::<c_char>()
+    };
+    Ok((ptr, len))
+}
+
+// Helper to cast to c_int safely, returning the correct error type if the cast
+// failed.
+fn len_as_c_int(len: usize) -> Result<c_int> {
+    if len >= (c_int::MAX as usize) {
+        // Err(Error::SqliteFailure(
+        //     ffi::Error::new(ffi::SQLITE_TOOBIG),
+        //     None,
+        // ))
+        todo!("error SQLITE_TOOBIG")
+    } else {
+        Ok(len as c_int)
     }
 }

--- a/crates/replication/src/client.rs
+++ b/crates/replication/src/client.rs
@@ -20,6 +20,7 @@ pub struct H2cChannel {
 }
 
 impl H2cChannel {
+    #[allow(unused)]
     pub fn new() -> Self {
         let https = HttpsConnectorBuilder::new()
             .with_webpki_roots()


### PR DESCRIPTION
This PR adds a new `Connection::execute_batch` fn and also improves CI to cover more tests.