### PR TITLE
Fix compilation errors on platforms with unsigned chars

### DIFF
--- a/crates/bindings/c/src/lib.rs
+++ b/crates/bindings/c/src/lib.rs
@@ -422,7 +422,7 @@ pub unsafe extern "C" fn libsql_get_blob(
             let data = buf.as_ptr();
             std::mem::forget(buf);
             *out_blob = blob {
-                ptr: data as *const i8,
+                ptr: data as *const std::ffi::c_char,
                 len,
             };
             0

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -1,3 +1,5 @@
+use std::ffi::c_char;
+
 use libsql_sys::ValueType;
 
 pub enum Params {
@@ -107,7 +109,7 @@ impl From<libsql_sys::Value> for Value {
                 if v.is_null() {
                     Value::Null
                 } else {
-                    let v = unsafe { std::ffi::CStr::from_ptr(v as *const i8) };
+                    let v = unsafe { std::ffi::CStr::from_ptr(v as *const c_char) };
                     let v = v.to_str().unwrap();
                     Value::Text(v.to_owned())
                 }
@@ -209,7 +211,7 @@ impl<'a> From<libsql_sys::Value> for ValueRef<'a> {
                 if v.is_null() {
                     ValueRef::Null
                 } else {
-                    let v = unsafe { std::ffi::CStr::from_ptr(v as *const i8) };
+                    let v = unsafe { std::ffi::CStr::from_ptr(v as *const c_char) };
                     ValueRef::Text(v.to_bytes())
                 }
             }

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -2,6 +2,7 @@ use crate::{errors, Connection, Error, Params, Result, Value};
 use libsql_sys::ValueType;
 
 use std::cell::RefCell;
+use std::ffi::c_char;
 use std::sync::Arc;
 
 /// Query result rows.
@@ -171,7 +172,7 @@ impl FromValue for String {
         if ret.is_null() {
             return Err(Error::NullValue);
         }
-        let ret = unsafe { std::ffi::CStr::from_ptr(ret as *const i8) };
+        let ret = unsafe { std::ffi::CStr::from_ptr(ret as *const c_char) };
         let ret = ret.to_str().unwrap();
         Ok(ret.to_string())
     }
@@ -194,7 +195,7 @@ impl FromValue for &str {
         if ret.is_null() {
             return Err(Error::NullValue);
         }
-        let ret = unsafe { std::ffi::CStr::from_ptr(ret as *const i8) };
+        let ret = unsafe { std::ffi::CStr::from_ptr(ret as *const c_char) };
         let ret = ret.to_str().unwrap();
         Ok(ret)
     }

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -50,7 +50,7 @@ impl Statement {
             crate::ffi::sqlite3_bind_text(
                 self.raw_stmt,
                 idx,
-                value.as_ptr() as *const i8,
+                value.as_ptr() as *const c_char,
                 value.len() as i32,
                 None,
             );
@@ -92,7 +92,7 @@ impl Statement {
 
     pub fn column_name(&self, idx: i32) -> &str {
         let raw_name = unsafe { crate::ffi::sqlite3_column_name(self.raw_stmt, idx) };
-        let raw_name = unsafe { std::ffi::CStr::from_ptr(raw_name as *const i8) };
+        let raw_name = unsafe { std::ffi::CStr::from_ptr(raw_name as *const c_char) };
         let raw_name = raw_name.to_str().unwrap();
         raw_name
     }
@@ -144,7 +144,7 @@ pub unsafe fn prepare_stmt(raw: *mut crate::ffi::sqlite3, sql: &str) -> Result<S
     let err = unsafe {
         crate::ffi::sqlite3_prepare_v2(
             raw,
-            sql.as_ptr() as *const i8,
+            sql.as_ptr() as *const c_char,
             sql.len() as i32,
             &mut raw_stmt,
             &mut c_tail,


### PR DESCRIPTION
`*const i8`/`*mut i8` was passed in a bunch of places where `*const c_char`/`*mut c_char` was expected which didn't compile on Linux on aarch64.