### PR TITLE
libsql/core: Switch to TryInto for params

### DIFF
--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -73,10 +73,13 @@ impl Connection {
     pub fn query<S, P>(&self, sql: S, params: P) -> Result<Option<Rows>>
     where
         S: Into<String>,
-        P: Into<Params>,
+        P: TryInto<Params>,
+        P::Error: Into<crate::BoxError>,
     {
         let stmt = Statement::prepare(self.clone(), self.raw, sql.into().as_str())?;
-        let params = params.into();
+        let params = params
+            .try_into()
+            .map_err(|e| Error::ToSqlConversionFailure(e.into()))?;
         let ret = stmt.query(&params)?;
         Ok(Some(ret))
     }
@@ -134,10 +137,13 @@ impl Connection {
     pub fn execute<S, P>(&self, sql: S, params: P) -> Result<u64>
     where
         S: Into<String>,
-        P: Into<Params>,
+        P: TryInto<Params>,
+        P::Error: Into<crate::BoxError>,
     {
         let stmt = Statement::prepare(self.clone(), self.raw, sql.into().as_str())?;
-        let params = params.into();
+        let params = params
+            .try_into()
+            .map_err(|e| Error::ToSqlConversionFailure(e.into()))?;
         stmt.execute(&params)
     }
 

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -20,6 +20,8 @@ pub enum Error {
     QueryReturnedNoRows,
     #[error("Execute returned rows")]
     ExecuteReturnedRows,
+    #[error("unable to convert to sql: `{0}`")]
+    ToSqlConversionFailure(crate::BoxError),
 }
 
 pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod statement;
 pub mod transaction;
 
 pub type Result<T> = std::result::Result<T, errors::Error>;
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 pub use libsql_sys::ffi;
 pub use libsql_sys::ValueType;
@@ -75,5 +76,10 @@ pub fn version_number() -> i32 {
 
 /// Return the version of the underlying SQLite library as a string.
 pub fn version() -> &'static str {
-    unsafe { std::ffi::CStr::from_ptr(ffi::sqlite3_libversion()).to_str().unwrap() }
+    unsafe {
+        std::ffi::CStr::from_ptr(ffi::sqlite3_libversion())
+            .to_str()
+            .unwrap()
+    }
 }
+

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -101,7 +101,10 @@ impl Statement {
         match err as u32 {
             crate::ffi::SQLITE_DONE => Ok(self.conn.changes()),
             crate::ffi::SQLITE_ROW => Err(Error::ExecuteReturnedRows),
-            _ => Err(Error::LibError(err, errors::error_from_handle(self.conn.raw))),
+            _ => Err(Error::LibError(
+                err,
+                errors::error_from_handle(self.conn.raw),
+            )),
         }
     }
 


### PR DESCRIPTION
This commit moves our usage of `Into<Params>` to `TryInto<Params` to enable users to have fallible conversions from their custom params type into a libsql's params type. This is a small step in the right direction for full rusqlite params support.