### PR TITLE
libsql/core: add error code to Error::PrepareFailed

### DIFF
--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -2,8 +2,8 @@
 pub enum Error {
     #[error("Failed to connect to database: `{0}`")]
     ConnectionFailed(String),
-    #[error("Failed to prepare statement `{0}`: `{1}`")]
-    PrepareFailed(String, String),
+    #[error("Failed to prepare statement `{1}`: `{2}`")]
+    PrepareFailed(i32, String, String),
     #[error("Failed to fetch row: `{0}`")]
     FetchRowFailed(String),
     #[error("Unknown value type for column `{0}`: `{1}`")]

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -23,7 +23,8 @@ impl Statement {
                 conn,
                 inner: Arc::new(stmt),
             }),
-            Err(libsql_sys::Error::LibError(_err)) => Err(Error::PrepareFailed(
+            Err(libsql_sys::Error::LibError(err)) => Err(Error::PrepareFailed(
+                err,
                 sql.to_string(),
                 errors::error_from_handle(raw),
             )),


### PR DESCRIPTION
Add result code to `Error::PrepareFailed` so that it's available to the user code.