### PR TITLE
libsql/shell: commands completion

### DIFF
--- a/crates/libsql-shell/Cargo.toml
+++ b/crates/libsql-shell/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.1.8", features = [ "derive", "env"] }
 home = "0.5.4"
 rusqlite = "0.28.0"
 rustyline = "11.0.0"
+rustyline-derive = "0.9.0"
 tabled = "0.12.2"
 tracing-subscriber = "0.3.16"
 


### PR DESCRIPTION
Simple implementation of tab completion logic based on interfaces provided by rustyline. List of commands to complete is hardcoded but I guess we could put list of all commands in some shared variable and reuse it where needed.