### PR TITLE
libsql/core: Fix Column::decl_type()

### DIFF
--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -264,6 +264,10 @@ impl Statement {
         self.inner.column_name(col as i32)
     }
 
+    pub fn column_decltype(&self, col: usize) -> Option<&str> {
+        self.inner.column_decltype(col as i32)
+    }
+
     /// Returns the column index in the result set for a given column name.
     ///
     /// If there is no AS clause then the name of the column is unspecified and
@@ -300,14 +304,7 @@ impl Statement {
         let mut cols = Vec::with_capacity(n);
         for i in 0..n {
             let name = self.column_name(i);
-            let decl_type = match self.inner.column_type(i as i32) as u32 {
-                libsql_sys::ffi::SQLITE_NULL => Some("null"),
-                libsql_sys::ffi::SQLITE_INTEGER => Some("integer"),
-                libsql_sys::ffi::SQLITE_FLOAT => Some("float"),
-                libsql_sys::ffi::SQLITE_TEXT => Some("text"),
-                libsql_sys::ffi::SQLITE_BLOB => Some("blob"),
-                _ => None,
-            };
+            let decl_type = self.column_decltype(i);
             cols.push(Column { name, decl_type });
         }
         cols

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -97,6 +97,16 @@ impl Statement {
         raw_name
     }
 
+    pub fn column_decltype(&self, idx: i32) -> Option<&str> {
+        let raw_name = unsafe { crate::ffi::sqlite3_column_decltype(self.raw_stmt, idx) };
+        if raw_name.is_null() {
+            return None;
+        }
+        let raw_name = unsafe { std::ffi::CStr::from_ptr(raw_name as *const c_char) };
+        let raw_name = raw_name.to_str().unwrap();
+        Some(raw_name)
+    }
+
     pub fn bind_parameter_index(&self, name: &str) -> i32 {
         let raw_name = std::ffi::CString::new(name).unwrap();
 


### PR DESCRIPTION
We need to use sqlite3_column_decltype() like rusqlite does because it returns the type of the column in the result set whereas sqlite3_column_type() returns the type of the current row.