### PR TITLE
libsql/core: add code to FetchRowFailed and use extended error codes

### DIFF
--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -3,9 +3,9 @@ pub enum Error {
     #[error("Failed to connect to database: `{0}`")]
     ConnectionFailed(String),
     #[error("Failed to prepare statement `{1}`: `{2}`")]
-    PrepareFailed(i32, String, String),
-    #[error("Failed to fetch row: `{0}`")]
-    FetchRowFailed(String),
+    PrepareFailed(std::ffi::c_int, String, String),
+    #[error("Failed to fetch row: `{1}`")]
+    FetchRowFailed(std::ffi::c_int, String),
     #[error("Unknown value type for column `{0}`: `{1}`")]
     UnknownColumnType(i32, i32),
     #[error("The value is NULL")]
@@ -27,6 +27,10 @@ pub enum Error {
 pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {
     let errmsg = unsafe { libsql_sys::ffi::sqlite3_errmsg(raw) };
     sqlite_errmsg_to_string(errmsg)
+}
+
+pub(crate) fn extended_error_code(raw: *mut libsql_sys::ffi::sqlite3) -> std::ffi::c_int {
+    unsafe { libsql_sys::ffi::sqlite3_extended_errcode(raw) }
 }
 
 pub fn error_from_code(code: i32) -> String {

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -32,7 +32,10 @@ impl Rows {
             libsql_sys::ffi::SQLITE_ROW => Ok(Some(Row {
                 stmt: self.stmt.clone(),
             })),
-            _ => Err(Error::FetchRowFailed(errors::error_from_code(err))),
+            _ => Err(Error::FetchRowFailed(
+                errors::extended_error_code(self.stmt.conn.raw),
+                errors::error_from_handle(self.stmt.conn.raw),
+            )),
         }
     }
 

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 /// A prepared statement.
 #[derive(Debug, Clone)]
 pub struct Statement {
-    conn: Connection,
+    pub(crate) conn: Connection,
     pub(crate) inner: Arc<libsql_sys::Statement>,
 }
 
@@ -23,8 +23,8 @@ impl Statement {
                 conn,
                 inner: Arc::new(stmt),
             }),
-            Err(libsql_sys::Error::LibError(err)) => Err(Error::PrepareFailed(
-                err,
+            Err(libsql_sys::Error::LibError(_err)) => Err(Error::PrepareFailed(
+                errors::extended_error_code(raw),
                 sql.to_string(),
                 errors::error_from_handle(raw),
             )),
@@ -104,7 +104,7 @@ impl Statement {
             crate::ffi::SQLITE_DONE => Ok(self.conn.changes()),
             crate::ffi::SQLITE_ROW => Err(Error::ExecuteReturnedRows),
             _ => Err(Error::LibError(
-                err,
+                errors::extended_error_code(self.conn.raw),
                 errors::error_from_handle(self.conn.raw),
             )),
         }


### PR DESCRIPTION
* Add error code to `FetchRowFailed`
* Use full error message in `FetchRowFailed`
* Use extended error codes in all errors

As a further improvement, it would probably be better to use https://www.sqlite.org/c3ref/extended_result_codes.html to get extended result codes directly instead of retrieving the extended error codes with a separate function call.