### PR TITLE
Switch to rusqlite errors

### DIFF
--- a/crates/bindings/go/libsql_test.go
+++ b/crates/bindings/go/libsql_test.go
@@ -344,7 +344,7 @@ func TestErrorExec(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if err.Error() != "failed to execute query CREATE TABLES test (id INTEGER, name TEXT)\nerror code = 1: Error executing statement: Failed to prepare statement `CREATE TABLES test (id INTEGER, name TEXT)`: `near \"TABLES\": syntax error`" {
+		if err.Error() != "failed to execute query CREATE TABLES test (id INTEGER, name TEXT)\nerror code = 1: Error executing statement: SQLite failure: `near \"TABLES\": syntax error`" {
 			t.Fatal("unexpected error:", err)
 		}
 	})
@@ -416,7 +416,7 @@ func TestErrorQuery(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if err.Error() != "failed to execute query SELECT NULL, id, name, gpa, cv FROM test\nerror code = 1: Error executing statement: Failed to prepare statement `SELECT NULL, id, name, gpa, cv FROM test`: `no such table: test`" {
+		if err.Error() != "failed to execute query SELECT NULL, id, name, gpa, cv FROM test\nerror code = 1: Error executing statement: SQLite failure: `no such table: test`" {
 			t.Fatal("unexpected error:", err)
 		}
 	})
@@ -489,7 +489,7 @@ func TestErrorRowsNext(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if err.Error() != "failed to get next row\nerror code = 1: Error fetching next row: Failed to fetch row: `database is locked`" {
+		if err.Error() != "failed to get next row\nerror code = 1: Error fetching next row: SQLite failure: `database is locked`" {
 			t.Fatal("unexpected error:", err)
 		}
 	})

--- a/crates/core/src/v1/errors.rs
+++ b/crates/core/src/v1/errors.rs
@@ -2,34 +2,28 @@
 pub enum Error {
     #[error("Failed to connect to database: `{0}`")]
     ConnectionFailed(String),
-    #[error("Failed to prepare statement `{1}`: `{2}`")]
-    PrepareFailed(std::ffi::c_int, String, String),
-    #[error("Failed to fetch row: `{1}`")]
-    FetchRowFailed(std::ffi::c_int, String),
-    #[error("Unknown value type for column `{0}`: `{1}`")]
-    UnknownColumnType(i32, i32),
-    #[error("The value is NULL")]
-    NullValue,
-    #[error("Library misuse: `{0}`")]
-    Misuse(String),
-    #[error("Invalid column name: {0}")]
-    InvalidColumnName(String),
-    #[error("libSQL error {0}: `{1}`")]
-    LibError(std::ffi::c_int, String),
-    #[error("Query returned no rows")]
-    QueryReturnedNoRows,
+    #[error("SQLite failure: `{1}`")]
+    SqliteFailure(std::ffi::c_int, String),
+    #[error("Null value")]
+    NullValue, // Not in rusqlite
+    #[error("API misuse: `{0}`")]
+    Misuse(String), // Not in rusqlite
     #[error("Execute returned rows")]
     ExecuteReturnedRows,
-    #[error("unable to convert to sql: `{0}`")]
+    #[error("Query returned no rows")]
+    QueryReturnedNoRows,
+    #[error("Invalid column name: `{0}`")]
+    InvalidColumnName(String),
+    #[error("SQL conversion failure: `{0}`")]
     ToSqlConversionFailure(crate::BoxError),
-    #[error("Hrana: `{0}`")]
-    Hrana(#[from] crate::v2::HranaError),
     #[error("Sync is not supported in databases opened in {0} mode.")]
-    SyncNotSupported(String),
+    SyncNotSupported(String), // Not in rusqlite
     #[error("Column not found: {0}")]
-    ColumnNotFound(i32),
+    ColumnNotFound(i32), // Not in rusqlite
+    #[error("Hrana: `{0}`")]
+    Hrana(#[from] crate::v2::HranaError), // Not in rusqlite
     #[error("Write delegation: `{0}`")]
-    WriteDelegation(crate::BoxError),
+    WriteDelegation(crate::BoxError), // Not in rusqlite
 }
 
 pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {

--- a/crates/core/src/v1/rows.rs
+++ b/crates/core/src/v1/rows.rs
@@ -41,7 +41,7 @@ impl Rows {
             libsql_sys::ffi::SQLITE_ROW => Ok(Some(Row {
                 stmt: self.stmt.clone(),
             })),
-            _ => Err(Error::FetchRowFailed(err_code, err_msg)),
+            _ => Err(Error::SqliteFailure(err_code, err_msg)),
         }
     }
 
@@ -61,7 +61,7 @@ impl Rows {
             libsql_sys::ffi::SQLITE_BLOB => Ok(ValueType::Blob),
             libsql_sys::ffi::SQLITE_TEXT => Ok(ValueType::Text),
             libsql_sys::ffi::SQLITE_NULL => Ok(ValueType::Null),
-            _ => Err(Error::UnknownColumnType(idx, val)),
+            _ => unreachable!("unknown column type {} at index {}", val, idx),
         }
     }
 }
@@ -129,7 +129,7 @@ impl Row {
             libsql_sys::ffi::SQLITE_BLOB => Ok(ValueType::Blob),
             libsql_sys::ffi::SQLITE_TEXT => Ok(ValueType::Text),
             libsql_sys::ffi::SQLITE_NULL => Ok(ValueType::Null),
-            _ => Err(Error::UnknownColumnType(idx, val)),
+            _ => unreachable!("unknown column type: {} at index {}", val, idx),
         }
     }
 

--- a/crates/core/src/v1/statement.rs
+++ b/crates/core/src/v1/statement.rs
@@ -29,9 +29,8 @@ impl Statement {
                 inner: Arc::new(stmt),
                 sql: sql.to_string(),
             }),
-            Err(libsql_sys::Error::LibError(_err)) => Err(Error::PrepareFailed(
+            Err(libsql_sys::Error::LibError(_err)) => Err(Error::SqliteFailure(
                 errors::extended_error_code(raw),
-                sql.to_string(),
                 errors::error_from_handle(raw),
             )),
             Err(err) => Err(Error::Misuse(format!(
@@ -129,7 +128,7 @@ impl Statement {
         match err as u32 {
             crate::ffi::SQLITE_DONE => Ok(self.conn.changes()),
             crate::ffi::SQLITE_ROW => Err(Error::ExecuteReturnedRows),
-            _ => Err(Error::LibError(
+            _ => Err(Error::SqliteFailure(
                 errors::extended_error_code(self.conn.raw),
                 errors::error_from_handle(self.conn.raw),
             )),
@@ -142,7 +141,7 @@ impl Statement {
         match err as u32 {
             crate::ffi::SQLITE_DONE => Ok(self.conn.changes()),
             crate::ffi::SQLITE_ROW => Err(Error::ExecuteReturnedRows),
-            _ => Err(Error::LibError(
+            _ => Err(Error::SqliteFailure(
                 errors::extended_error_code(self.conn.raw),
                 errors::error_from_handle(self.conn.raw),
             )),
@@ -241,7 +240,7 @@ impl Statement {
         match err as u32 {
             crate::ffi::SQLITE_DONE => Ok(()),
             crate::ffi::SQLITE_ROW => Err(Error::ExecuteReturnedRows),
-            _ => Err(Error::LibError(
+            _ => Err(Error::SqliteFailure(
                 errors::extended_error_code(self.conn.raw),
                 errors::error_from_handle(self.conn.raw),
             )),

--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -87,6 +87,21 @@ async fn connection_execute_batch_newline() {
 }
 
 #[tokio::test]
+async fn prepare_invalid_sql() {
+    let conn = setup().await;
+    let result = conn.prepare("SYNTAX ERROR").await;
+    assert!(result.is_err());
+    let actual = result.err().unwrap();
+    match actual {
+        libsql::Error::SqliteFailure(code, msg) => {
+            assert_eq!(code, 1);
+            assert_eq!(msg, "near \"SYNTAX\": syntax error".to_string());
+        }
+        _ => panic!("Expected SqliteFailure"),
+    }
+}
+
+#[tokio::test]
 async fn statement_query() {
     let conn = setup().await;
     let _ = conn


### PR DESCRIPTION
Switch the libSQL specific errors to be as close as possible to rusqlite to simplify porting apps.