### PR TITLE
libsql/core: Add `v2` api

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -17,3 +17,4 @@ panic = "abort"
 [patch.crates-io]
 tonic = { git = "https://github.com/hyperium/tonic" }
 tonic-build = { git = "https://github.com/hyperium/tonic" }
+hrana-client-proto = { path = "../../hrana-client-rs/hrana-client-proto" }

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -17,4 +17,3 @@ panic = "abort"
 [patch.crates-io]
 tonic = { git = "https://github.com/hyperium/tonic" }
 tonic-build = { git = "https://github.com/hyperium/tonic" }
-hrana-client-proto = { path = "../../hrana-client-rs/hrana-client-proto" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,6 +18,8 @@ parking_lot = "0.12.1"
 hrana-client-proto = "0.2"
 hyper = "0.14"
 hyper-rustls = { version = "0.24", features = ["rustls-native-certs"] }
+base64 = "0.21"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
 crossbeam-channel = "0.5"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,12 @@ tokio = { version = "1.29.1", features = ["macros"] }
 tracing-subscriber = "0.3.17"
 tracing = "0.1.37"
 parking_lot = "0.12.1"
+hrana-client-proto = "0.2"
+hyper = "0.14"
+hyper-rustls = { version = "0.24", features = ["rustls-native-certs"] }
+serde_json = "1"
+async-trait = "0.1"
+crossbeam-channel = "0.5"
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/crates/core/examples/example_v2.rs
+++ b/crates/core/examples/example_v2.rs
@@ -1,0 +1,41 @@
+use libsql::v2::Database;
+
+#[tokio::main]
+async fn main() {
+    let db = if let Ok(url) = std::env::var("LIBSQL_HRANA_URL") {
+        Database::open_http(url).unwrap()
+    } else {
+        Database::open_in_memory().unwrap()
+    };
+
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)", ())
+        .await
+        .unwrap();
+
+    let stmt = conn
+        .prepare("INSERT INTO users (email) VALUES (?1)")
+        .await
+        .unwrap();
+
+    stmt.execute(&libsql::params!["foo@example.com"])
+        .await
+        .unwrap();
+
+    let stmt = conn
+        .prepare("SELECT * FROM users WHERE email = ?1")
+        .await
+        .unwrap();
+
+    let mut rows = stmt
+        .query(&libsql::params!["foo@example.com"])
+        .await
+        .unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+
+    let value = row.get_value(0).unwrap();
+
+    println!("Row: {:?}", value);
+}

--- a/crates/core/examples/example_v2.rs
+++ b/crates/core/examples/example_v2.rs
@@ -3,7 +3,7 @@ use libsql::v2::Database;
 #[tokio::main]
 async fn main() {
     let db = if let Ok(url) = std::env::var("LIBSQL_HRANA_URL") {
-        Database::open_http(url).unwrap()
+        Database::open_remote(url).unwrap()
     } else {
         Database::open_in_memory().unwrap()
     };

--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -23,6 +23,8 @@ impl Drop for Connection {
 
 // SAFETY: This is safe because we compile sqlite3 w/ SQLITE_THREADSAFE=1
 unsafe impl Send for Connection {}
+// SAFETY: This is safe because we compile sqlite3 w/ SQLITE_THREADSAFE=1
+unsafe impl Sync for Connection {}
 
 impl Connection {
     /// Connect to the database.

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -22,6 +22,8 @@ pub enum Error {
     ExecuteReturnedRows,
     #[error("unable to convert to sql: `{0}`")]
     ToSqlConversionFailure(crate::BoxError),
+    #[error("Hrana: `{0}`")]
+    Hrana(#[from] crate::v2::HranaError),
 }
 
 pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod params;
 pub mod rows;
 pub mod statement;
 pub mod transaction;
+pub mod v2;
 
 pub type Result<T> = std::result::Result<T, errors::Error>;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -4,6 +4,7 @@ use libsql_sys::ValueType;
 
 use crate::{Error, Result};
 
+#[derive(Clone)]
 pub enum Params {
     None,
     Positional(Vec<Value>),
@@ -79,6 +80,7 @@ impl From<Vec<(String, Value)>> for Params {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum Value {
     Null,
     Integer(i64),

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -12,6 +12,7 @@ pub struct Rows {
 }
 
 unsafe impl Send for Rows {} // TODO: is this safe?
+unsafe impl Sync for Rows {} // TODO: is this safe?
 
 impl Rows {
     pub fn new(stmt: Statement) -> Rows {

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -108,7 +108,7 @@ impl Statement {
             crate::ffi::SQLITE_DONE => Ok(self.conn.changes()),
             crate::ffi::SQLITE_ROW => Err(Error::ExecuteReturnedRows),
             _ => Err(Error::LibError(
-                errors::extended_error_code(self.conn.raw),
+                err,
                 errors::error_from_handle(self.conn.raw),
             )),
         }

--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -1,8 +1,12 @@
-use hrana_client_proto::pipeline::{
+mod pipeline;
+mod proto;
+
+use pipeline::{
     ClientMsg, Response, ServerMsg, StreamBatchReq, StreamExecuteReq, StreamRequest,
     StreamResponse, StreamResponseError, StreamResponseOk,
 };
-use hrana_client_proto::{Batch, BatchResult, Col, Stmt, StmtResult};
+use proto::{Batch, BatchResult, Col, Stmt, StmtResult};
+
 use hyper::client::HttpConnector;
 use hyper::StatusCode;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
@@ -310,7 +314,7 @@ impl super::statement::Stmt for Statement {
 
 pub struct Rows {
     cols: Arc<Vec<Col>>,
-    rows: Vec<Vec<hrana_client_proto::Value>>,
+    rows: Vec<Vec<proto::Value>>,
 }
 
 #[async_trait::async_trait]
@@ -332,7 +336,7 @@ impl RowsInner for Rows {
 
 pub struct Row {
     cols: Arc<Vec<Col>>,
-    inner: Vec<hrana_client_proto::Value>,
+    inner: Vec<proto::Value>,
 }
 
 impl RowInner for Row {
@@ -366,22 +370,22 @@ fn bind_params(params: Params, stmt: &mut Stmt) {
     }
 }
 
-fn into_value(value: crate::Value) -> hrana_client_proto::Value {
+fn into_value(value: crate::Value) -> proto::Value {
     match value {
-        crate::Value::Null => hrana_client_proto::Value::Null,
-        crate::Value::Integer(value) => hrana_client_proto::Value::Integer { value },
-        crate::Value::Real(value) => hrana_client_proto::Value::Float { value },
-        crate::Value::Text(value) => hrana_client_proto::Value::Text { value },
-        crate::Value::Blob(value) => hrana_client_proto::Value::Blob { value },
+        crate::Value::Null => proto::Value::Null,
+        crate::Value::Integer(value) => proto::Value::Integer { value },
+        crate::Value::Real(value) => proto::Value::Float { value },
+        crate::Value::Text(value) => proto::Value::Text { value },
+        crate::Value::Blob(value) => proto::Value::Blob { value },
     }
 }
 
-fn into_value2(value: hrana_client_proto::Value) -> crate::Value {
+fn into_value2(value: proto::Value) -> crate::Value {
     match value {
-        hrana_client_proto::Value::Null => crate::Value::Null,
-        hrana_client_proto::Value::Integer { value } => crate::Value::Integer(value),
-        hrana_client_proto::Value::Float { value } => crate::Value::Real(value),
-        hrana_client_proto::Value::Text { value } => crate::Value::Text(value),
-        hrana_client_proto::Value::Blob { value } => crate::Value::Blob(value),
+        proto::Value::Null => crate::Value::Null,
+        proto::Value::Integer { value } => crate::Value::Integer(value),
+        proto::Value::Float { value } => crate::Value::Real(value),
+        proto::Value::Text { value } => crate::Value::Text(value),
+        proto::Value::Blob { value } => crate::Value::Blob(value),
     }
 }

--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -1,0 +1,387 @@
+use hrana_client_proto::pipeline::{
+    ClientMsg, Response, ServerMsg, StreamBatchReq, StreamExecuteReq, StreamRequest,
+    StreamResponse, StreamResponseError, StreamResponseOk,
+};
+use hrana_client_proto::{Batch, BatchResult, Col, Stmt, StmtResult};
+use hyper::client::HttpConnector;
+use hyper::StatusCode;
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
+
+// use crate::client::Config;
+use crate::{Params, Result};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use super::rows::{RowInner, RowsInner};
+use super::Conn;
+
+/// Information about the current session: the server-generated cookie
+/// and the URL that should be used for further communication.
+#[derive(Clone, Debug, Default)]
+struct Cookie {
+    baton: Option<String>,
+    base_url: Option<String>,
+}
+
+/// Generic HTTP client. Needs a helper function that actually sends
+/// the request.
+#[derive(Clone, Debug)]
+pub struct Client {
+    inner: InnerClient,
+    cookies: Arc<RwLock<HashMap<u64, Cookie>>>,
+    url_for_queries: String,
+    auth: String,
+}
+
+#[derive(Clone, Debug)]
+struct InnerClient {
+    inner: hyper::Client<HttpsConnector<HttpConnector>, hyper::Body>,
+}
+
+impl InnerClient {
+    fn new() -> Self {
+        let https = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_or_http()
+            .enable_http1()
+            .build();
+        let inner = hyper::Client::builder().build(https);
+
+        Self { inner }
+    }
+
+    async fn send(&self, url: String, _auth: String, body: String) -> Result<ServerMsg> {
+        let req = hyper::Request::post(url)
+            .body(hyper::Body::from(body))
+            .unwrap();
+
+        let res = self.inner.request(req).await.map_err(HranaError::from)?;
+
+        if res.status() != StatusCode::OK {
+            // TODO(lucio): Error branch!
+        }
+
+        let body = hyper::body::to_bytes(res.into_body())
+            .await
+            .map_err(HranaError::from)?;
+
+        let msg = serde_json::from_slice::<ServerMsg>(&body[..]).map_err(HranaError::from)?;
+
+        Ok(msg)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HranaError {
+    #[error("missing environment variable: `{0}`")]
+    MissingEnv(String),
+    #[error("unexpected response: `{0}`")]
+    UnexpectedResponse(String),
+    #[error("stream closed: `{0}`")]
+    StreamClosed(String),
+    #[error("stream error: `{0:?}`")]
+    StreamError(StreamResponseError),
+    #[error("json error: `{0}`")]
+    Json(#[from] serde_json::Error),
+    #[error("http error: `{0}`")]
+    Http(#[from] hyper::Error),
+}
+
+impl Client {
+    /// Creates a database client with JWT authentication.
+    ///
+    /// # Arguments
+    /// * `url` - URL of the database endpoint
+    /// * `token` - auth token
+    pub fn new(url: impl Into<String>, token: impl Into<String>) -> Self {
+        let inner = InnerClient::new();
+
+        let token = token.into();
+        let url = url.into();
+        // Auto-update the URL to start with https:// if no protocol was specified
+        let base_url = if !url.contains("://") {
+            format!("https://{}", &url)
+        } else {
+            url
+        };
+        let url_for_queries = format!("{base_url}/v2/pipeline");
+        Self {
+            inner,
+            cookies: Arc::new(RwLock::new(HashMap::new())),
+            url_for_queries,
+            auth: format!("Bearer {token}"),
+        }
+    }
+
+    pub fn from_env() -> Result<Client> {
+        let url = std::env::var("LIBSQL_CLIENT_URL").map_err(|_| {
+            HranaError::MissingEnv(
+                "LIBSQL_CLIENT_URL variable should point to your sqld database".into(),
+            )
+        })?;
+
+        let token = std::env::var("LIBSQL_CLIENT_TOKEN").unwrap_or_default();
+        Ok(Client::new(url, token))
+    }
+}
+
+impl Client {
+    pub async fn raw_batch(&self, stmts: impl IntoIterator<Item = Stmt>) -> Result<BatchResult> {
+        let mut batch = Batch::new();
+        for stmt in stmts.into_iter() {
+            batch.step(None, stmt);
+        }
+
+        let msg = ClientMsg {
+            baton: None,
+            requests: vec![
+                StreamRequest::Batch(StreamBatchReq { batch }),
+                StreamRequest::Close,
+            ],
+        };
+        let body = serde_json::to_string(&msg).map_err(HranaError::Json)?;
+        let mut response: ServerMsg = self
+            .inner
+            .send(self.url_for_queries.clone(), self.auth.clone(), body)
+            .await?;
+
+        if response.results.is_empty() {
+            Err(HranaError::UnexpectedResponse(format!(
+                "Unexpected empty response from server: {:?}",
+                response.results
+            )))?;
+        }
+        if response.results.len() > 2 {
+            // One with actual results, one closing the stream
+            Err(HranaError::UnexpectedResponse(format!(
+                "Unexpected multiple responses from server: {:?}",
+                response.results
+            )))?;
+        }
+        match response.results.swap_remove(0) {
+            Response::Ok(StreamResponseOk {
+                response: StreamResponse::Batch(batch_result),
+            }) => Ok(batch_result.result),
+            Response::Ok(_) => Err(HranaError::UnexpectedResponse(format!(
+                "Unexpected response from server: {:?}",
+                response.results
+            ))
+            .into()),
+            Response::Error(e) => Err(HranaError::StreamError(e).into()),
+        }
+    }
+
+    async fn execute_inner(&self, stmt: Stmt, tx_id: u64) -> Result<StmtResult> {
+        let cookie = if tx_id > 0 {
+            self.cookies
+                .read()
+                .unwrap()
+                .get(&tx_id)
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            Cookie::default()
+        };
+        let msg = ClientMsg {
+            baton: cookie.baton,
+            requests: vec![StreamRequest::Execute(StreamExecuteReq { stmt })],
+        };
+        let body = serde_json::to_string(&msg).map_err(HranaError::Json)?;
+        let url = cookie
+            .base_url
+            .unwrap_or_else(|| self.url_for_queries.clone());
+        let mut response: ServerMsg = self.inner.send(url, self.auth.clone(), body).await?;
+
+        if tx_id > 0 {
+            let base_url = response.base_url;
+            match response.baton {
+                Some(baton) => {
+                    self.cookies.write().unwrap().insert(
+                        tx_id,
+                        Cookie {
+                            baton: Some(baton),
+                            base_url,
+                        },
+                    );
+                }
+                None => Err(HranaError::StreamClosed(
+                    "Stream closed: server returned empty baton".into(),
+                ))?,
+            }
+        }
+
+        if response.results.is_empty() {
+            Err(HranaError::UnexpectedResponse(format!(
+                "Unexpected empty response from server: {:?}",
+                response.results
+            )))?;
+        }
+        if response.results.len() > 1 {
+            // One with actual results, one closing the stream
+            Err(HranaError::UnexpectedResponse(format!(
+                "Unexpected multiple responses from server: {:?}",
+                response.results
+            )))?;
+        }
+        match response.results.swap_remove(0) {
+            Response::Ok(StreamResponseOk {
+                response: StreamResponse::Execute(execute_result),
+            }) => Ok(execute_result.result),
+            Response::Ok(_) => Err(HranaError::UnexpectedResponse(format!(
+                "Unexpected response from server: {:?}",
+                response.results
+            ))
+            .into()),
+            Response::Error(e) => Err(HranaError::StreamError(e).into()),
+        }
+    }
+
+    async fn _close_stream_for(&self, tx_id: u64) -> Result<()> {
+        let cookie = self
+            .cookies
+            .read()
+            .unwrap()
+            .get(&tx_id)
+            .cloned()
+            .unwrap_or_default();
+        let msg = ClientMsg {
+            baton: cookie.baton,
+            requests: vec![StreamRequest::Close],
+        };
+        let url = cookie
+            .base_url
+            .unwrap_or_else(|| self.url_for_queries.clone());
+        let body = serde_json::to_string(&msg).map_err(HranaError::Json)?;
+        self.inner.send(url, self.auth.clone(), body).await.ok();
+        self.cookies.write().unwrap().remove(&tx_id);
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Conn for Client {
+    async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
+        let stmt = self.prepare(sql).await?;
+        let rows = stmt.execute(&params).await?;
+
+        Ok(rows as u64)
+    }
+
+    async fn prepare(&self, sql: &str) -> Result<super::Statement> {
+        let stmt = Statement {
+            client: self.clone(),
+            inner: Stmt::new(sql, true),
+        };
+        Ok(super::Statement {
+            inner: Arc::new(stmt),
+        })
+    }
+}
+
+pub struct Statement {
+    client: Client,
+    inner: Stmt,
+}
+
+#[async_trait::async_trait]
+impl super::statement::Stmt for Statement {
+    async fn execute(&self, params: &Params) -> Result<usize> {
+        let mut stmt = self.inner.clone();
+        bind_params(params.clone(), &mut stmt);
+
+        let v = self.client.execute_inner(stmt, 0).await?;
+        Ok(v.affected_row_count as usize)
+    }
+
+    async fn query(&self, params: &Params) -> Result<super::Rows> {
+        let mut stmt = self.inner.clone();
+        bind_params(params.clone(), &mut stmt);
+
+        let StmtResult { rows, cols, .. } = self.client.execute_inner(stmt, 0).await?;
+
+        Ok(super::Rows {
+            inner: Box::new(Rows {
+                rows,
+                cols: Arc::new(cols),
+            }),
+        })
+    }
+}
+
+pub struct Rows {
+    cols: Arc<Vec<Col>>,
+    rows: Vec<Vec<hrana_client_proto::Value>>,
+}
+
+#[async_trait::async_trait]
+impl RowsInner for Rows {
+    async fn next(&mut self) -> Result<Option<super::Row>> {
+        let row = match self.rows.pop() {
+            Some(row) => Row {
+                cols: self.cols.clone(),
+                inner: row,
+            },
+            None => return Ok(None),
+        };
+
+        Ok(Some(super::Row {
+            inner: Box::new(row),
+        }))
+    }
+}
+
+pub struct Row {
+    cols: Arc<Vec<Col>>,
+    inner: Vec<hrana_client_proto::Value>,
+}
+
+impl RowInner for Row {
+    fn column_value(&self, idx: i32) -> Result<crate::Value> {
+        let v = self.inner.get(idx as usize).cloned().unwrap();
+        Ok(into_value2(v))
+    }
+
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.cols
+            .get(idx as usize)
+            .map(|c| c.name.as_ref())
+            .flatten()
+            .map(|s| s.as_str())
+    }
+}
+
+fn bind_params(params: Params, stmt: &mut Stmt) {
+    match params {
+        Params::None => {}
+        Params::Positional(values) => {
+            for value in values {
+                stmt.bind(into_value(value));
+            }
+        }
+        Params::Named(values) => {
+            for (name, value) in values {
+                stmt.bind_named(name, into_value(value));
+            }
+        }
+    }
+}
+
+fn into_value(value: crate::Value) -> hrana_client_proto::Value {
+    match value {
+        crate::Value::Null => hrana_client_proto::Value::Null,
+        crate::Value::Integer(value) => hrana_client_proto::Value::Integer { value },
+        crate::Value::Real(value) => hrana_client_proto::Value::Float { value },
+        crate::Value::Text(value) => hrana_client_proto::Value::Text { value },
+        crate::Value::Blob(value) => hrana_client_proto::Value::Blob { value },
+    }
+}
+
+fn into_value2(value: hrana_client_proto::Value) -> crate::Value {
+    match value {
+        hrana_client_proto::Value::Null => crate::Value::Null,
+        hrana_client_proto::Value::Integer { value } => crate::Value::Integer(value),
+        hrana_client_proto::Value::Float { value } => crate::Value::Real(value),
+        hrana_client_proto::Value::Text { value } => crate::Value::Text(value),
+        hrana_client_proto::Value::Blob { value } => crate::Value::Blob(value),
+    }
+}

--- a/crates/core/src/v2/hrana/pipeline.rs
+++ b/crates/core/src/v2/hrana/pipeline.rs
@@ -1,0 +1,80 @@
+// https://github.com/libsql/sqld/blob/main/docs/HTTP_V2_SPEC.md
+
+use super::proto::{Batch, BatchResult, Error, Stmt, StmtResult};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Debug)]
+pub struct ClientMsg {
+    pub baton: Option<String>,
+    pub requests: Vec<StreamRequest>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ServerMsg {
+    pub baton: Option<String>,
+    pub base_url: Option<String>,
+    pub results: Vec<Response>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamRequest {
+    Close,
+    Execute(StreamExecuteReq),
+    Batch(StreamBatchReq),
+    // TODO: implement
+    //    Sequence(Sequence),
+    //    Describe(Describe),
+    //    StoreSql(StoreSql),
+    //    CloseSql(CloseSql),
+}
+
+#[derive(Serialize, Debug)]
+pub struct StreamExecuteReq {
+    pub stmt: Stmt,
+}
+
+#[derive(Serialize, Debug)]
+pub struct StreamBatchReq {
+    pub batch: Batch,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Response {
+    Ok(StreamResponseOk),
+    Error(StreamResponseError),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct StreamResponseOk {
+    pub response: StreamResponse,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct StreamResponseError {
+    pub error: Error,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamResponse {
+    Close,
+    Execute(StreamExecuteResult),
+    Batch(StreamBatchResult),
+    // TODO: implement
+    //    Sequence(SequenceResult),
+    //    Describe(DescribeResult),
+    //    StoreSql(StoreSqlResult),
+    //    CloseSql(CloseSqlResult),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct StreamExecuteResult {
+    pub result: StmtResult,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct StreamBatchResult {
+    pub result: BatchResult,
+}

--- a/crates/core/src/v2/hrana/proto.rs
+++ b/crates/core/src/v2/hrana/proto.rs
@@ -1,0 +1,400 @@
+//! Messages in the Hrana protocol.
+//!
+//! Please consult the Hrana specification in the `docs/` directory for more information.
+#![allow(dead_code)]
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientMsg {
+    Hello { jwt: Option<String> },
+    Request { request_id: i32, request: Request },
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerMsg {
+    HelloOk {},
+    HelloError { error: Error },
+    ResponseOk { request_id: i32, response: Response },
+    ResponseError { request_id: i32, error: Error },
+}
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Request {
+    OpenStream(OpenStreamReq),
+    CloseStream(CloseStreamReq),
+    Execute(ExecuteReq),
+    Batch(BatchReq),
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Response {
+    OpenStream(OpenStreamResp),
+    CloseStream(CloseStreamResp),
+    Execute(ExecuteResp),
+    Batch(BatchResp),
+}
+
+#[derive(Serialize, Debug)]
+pub struct OpenStreamReq {
+    pub stream_id: i32,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct OpenStreamResp {}
+
+#[derive(Serialize, Debug)]
+pub struct CloseStreamReq {
+    pub stream_id: i32,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CloseStreamResp {}
+
+#[derive(Serialize, Debug)]
+pub struct ExecuteReq {
+    pub stream_id: i32,
+    pub stmt: Stmt,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ExecuteResp {
+    pub result: StmtResult,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct Stmt {
+    pub sql: String,
+    #[serde(default)]
+    pub args: Vec<Value>,
+    #[serde(default)]
+    pub named_args: Vec<NamedArg>,
+    pub want_rows: bool,
+}
+
+impl Stmt {
+    pub fn new(sql: impl Into<String>, want_rows: bool) -> Self {
+        let sql = sql.into();
+        Self {
+            sql,
+            want_rows,
+            named_args: Vec::new(),
+            args: Vec::new(),
+        }
+    }
+
+    pub fn bind(&mut self, val: Value) {
+        self.args.push(val);
+    }
+
+    pub fn bind_named(&mut self, name: String, value: Value) {
+        self.named_args.push(NamedArg { name, value });
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct NamedArg {
+    pub name: String,
+    pub value: Value,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct StmtResult {
+    pub cols: Vec<Col>,
+    pub rows: Vec<Vec<Value>>,
+    pub affected_row_count: u64,
+    #[serde(with = "option_i64_as_str")]
+    pub last_insert_rowid: Option<i64>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Col {
+    pub name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Value {
+    Null,
+    Integer {
+        #[serde(with = "i64_as_str")]
+        value: i64,
+    },
+    Float {
+        value: f64,
+    },
+    Text {
+        value: String,
+    },
+    Blob {
+        #[serde(with = "bytes_as_base64", rename = "base64")]
+        value: Vec<u8>,
+    },
+}
+
+#[derive(Serialize, Debug)]
+pub struct BatchReq {
+    pub stream_id: i32,
+    pub batch: Batch,
+}
+
+#[derive(Serialize, Debug, Default)]
+pub struct Batch {
+    steps: Vec<BatchStep>,
+}
+
+impl Batch {
+    pub fn new() -> Self {
+        Self { steps: Vec::new() }
+    }
+
+    pub fn step(&mut self, condition: Option<BatchCond>, stmt: Stmt) {
+        self.steps.push(BatchStep { condition, stmt });
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct BatchStep {
+    condition: Option<BatchCond>,
+    stmt: Stmt,
+}
+
+#[derive(Serialize, Debug)]
+pub enum BatchCond {
+    Ok { step: i32 },
+    Error { step: i32 },
+    Not { cond: Box<BatchCond> },
+    And { conds: Vec<BatchCond> },
+    Or { conds: Vec<BatchCond> },
+}
+
+#[derive(Deserialize, Debug)]
+pub struct BatchResp {
+    pub result: BatchResult,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct BatchResult {
+    pub step_results: Vec<Option<StmtResult>>,
+    pub step_errors: Vec<Option<Error>>,
+}
+
+impl<T> From<Option<T>> for Value
+where
+    T: Into<Value>,
+{
+    fn from(value: Option<T>) -> Self {
+        match value {
+            None => Self::Null,
+            Some(t) => t.into(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Error {
+    pub message: String,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for Error {}
+
+mod i64_as_str {
+    use serde::{de, ser};
+    use serde::{de::Error as _, Serialize as _};
+
+    pub fn serialize<S: ser::Serializer>(value: &i64, ser: S) -> Result<S::Ok, S::Error> {
+        value.to_string().serialize(ser)
+    }
+
+    pub fn deserialize<'de, D: de::Deserializer<'de>>(de: D) -> Result<i64, D::Error> {
+        let str_value = <&'de str as de::Deserialize>::deserialize(de)?;
+        str_value.parse().map_err(|_| {
+            D::Error::invalid_value(
+                de::Unexpected::Str(str_value),
+                &"decimal integer as a string",
+            )
+        })
+    }
+}
+
+mod option_i64_as_str {
+    use serde::{de, de::Error as _};
+
+    pub fn deserialize<'de, D: de::Deserializer<'de>>(de: D) -> Result<Option<i64>, D::Error> {
+        let str_value = <Option<&'de str> as de::Deserialize>::deserialize(de)?;
+        str_value
+            .map(|s| {
+                s.parse().map_err(|_| {
+                    D::Error::invalid_value(de::Unexpected::Str(s), &"decimal integer as a string")
+                })
+            })
+            .transpose()
+    }
+}
+
+mod bytes_as_base64 {
+    use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
+    use serde::{de, ser};
+    use serde::{de::Error as _, Serialize as _};
+
+    pub fn serialize<S: ser::Serializer>(value: &Vec<u8>, ser: S) -> Result<S::Ok, S::Error> {
+        STANDARD_NO_PAD.encode(value).serialize(ser)
+    }
+
+    pub fn deserialize<'de, D: de::Deserializer<'de>>(de: D) -> Result<Vec<u8>, D::Error> {
+        let str_value = <&'de str as de::Deserialize>::deserialize(de)?;
+        STANDARD_NO_PAD
+            .decode(str_value.trim_end_matches('='))
+            .map_err(|_| {
+                D::Error::invalid_value(
+                    de::Unexpected::Str(str_value),
+                    &"binary data encoded as base64",
+                )
+            })
+    }
+}
+
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::Null => write!(f, "null"),
+            Value::Integer { value: n } => write!(f, "{n}"),
+            Value::Float { value: d } => write!(f, "{d}"),
+            Value::Text { value: s } => write!(f, "{}", serde_json::json!(s)),
+            Value::Blob { value: b } => {
+                use base64::{prelude::BASE64_STANDARD_NO_PAD, Engine};
+                let b = BASE64_STANDARD_NO_PAD.encode(b);
+                write!(f, "{{\"base64\": {b}}}")
+            }
+        }
+    }
+}
+
+impl From<()> for Value {
+    fn from(_: ()) -> Value {
+        Value::Null
+    }
+}
+
+macro_rules! impl_from_value {
+    ($typename: ty, $variant: ident) => {
+        impl From<$typename> for Value {
+            fn from(t: $typename) -> Value {
+                Value::$variant { value: t.into() }
+            }
+        }
+    };
+}
+
+impl_from_value!(String, Text);
+impl_from_value!(&String, Text);
+impl_from_value!(&str, Text);
+
+impl_from_value!(i8, Integer);
+impl_from_value!(i16, Integer);
+impl_from_value!(i32, Integer);
+impl_from_value!(i64, Integer);
+
+impl_from_value!(u8, Integer);
+impl_from_value!(u16, Integer);
+impl_from_value!(u32, Integer);
+
+// rust doesn't like usize.into() for i64, so do it manually.
+impl From<usize> for Value {
+    fn from(t: usize) -> Value {
+        Value::Integer { value: t as _ }
+    }
+}
+
+impl From<isize> for Value {
+    fn from(t: isize) -> Value {
+        Value::Integer { value: t as _ }
+    }
+}
+
+impl_from_value!(f32, Float);
+impl_from_value!(f64, Float);
+
+impl_from_value!(Vec<u8>, Blob);
+
+macro_rules! impl_value_try_from_core {
+    ($variant: ident, $typename: ty) => {
+        impl TryFrom<Value> for $typename {
+            type Error = String;
+            fn try_from(v: Value) -> Result<$typename, Self::Error> {
+                match v {
+                    Value::$variant { value: v } => v.try_into().map_err(|e| format!("{e}")),
+                    other => Err(format!(
+                        "cannot transform {other:?} to {}",
+                        stringify!($variant)
+                    )),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_value_try_from_pod {
+    ($variant: ident, $typename: ty) => {
+        impl_value_try_from_core!($variant, $typename);
+
+        impl TryFrom<&Value> for $typename {
+            type Error = String;
+            fn try_from(v: &Value) -> Result<$typename, Self::Error> {
+                match v {
+                    Value::$variant { value: v } => (*v).try_into().map_err(|e| format!("{e}")),
+                    other => Err(format!(
+                        "cannot transform {other:?} to {}",
+                        stringify!($variant)
+                    )),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_value_try_from_ref {
+    ($variant: ident, $typename: ty, $reftype: ty) => {
+        impl_value_try_from_core!($variant, $typename);
+
+        impl<'a> TryFrom<&'a Value> for &'a $reftype {
+            type Error = String;
+            fn try_from(v: &'a Value) -> Result<&'a $reftype, Self::Error> {
+                match v {
+                    Value::$variant { value: v } => Ok(v),
+                    other => Err(format!(
+                        "cannot transform {other:?} to {}",
+                        stringify!($variant)
+                    )),
+                }
+            }
+        }
+    };
+}
+
+impl_value_try_from_pod!(Integer, i8);
+impl_value_try_from_pod!(Integer, i16);
+impl_value_try_from_pod!(Integer, i32);
+impl_value_try_from_pod!(Integer, i64);
+impl_value_try_from_pod!(Integer, u8);
+impl_value_try_from_pod!(Integer, u16);
+impl_value_try_from_pod!(Integer, u32);
+impl_value_try_from_pod!(Integer, u64);
+impl_value_try_from_pod!(Integer, usize);
+impl_value_try_from_pod!(Integer, isize);
+impl_value_try_from_pod!(Float, f64);
+
+impl_value_try_from_ref!(Text, String, str);
+impl_value_try_from_ref!(Blob, Vec<u8>, [u8]);

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -1,0 +1,117 @@
+mod hrana;
+mod rows;
+mod statement;
+
+use std::sync::Arc;
+
+use crate::{Params, Result};
+pub use hrana::{Client, HranaError};
+
+pub use rows::{Row, Rows};
+use statement::LibsqlStmt;
+pub use statement::Statement;
+
+// TODO(lucio): Improve construction via
+//      1) Move open errors into open fn rather than connect
+//      2) Support replication setup
+enum DbType {
+    Memory,
+    Path { path: String },
+    Http { url: String },
+}
+
+pub struct Database {
+    db_type: DbType,
+}
+
+impl Database {
+    pub fn open_in_memory() -> Result<Self> {
+        Ok(Database {
+            db_type: DbType::Memory,
+        })
+    }
+
+    pub fn open(db_path: impl Into<String>) -> Result<Database> {
+        Ok(Database {
+            db_type: DbType::Path {
+                path: db_path.into(),
+            },
+        })
+    }
+
+    pub fn open_http(url: impl Into<String>) -> Result<Self> {
+        Ok(Database {
+            db_type: DbType::Http { url: url.into() },
+        })
+    }
+
+    pub fn connect(&self) -> Result<Connection> {
+        match &self.db_type {
+            DbType::Memory => {
+                let db = crate::Database::open(":memory:")?;
+                let conn = db.connect()?;
+
+                let conn = Arc::new(LibsqlConnection { conn });
+
+                Ok(Connection { conn })
+            }
+
+            DbType::Path { path } => {
+                let db = crate::Database::open(path)?;
+                let conn = db.connect()?;
+
+                let conn = Arc::new(LibsqlConnection { conn });
+
+                Ok(Connection { conn })
+            }
+
+            DbType::Http { url } => {
+                let conn = Arc::new(hrana::Client::new(url, ""));
+
+                Ok(Connection { conn })
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+trait Conn {
+    async fn execute(&self, sql: &str, params: Params) -> Result<u64>;
+
+    async fn prepare(&self, sql: &str) -> Result<Statement>;
+}
+
+pub struct Connection {
+    conn: Arc<dyn Conn + Send + Sync>,
+}
+
+impl Connection {
+    pub async fn execute(&self, sql: &str, params: impl Into<Params>) -> Result<u64> {
+        self.conn.execute(sql, params.into()).await
+    }
+
+    pub async fn prepare(&self, sql: &str) -> Result<Statement> {
+        self.conn.prepare(sql).await
+    }
+}
+
+struct LibsqlConnection {
+    conn: crate::Connection,
+}
+
+#[async_trait::async_trait]
+impl Conn for LibsqlConnection {
+    async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
+        self.conn.execute(sql, params)
+    }
+
+    async fn prepare(&self, sql: &str) -> Result<Statement> {
+        let sql = sql.to_string();
+
+        let stmt = self.conn.prepare(sql)?;
+
+        Ok(Statement {
+            inner: Arc::new(LibsqlStmt(stmt)),
+        })
+    }
+}

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -16,8 +16,8 @@ pub use statement::Statement;
 //      2) Support replication setup
 enum DbType {
     Memory,
-    Path { path: String },
-    Http { url: String },
+    File { path: String },
+    Remote { url: String },
 }
 
 pub struct Database {
@@ -33,15 +33,15 @@ impl Database {
 
     pub fn open(db_path: impl Into<String>) -> Result<Database> {
         Ok(Database {
-            db_type: DbType::Path {
+            db_type: DbType::File {
                 path: db_path.into(),
             },
         })
     }
 
-    pub fn open_http(url: impl Into<String>) -> Result<Self> {
+    pub fn open_remote(url: impl Into<String>) -> Result<Self> {
         Ok(Database {
-            db_type: DbType::Http { url: url.into() },
+            db_type: DbType::Remote { url: url.into() },
         })
     }
 
@@ -56,7 +56,7 @@ impl Database {
                 Ok(Connection { conn })
             }
 
-            DbType::Path { path } => {
+            DbType::File { path } => {
                 let db = crate::Database::open(path)?;
                 let conn = db.connect()?;
 
@@ -65,7 +65,7 @@ impl Database {
                 Ok(Connection { conn })
             }
 
-            DbType::Http { url } => {
+            DbType::Remote { url } => {
                 let conn = Arc::new(hrana::Client::new(url, ""));
 
                 Ok(Connection { conn })

--- a/crates/core/src/v2/rows.rs
+++ b/crates/core/src/v2/rows.rs
@@ -1,0 +1,56 @@
+use crate::{Result, Value};
+
+#[async_trait::async_trait]
+pub(super) trait RowsInner {
+    async fn next(&mut self) -> Result<Option<Row>>;
+}
+
+pub struct Rows {
+    pub(super) inner: Box<dyn RowsInner + Send + Sync>,
+}
+
+impl Rows {
+    pub async fn next(&mut self) -> Result<Option<Row>> {
+        self.inner.next().await
+    }
+}
+
+pub(super) struct LibsqlRows(pub(super) crate::Rows);
+
+#[async_trait::async_trait]
+impl RowsInner for LibsqlRows {
+    async fn next(&mut self) -> Result<Option<Row>> {
+        let row = self.0.next()?.map(|r| Row {
+            inner: Box::new(LibsqlRow(r)),
+        });
+
+        Ok(row)
+    }
+}
+
+pub struct Row {
+    pub(super) inner: Box<dyn RowInner + Send + Sync>,
+}
+
+impl Row {
+    pub fn get_value(&self, idx: i32) -> Result<Value> {
+        self.inner.column_value(idx)
+    }
+}
+
+pub(super) trait RowInner {
+    fn column_value(&self, idx: i32) -> Result<Value>;
+    fn column_name(&self, idx: i32) -> Option<&str>;
+}
+
+struct LibsqlRow(crate::Row);
+
+impl RowInner for LibsqlRow {
+    fn column_value(&self, idx: i32) -> Result<Value> {
+        self.0.get_value(idx)
+    }
+
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.0.column_name(idx)
+    }
+}

--- a/crates/core/src/v2/statement.rs
+++ b/crates/core/src/v2/statement.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use crate::{Params, Result};
+
+use super::{rows::LibsqlRows, Rows};
+
+#[async_trait::async_trait]
+pub(super) trait Stmt {
+    async fn execute(&self, params: &Params) -> Result<usize>;
+
+    async fn query(&self, params: &Params) -> Result<Rows>;
+}
+
+pub struct Statement {
+    pub(super) inner: Arc<dyn Stmt + Send + Sync>,
+}
+
+impl Statement {
+    pub async fn execute(&self, params: &Params) -> Result<usize> {
+        self.inner.execute(params).await
+    }
+
+    pub async fn query(&self, params: &Params) -> Result<Rows> {
+        self.inner.query(params).await
+    }
+}
+
+pub(super) struct LibsqlStmt(pub(super) crate::Statement);
+
+#[async_trait::async_trait]
+impl Stmt for LibsqlStmt {
+    async fn execute(&self, params: &Params) -> Result<usize> {
+        let params = params.clone();
+        let stmt = self.0.clone();
+
+        stmt.execute(&params).map(|i| i as usize)
+    }
+
+    async fn query(&self, params: &Params) -> Result<Rows> {
+        let params = params.clone();
+        let stmt = self.0.clone();
+
+        stmt.query(&params).map(|rows| Rows {
+            inner: Box::new(LibsqlRows(rows)),
+        })
+    }
+}

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -104,9 +104,6 @@ impl Statement {
 
     pub fn column_origin_name(&self, idx: i32) -> Option<&str> {
         let raw_name = unsafe { crate::ffi::sqlite3_column_origin_name(self.raw_stmt, idx) };
-        if raw_name.is_null() {
-            return None;
-        }
         let raw_name = unsafe { std::ffi::CStr::from_ptr(raw_name as *const c_char) };
         let raw_name = raw_name.to_str().unwrap();
         Some(raw_name)

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -104,7 +104,13 @@ impl Statement {
 
     pub fn column_origin_name(&self, idx: i32) -> Option<&str> {
         let raw_name = unsafe { crate::ffi::sqlite3_column_origin_name(self.raw_stmt, idx) };
+
+        if raw_name.is_null() {
+            return None;
+        }
+
         let raw_name = unsafe { std::ffi::CStr::from_ptr(raw_name as *const c_char) };
+
         let raw_name = raw_name.to_str().unwrap();
         Some(raw_name)
     }


### PR DESCRIPTION
This PR adds a new in-progress v2 rewrite of the libsql API to support both a sqlite3 and http based backend. None of this code affects the current API and is written in such a way to migrate over easily.

The current approach to abstract both the sqlite3 and http api is to use internal trait objects so that the public types do not contain generics. In the future, if we find that trait objects are too slow we can move to enums.