### PR TITLE
Fix Github actions workflow names

### DIFF
--- a/.github/workflows/golang-bindings.yml
+++ b/.github/workflows/golang-bindings.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  golang-bindings:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/maketest.yml
+++ b/.github/workflows/maketest.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  maketest:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/maketestwasm.yml
+++ b/.github/workflows/maketestwasm.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  maketestwasm:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Let's use an unique name for each task so that we can configure Github actions to check that they all pass before merging.