### PR TITLE
Return correct error from Rows::next

### DIFF
--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -1,4 +1,4 @@
-use crate::{errors, Connection, Statement, Error, Params, Result, Value};
+use crate::{errors, Connection, Error, Params, Result, Statement, Value};
 use libsql_sys::ValueType;
 
 use std::cell::RefCell;
@@ -8,7 +8,7 @@ use std::ffi::c_char;
 #[derive(Debug, Clone)]
 pub struct Rows {
     pub(crate) stmt: Statement,
-    pub(crate) err: RefCell<Option<i32>>,
+    pub(crate) err: RefCell<Option<(i32, i32, String)>>,
 }
 
 unsafe impl Send for Rows {} // TODO: is this safe?
@@ -22,20 +22,25 @@ impl Rows {
     }
 
     pub fn next(&self) -> Result<Option<Row>> {
-        let err = match self.err.take() {
-            Some(err) => err,
-            None => self.stmt.inner.step(),
-        };
+        let err;
+        let err_code;
+        let err_msg;
+        if let Some((e, code, msg)) = self.err.take() {
+            err = e;
+            err_code = code;
+            err_msg = msg;
+        } else {
+            err = self.stmt.inner.step();
+            err_code = errors::extended_error_code(self.stmt.conn.raw);
+            err_msg = errors::error_from_handle(self.stmt.conn.raw);
+        }
         match err as u32 {
             libsql_sys::ffi::SQLITE_OK => Ok(None),
             libsql_sys::ffi::SQLITE_DONE => Ok(None),
             libsql_sys::ffi::SQLITE_ROW => Ok(Some(Row {
                 stmt: self.stmt.clone(),
             })),
-            _ => Err(Error::FetchRowFailed(
-                errors::extended_error_code(self.stmt.conn.raw),
-                errors::error_from_handle(self.stmt.conn.raw),
-            )),
+            _ => Err(Error::FetchRowFailed(err_code, err_msg)),
         }
     }
 

--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -48,7 +48,11 @@ impl Statement {
         let err = self.inner.step();
         Ok(Rows {
             stmt: self.clone(),
-            err: RefCell::new(Some(err)),
+            err: RefCell::new(Some((
+                err,
+                errors::extended_error_code(self.conn.raw),
+                errors::error_from_handle(self.conn.raw),
+            ))),
         })
     }
 
@@ -338,7 +342,13 @@ impl Statement {
             let table_name = self.column_table_name(i);
             let database_name = self.column_database_name(i);
             let decl_type = self.column_decltype(i);
-            cols.push(Column { name, origin_name, table_name, database_name, decl_type });
+            cols.push(Column {
+                name,
+                origin_name,
+                table_name,
+                database_name,
+                decl_type,
+            });
         }
         cols
     }


### PR DESCRIPTION
Revert the change introduced by 77c8b71481ebac0dbfa928f5c108fcd00d64ed81. It caused a wrong error being returned.
For example `column index out of range` was returned when `database is locked` was expected.