### PR TITLE
libsql/core: `column_names` return `Option<&str>`

### DIFF
--- a/crates/bindings/c/src/lib.rs
+++ b/crates/bindings/c/src/lib.rs
@@ -255,7 +255,9 @@ pub unsafe extern "C" fn libsql_column_name(
         );
         return 1;
     }
-    let name = res.column_name(col);
+    let name = res
+        .column_name(col)
+        .expect("Column should have valid index");
     match std::ffi::CString::new(name) {
         Ok(name) => {
             *out_name = name.into_raw();

--- a/crates/core/src/rows.rs
+++ b/crates/core/src/rows.rs
@@ -1,4 +1,4 @@
-use crate::{errors, Connection, Statement, Error, Params, Result, Value};
+use crate::{errors, Connection, Error, Params, Result, Statement, Value};
 use libsql_sys::ValueType;
 
 use std::cell::RefCell;
@@ -43,7 +43,7 @@ impl Rows {
         self.stmt.inner.column_count()
     }
 
-    pub fn column_name(&self, idx: i32) -> &str {
+    pub fn column_name(&self, idx: i32) -> Option<&str> {
         self.stmt.inner.column_name(idx)
     }
 
@@ -117,7 +117,7 @@ impl Row {
         }
     }
 
-    pub fn column_name(&self, idx: i32) -> &str {
+    pub fn column_name(&self, idx: i32) -> Option<&str> {
         self.stmt.inner.column_name(idx)
     }
 

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -90,11 +90,16 @@ impl Statement {
         unsafe { crate::ffi::sqlite3_column_type(self.raw_stmt, idx) }
     }
 
-    pub fn column_name(&self, idx: i32) -> &str {
+    pub fn column_name(&self, idx: i32) -> Option<&str> {
         let raw_name = unsafe { crate::ffi::sqlite3_column_name(self.raw_stmt, idx) };
+
+        if raw_name.is_null() {
+            return None;
+        }
+
         let raw_name = unsafe { std::ffi::CStr::from_ptr(raw_name as *const c_char) };
         let raw_name = raw_name.to_str().unwrap();
-        raw_name
+        Some(raw_name)
     }
 
     pub fn column_origin_name(&self, idx: i32) -> Option<&str> {


### PR DESCRIPTION
`column_names` now returns `Option<&str>` instead of segfaulting when the provided index is not valid.