### PR TITLE
Use latest stable Rust toolchain in CI

### DIFF
--- a/.github/workflows/golang-bindings.yml
+++ b/.github/workflows/golang-bindings.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@1.66.0
+    - uses: dtolnay/rust-toolchain@stable
     
     - name: get TCL
       run: sudo apt-get install -y tcl8.6-dev

--- a/.github/workflows/maketestwasm.yml
+++ b/.github/workflows/maketestwasm.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@1.66.0
+    - uses: dtolnay/rust-toolchain@stable
     
     - name: get TCL
       run: sudo apt-get install -y tcl8.6-dev


### PR DESCRIPTION
CI build is failing because Rust 1.66 is too old to build latest Clap. Let's use latest stable instead.