### PR TITLE
libsql/core: Implement hrana Statement::reset()

### DIFF
--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -324,7 +324,6 @@ impl super::statement::Stmt for Statement {
     }
 
     fn reset(&self) {
-        todo!()
     }
 
     fn parameter_count(&self) -> usize {


### PR DESCRIPTION
There's no state to reset so it's a no-op.