### PR TITLE
libsql/core: Fix row ordering with Hrana

### DIFF
--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -13,7 +13,7 @@ use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 
 // use crate::client::Config;
 use crate::{Column, Params, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, RwLock};
 
 use super::rows::{RowInner, RowsInner};
@@ -342,12 +342,12 @@ impl super::statement::Stmt for Statement {
 
 pub struct Rows {
     cols: Arc<Vec<Col>>,
-    rows: Vec<Vec<proto::Value>>,
+    rows: VecDeque<Vec<proto::Value>>,
 }
 
 impl RowsInner for Rows {
     fn next(&mut self) -> Result<Option<super::Row>> {
-        let row = match self.rows.pop() {
+        let row = match self.rows.pop_front() {
             Some(row) => Row {
                 cols: self.cols.clone(),
                 inner: row,

--- a/crates/core/src/v2/hrana/proto.rs
+++ b/crates/core/src/v2/hrana/proto.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 
 use std::fmt;
+use std::collections::VecDeque;
 
 use serde::{Deserialize, Serialize};
 
@@ -107,7 +108,7 @@ pub struct NamedArg {
 #[derive(Deserialize, Clone, Debug)]
 pub struct StmtResult {
     pub cols: Vec<Col>,
-    pub rows: Vec<Vec<Value>>,
+    pub rows: VecDeque<Vec<Value>>,
     pub affected_row_count: u64,
     #[serde(with = "option_i64_as_str")]
     pub last_insert_rowid: Option<i64>,


### PR DESCRIPTION
The Vec::pop() call results in queries seeing rows in reverse order. Switch to VecDeque::pop_front() to fix it.