### PR TITLE
Fix broken import

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -16,6 +16,6 @@ panic = "abort"
 
 [patch.crates-io]
 tonic = { git = "https://github.com/hyperium/tonic" }
-tonic-web = { git = "https://github.com/hyperium/tonic", branch = "lucio/grpc-web-client" }
+tonic-web = { git = "https://github.com/hyperium/tonic" }
 tonic-build = { git = "https://github.com/hyperium/tonic" }
 tower-http = { git = "https://github.com/tower-rs/tower-http", branch = "lucio/grpc-defaults" }


### PR DESCRIPTION
`tonic-web` was pointing to a deleted branch which is now merged into main. This patch fixes the imports.