### PR TITLE
crates/core: introduce a "core" feature

### DIFF
--- a/crates/bindings/c/src/lib.rs
+++ b/crates/bindings/c/src/lib.rs
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn libsql_connect(
     out_err_msg: *mut *const std::ffi::c_char,
 ) -> std::ffi::c_int {
     let db = db.get_ref();
-    let conn = match RT.block_on(db.connect()) {
+    let conn = match db.connect() {
         Ok(conn) => conn,
         Err(err) => {
             set_err_msg(format!("Unable to connect: {}", err), out_err_msg);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql"
-version = "0.1.9"
+version = "0.1.11"
 edition = "2021"
 description = "libSQL library: the main gateway for interacting with the database"
 repository = "https://github.com/libsql/libsql"
@@ -8,9 +8,9 @@ license = "MIT"
 
 [dependencies]
 futures = "0.3.28"
-libsql-sys = { version = "0", path = "../libsql-sys" }
+libsql-sys = { version = "0.2.13", path = "../libsql-sys", optional = true }
 thiserror = "1.0.40"
-libsql_replication = { version = "0", path = "../replication", optional = true }
+libsql_replication = { version = "0.0.5", path = "../replication", optional = true }
 tokio = { version = "1.29.1", features = ["macros"] }
 tracing-subscriber = "0.3.17"
 tracing = "0.1.37"
@@ -33,7 +33,8 @@ tempfile = "3.7.0"
 tokio = { version = "1.29.1", features = ["full"] }
 
 [features]
-default = ["replication"]
+default = ["core", "replication"]
+core = ["libsql-sys"]
 replication = ["dep:libsql_replication", "dep:bincode"]
 
 [[bench]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql"
-version = "0.1.7"
+version = "0.1.9"
 edition = "2021"
 description = "libSQL library: the main gateway for interacting with the database"
 repository = "https://github.com/libsql/libsql"

--- a/crates/core/benches/benchmark.rs
+++ b/crates/core/benches/benchmark.rs
@@ -14,7 +14,7 @@ fn bench(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
 
     let db = bench_db();
-    let conn = rt.block_on(db.connect()).unwrap();
+    let conn = db.connect().unwrap();
 
     group.bench_function("select 1", |b| {
         b.to_async(&rt).iter(|| async {

--- a/crates/core/examples/example.rs
+++ b/crates/core/examples/example.rs
@@ -3,7 +3,7 @@ use libsql::Database;
 #[tokio::main]
 async fn main() {
     let db = Database::open(":memory:").unwrap();
-    let conn = db.connect().await.unwrap();
+    let conn = db.connect().unwrap();
     conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)", ())
         .await
         .unwrap();

--- a/crates/core/examples/example_v2.rs
+++ b/crates/core/examples/example_v2.rs
@@ -15,7 +15,7 @@ async fn main() {
         Database::open_in_memory().unwrap()
     };
 
-    let conn = db.connect().await.unwrap();
+    let conn = db.connect().unwrap();
 
     conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)", ())
         .await

--- a/crates/core/examples/from_snapshot.rs
+++ b/crates/core/examples/from_snapshot.rs
@@ -1,5 +1,5 @@
 use libsql::Database;
-use libsql_replication::{Frames, TempSnapshot};
+se libsql_replication::{Frames, TempSnapshot};
 
 #[tokio::main]
 async fn main() {
@@ -8,7 +8,7 @@ async fn main() {
     let db = Database::open_with_sync("test.db", "http://localhost:8080", "")
         .await
         .unwrap();
-    let conn = db.connect().await.unwrap();
+    let conn = db.connect().unwrap();
 
     let args = std::env::args().collect::<Vec<String>>();
     if args.len() < 2 {

--- a/crates/core/examples/from_snapshot.rs
+++ b/crates/core/examples/from_snapshot.rs
@@ -1,5 +1,5 @@
 use libsql::Database;
-se libsql_replication::{Frames, TempSnapshot};
+use libsql_replication::{Frames, TempSnapshot};
 
 #[tokio::main]
 async fn main() {

--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -17,7 +17,7 @@ async fn main() {
     )
     .await
     .unwrap();
-    let conn = db.connect().await.unwrap();
+    let conn = db.connect().unwrap();
 
     let f = db.sync().await.unwrap();
     println!("inital sync complete, frame no: {}", f);

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -20,26 +20,31 @@ pub enum Error {
     SyncNotSupported(String), // Not in rusqlite
     #[error("Column not found: {0}")]
     ColumnNotFound(i32), // Not in rusqlite
+    #[cfg(feature = "core")]
     #[error("Hrana: `{0}`")]
     Hrana(#[from] crate::v2::HranaError), // Not in rusqlite
     #[error("Write delegation: `{0}`")]
     WriteDelegation(crate::BoxError), // Not in rusqlite
 }
 
+#[cfg(feature = "core")]
 pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {
     let errmsg = unsafe { libsql_sys::ffi::sqlite3_errmsg(raw) };
     sqlite_errmsg_to_string(errmsg)
 }
 
+#[cfg(feature = "core")]
 pub(crate) fn extended_error_code(raw: *mut libsql_sys::ffi::sqlite3) -> std::ffi::c_int {
     unsafe { libsql_sys::ffi::sqlite3_extended_errcode(raw) }
 }
 
+#[cfg(feature = "core")]
 pub fn error_from_code(code: i32) -> String {
     let errmsg = unsafe { libsql_sys::ffi::sqlite3_errstr(code) };
     sqlite_errmsg_to_string(errmsg)
 }
 
+#[cfg(feature = "core")]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn sqlite_errmsg_to_string(errmsg: *const std::ffi::c_char) -> String {
     let errmsg = unsafe { std::ffi::CStr::from_ptr(errmsg) }.to_bytes();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,7 +13,7 @@
 //! use libsql::Database;
 //!
 //! let db = Database::open_in_memory().unwrap();
-//! let conn = db.connect().await.unwrap();
+//! let conn = db.connect().unwrap();
 //! conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)", ()).await.unwrap();
 //! conn.execute("INSERT INTO users (email) VALUES ('alice@example.org')", ()).await.unwrap();
 //! # }
@@ -35,7 +35,7 @@
 //!
 //! let frames = Frames::Vec(vec![]);
 //! db.sync_frames(frames).unwrap();
-//! let conn = db.connect().await.unwrap();
+//! let conn = db.connect().unwrap();
 //! conn.execute("SELECT * FROM users", ()).await.unwrap();
 //! # }
 //! ```
@@ -46,18 +46,25 @@
 
 // Legacy mode, for compatibility with the old libsql API, it is doc hidden so
 // that new users do not use this api as its deprecated in favor of the v2 api.
+#[cfg(feature = "core")]
 mod v1;
+#[cfg(feature = "core")]
 mod v2;
 
+pub mod errors;
+pub use errors::Error;
+
+#[cfg(all(feature = "core", feature = "replication"))]
+pub use v1::database::Opts;
+
+#[cfg(feature = "core")]
 pub use v1::{
-    database::Opts,
-    errors,
-    errors::Error,
     params,
     params::{params_from_iter, Params, Value, ValueRef},
-    version, version_number, Result, RowsFuture,
+    version, version_number, RowsFuture,
 };
 
+#[cfg(feature = "core")]
 pub use v2::{
     hrana, rows,
     rows::{Row, Rows},
@@ -68,6 +75,8 @@ pub use v2::{
     Connection, Database,
 };
 
+#[cfg(feature = "core")]
 pub use libsql_sys::ffi;
 
+pub type Result<T> = std::result::Result<T, errors::Error>;
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/crates/core/src/v1/connection.rs
+++ b/crates/core/src/v1/connection.rs
@@ -90,7 +90,8 @@ impl Connection {
     /// ## Example
     ///
     /// ```rust,no_run,ignore
-    /// # use libsql::v1::{Connection, Result, Rows};
+    /// # use libsql::Result;
+    /// # use libsql::v1::{Connection, Rows};
     /// # fn create_tables(conn: &Connection) -> Result<Option<Rows>> {
     /// conn.query("SELECT * FROM users WHERE name = ?1;", vec![libsql::Value::from(1)])
     /// # }
@@ -115,7 +116,8 @@ impl Connection {
     /// ## Example
     ///
     /// ```rust,no_run,ignore
-    /// # use libsql::v1::{Connection, Result};
+    /// # use libsql::Result;
+    /// # use libsql::v1::Connection;
     /// # fn create_tables(conn: &Connection) -> Result<()> {
     /// conn.execute_batch(
     ///     "BEGIN;

--- a/crates/core/src/v1/database.rs
+++ b/crates/core/src/v1/database.rs
@@ -1,4 +1,5 @@
-use crate::v1::{connection::Connection, errors::Error::ConnectionFailed, Result};
+use crate::v1::connection::Connection;
+use crate::{Error::ConnectionFailed, Result};
 #[cfg(feature = "replication")]
 use libsql_replication::Replicator;
 #[cfg(feature = "replication")]

--- a/crates/core/src/v1/mod.rs
+++ b/crates/core/src/v1/mod.rs
@@ -1,21 +1,18 @@
 pub mod connection;
 pub mod database;
-pub mod errors;
 pub mod params;
 pub mod rows;
 pub mod statement;
 pub mod transaction;
 
-pub type Result<T> = std::result::Result<T, errors::Error>;
-
 pub use libsql_sys::ffi;
 pub use libsql_sys::ValueType;
 
+pub use crate::{errors, Error, Result};
 pub use connection::Connection;
 pub use database::Database;
 #[cfg(feature = "replication")]
 pub use database::Opts;
-pub use errors::Error;
 pub use params::Params;
 pub use params::{params_from_iter, Value, ValueRef};
 pub use rows::Row;

--- a/crates/core/src/v1/params.rs
+++ b/crates/core/src/v1/params.rs
@@ -114,7 +114,7 @@ impl From<libsql_sys::Value> for Value {
     fn from(value: libsql_sys::Value) -> Value {
         match value.value_type() {
             ValueType::Null => Value::Null,
-            ValueType::Integer => Value::Integer(value.int64().into()),
+            ValueType::Integer => Value::Integer(value.int64()),
             ValueType::Real => Value::Real(value.double()),
             ValueType::Text => {
                 let v = value.text();
@@ -216,7 +216,7 @@ impl<'a> From<libsql_sys::Value> for ValueRef<'a> {
     fn from(value: libsql_sys::Value) -> ValueRef<'a> {
         match value.value_type() {
             ValueType::Null => ValueRef::Null,
-            ValueType::Integer => ValueRef::Integer(value.int64().into()),
+            ValueType::Integer => ValueRef::Integer(value.int64()),
             ValueType::Real => todo!(),
             ValueType::Text => {
                 let v = value.text();

--- a/crates/core/src/v1/rows.rs
+++ b/crates/core/src/v1/rows.rs
@@ -1,4 +1,5 @@
-use crate::v1::{errors, Connection, Error, Params, Result, Statement, Value};
+use crate::v1::{Connection, Params, Statement, Value};
+use crate::{errors, Error, Result};
 use libsql_sys::ValueType;
 
 use std::cell::RefCell;

--- a/crates/core/src/v1/statement.rs
+++ b/crates/core/src/v1/statement.rs
@@ -1,5 +1,6 @@
 use crate::v1::rows::{MappedRows, Row};
-use crate::v1::{errors, Connection, Error, Params, Result, Rows, ValueRef};
+use crate::v1::{Connection, Params, Rows, ValueRef};
+use crate::{errors, Error, Result};
 
 use std::cell::RefCell;
 use std::ffi::c_int;

--- a/crates/core/src/v1/transaction.rs
+++ b/crates/core/src/v1/transaction.rs
@@ -1,4 +1,5 @@
-use crate::v1::{Connection, Result};
+use crate::v1::Connection;
+use crate::Result;
 use std::ops::Deref;
 
 pub enum TransactionBehavior {

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -5,7 +5,8 @@ pub mod transaction;
 
 use std::sync::Arc;
 
-use crate::v1::{Params, Result, TransactionBehavior};
+use crate::v1::{Params, TransactionBehavior};
+use crate::Result;
 pub use hrana::{Client, HranaError};
 
 pub use rows::{Row, Rows};
@@ -43,6 +44,7 @@ impl Database {
         })
     }
 
+    #[cfg(feature = "replication")]
     pub async fn open_with_sync(
         db_path: impl Into<String>,
         url: impl Into<String>,

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -64,7 +64,7 @@ impl Database {
         })
     }
 
-    pub async fn connect(&self) -> Result<Connection> {
+    pub fn connect(&self) -> Result<Connection> {
         match &self.db_type {
             DbType::Memory => {
                 let db = crate::v1::Database::open(":memory:")?;

--- a/crates/core/src/v2/statement.rs
+++ b/crates/core/src/v2/statement.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 pub use crate::v1::Column;
-use crate::v1::{Error, Params, Result};
+use crate::v1::Params;
+use crate::{Error, Result};
 
 use crate::{rows::LibsqlRows, Row, Rows};
 

--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -2,7 +2,7 @@ use libsql::{named_params, params, Connection, Database, Params, Value};
 
 async fn setup() -> Connection {
     let db = Database::open(":memory:").unwrap();
-    let conn = db.connect().await.unwrap();
+    let conn = db.connect().unwrap();
     let _ = conn
         .execute("CREATE TABLE users (id INTEGER, name TEXT)", ())
         .await;
@@ -12,7 +12,7 @@ async fn setup() -> Connection {
 #[tokio::test]
 async fn connection_drops_before_statements() {
     let db = Database::open(":memory:").unwrap();
-    let conn = db.connect().await.unwrap();
+    let conn = db.connect().unwrap();
     let _stmt = conn.prepare("SELECT 1").await.unwrap();
     drop(conn);
 }

--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql_replication"
-version = "0.0.3"
+version = "0.0.5"
 edition = "2021"
 description = "Replication support for libsql"
 repository = "https://github.com/libsql/libsql"


### PR DESCRIPTION
Without it, only basic utilities are compiled-in - errors and some types. Useful for exposing the API without forcing the dependent crate to be able to compile and link libsql-sys.