### PR TITLE
crates/{core,libsql-sys}: Add Statement.finalize()

### DIFF
--- a/crates/core/src/statement.rs
+++ b/crates/core/src/statement.rs
@@ -13,6 +13,10 @@ pub struct Statement {
 }
 
 impl Statement {
+    pub(crate) fn finalize(&self) {
+        self.inner.finalize();
+    }
+
     pub(crate) fn prepare(
         conn: Connection,
         raw: *mut libsql_sys::ffi::sqlite3,

--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -325,6 +325,9 @@ pub struct Statement {
 
 #[async_trait::async_trait]
 impl super::statement::Stmt for Statement {
+    fn finalize(&self) {
+    }
+
     async fn execute(&self, params: &Params) -> Result<usize> {
         let mut stmt = self.inner.clone();
         bind_params(params.clone(), &mut stmt);

--- a/crates/core/src/v2/statement.rs
+++ b/crates/core/src/v2/statement.rs
@@ -7,6 +7,8 @@ use super::{rows::LibsqlRows, Row, Rows};
 // TODO(lucio): Add `column_*` based fn
 #[async_trait::async_trait]
 pub(super) trait Stmt {
+    fn finalize(&self);
+
     async fn execute(&self, params: &Params) -> Result<usize>;
 
     async fn query(&self, params: &Params) -> Result<Rows>;
@@ -27,6 +29,10 @@ pub struct Statement {
 // TODO(lucio): Unify param usage, here we use & and in conn we use
 //      Into.
 impl Statement {
+    pub fn finalize(&self) {
+        self.inner.finalize();
+    }
+
     pub async fn execute(&self, params: &Params) -> Result<usize> {
         self.inner.execute(params).await
     }
@@ -97,6 +103,10 @@ pub(super) struct LibsqlStmt(pub(super) crate::Statement);
 
 #[async_trait::async_trait]
 impl Stmt for LibsqlStmt {
+    fn finalize(&self) {
+        self.0.finalize();
+    }
+
     async fn execute(&self, params: &Params) -> Result<usize> {
         let params = params.clone();
         let stmt = self.0.clone();


### PR DESCRIPTION
It's convenient to have it around for GC languages where it's hard to control when Statement objects are dropped.