### PR TITLE
libsq/core: Fix integer truncation in values

### DIFF
--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -111,7 +111,7 @@ impl From<libsql_sys::Value> for Value {
     fn from(value: libsql_sys::Value) -> Value {
         match value.value_type() {
             ValueType::Null => Value::Null,
-            ValueType::Integer => Value::Integer(value.int().into()),
+            ValueType::Integer => Value::Integer(value.int64().into()),
             ValueType::Real => Value::Real(value.double()),
             ValueType::Text => {
                 let v = value.text();
@@ -213,7 +213,7 @@ impl<'a> From<libsql_sys::Value> for ValueRef<'a> {
     fn from(value: libsql_sys::Value) -> ValueRef<'a> {
         match value.value_type() {
             ValueType::Null => ValueRef::Null,
-            ValueType::Integer => ValueRef::Integer(value.int().into()),
+            ValueType::Integer => ValueRef::Integer(value.int64().into()),
             ValueType::Real => todo!(),
             ValueType::Text => {
                 let v = value.text();


### PR DESCRIPTION
The `Integer` value holds a 64-bit integer so that it can represent the whole range of numbers. Fix integer truncation in the conversion process where we accidentally use int() instead of int64().