### PR TITLE
libsql/core: Use mutable refs for statement

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ criterion = { version = "0.5", features = ["html_reports", "async", "async_futur
 pprof = { version = "0.12.1", features = ["criterion", "flamegraph"] }
 tempfile = "3.7.0"
 tokio = { version = "1.29.1", features = ["full"] }
+tokio-test = "0.4"
 
 [features]
 default = ["replication"]

--- a/crates/core/examples/example_v2.rs
+++ b/crates/core/examples/example_v2.rs
@@ -21,7 +21,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let stmt = conn
+    let mut stmt = conn
         .prepare("INSERT INTO users (email) VALUES (?1)")
         .await
         .unwrap();
@@ -32,7 +32,7 @@ async fn main() {
 
     db.sync().await.unwrap();
 
-    let stmt = conn
+    let mut stmt = conn
         .prepare("SELECT * FROM users WHERE email = ?1")
         .await
         .unwrap();

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -160,7 +160,7 @@ impl Connection {
     }
 
     pub async fn query(&self, sql: &str, params: impl Into<Params>) -> Result<Rows> {
-        let stmt = self.prepare(sql).await?;
+        let mut stmt = self.prepare(sql).await?;
 
         stmt.query(&params.into()).await
     }
@@ -217,7 +217,7 @@ impl Conn for LibsqlConnection {
         let stmt = self.conn.prepare(sql)?;
 
         Ok(Statement {
-            inner: Arc::new(LibsqlStmt(stmt)),
+            inner: Box::new(LibsqlStmt(stmt)),
         })
     }
 

--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -96,7 +96,7 @@ async fn statement_query() {
 
     let params = Params::from(vec![libsql::Value::from(2)]);
 
-    let stmt = conn
+    let mut stmt = conn
         .prepare("SELECT * FROM users WHERE id = ?1")
         .await
         .unwrap();


### PR DESCRIPTION
This changes `Statment` to use `&mut self` for fn that modify the statement state. This will enable write delegation enabled statments to "cache" the bindings locally without needing a mutex.