### PR TITLE
crates/core: add try_params and more conversions

### DIFF
--- a/crates/core/examples/example.rs
+++ b/crates/core/examples/example.rs
@@ -10,4 +10,26 @@ async fn main() {
     conn.execute("INSERT INTO users (email) VALUES ('alice@example.org')", ())
         .await
         .unwrap();
+    conn.execute(
+        "CREATE TABLE test1 (t TEXT, i INTEGER, f FLOAT, b BLOB)",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
+        libsql::params!("a", 1, 1.0, vec![1, 2, 3]),
+    )
+    .await
+    .unwrap();
+    let mut rows = conn.query("SELECT * FROM test1", ()).await.unwrap();
+    while let Ok(Some(row)) = rows.next() {
+        println!(
+            "{:?} {:?} {:?} {:?}",
+            row.get_value(0),
+            row.get_value(1),
+            row.get_value(2),
+            row.get_value(3)
+        );
+    }
 }

--- a/crates/core/examples/example.rs
+++ b/crates/core/examples/example.rs
@@ -1,4 +1,4 @@
-use libsql::Database;
+use libsql::{params, try_params, Database};
 
 #[tokio::main]
 async fn main() {
@@ -18,7 +18,13 @@ async fn main() {
     .unwrap();
     conn.execute(
         "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
-        libsql::params!("a", 1, 1.0, vec![1, 2, 3]),
+        params!("a", 1, 1.0, vec![1, 2, 3]),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
+        try_params!("b", 2_u64, 2.0, vec![4, 5, 6]).unwrap(),
     )
     .await
     .unwrap();

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -27,6 +27,12 @@ pub enum Error {
     WriteDelegation(crate::BoxError), // Not in rusqlite
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(_: std::convert::Infallible) -> Self {
+        unreachable!()
+    }
+}
+
 #[cfg(feature = "core")]
 pub(crate) fn error_from_handle(raw: *mut libsql_sys::ffi::sqlite3) -> String {
     let errmsg = unsafe { libsql_sys::ffi::sqlite3_errmsg(raw) };

--- a/crates/core/src/v1/params.rs
+++ b/crates/core/src/v1/params.rs
@@ -98,6 +98,30 @@ impl From<i32> for Value {
     }
 }
 
+impl From<i64> for Value {
+    fn from(value: i64) -> Value {
+        Value::Integer(value)
+    }
+}
+
+impl From<u32> for Value {
+    fn from(value: u32) -> Value {
+        Value::Integer(value as i64)
+    }
+}
+
+impl From<f32> for Value {
+    fn from(value: f32) -> Value {
+        Value::Real(value as f64)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Value {
+        Value::Real(value)
+    }
+}
+
 impl From<&str> for Value {
     fn from(value: &str) -> Value {
         Value::Text(value.to_owned())

--- a/crates/core/src/v1/params.rs
+++ b/crates/core/src/v1/params.rs
@@ -23,12 +23,36 @@ macro_rules! params {
 }
 
 #[macro_export]
+macro_rules! try_params {
+    () => {
+        Ok($crate::Params::None)
+    };
+    ($($value:expr),* $(,)?) => {
+        || -> $crate::Result<$crate::Params> {
+            Ok($crate::Params::Positional(vec![$($value.try_into()?),*]))
+        }()
+    };
+}
+
+#[macro_export]
 macro_rules! named_params {
     () => {
         $crate::Params::None
     };
     ($($param_name:literal: $value:expr),* $(,)?) => {
         $crate::Params::Named(vec![$(($param_name.to_string(), $crate::params::Value::from($value))),*])
+    };
+}
+
+#[macro_export]
+macro_rules! try_named_params {
+    () => {
+        Ok($crate::Params::None)
+    };
+    ($($param_name:literal: $value:expr),* $(,)?) => {
+        || -> $crate::Result<$crate::Params> {
+            Ok($crate::Params::Named(vec![$(($param_name.to_string(), $crate::params::Value::try_from($value)?)),*]))
+        }()
     };
 }
 
@@ -110,6 +134,20 @@ impl From<u32> for Value {
     }
 }
 
+impl TryFrom<u64> for Value {
+    type Error = crate::Error;
+
+    fn try_from(value: u64) -> Result<Value> {
+        if value > i64::MAX as u64 {
+            Err(Error::ToSqlConversionFailure(
+                "u64 is too large to fit in an i64".into(),
+            ))
+        } else {
+            Ok(Value::Integer(value as i64))
+        }
+    }
+}
+
 impl From<f32> for Value {
     fn from(value: f32) -> Value {
         Value::Real(value as f64)
@@ -125,6 +163,18 @@ impl From<f64> for Value {
 impl From<&str> for Value {
     fn from(value: &str) -> Value {
         Value::Text(value.to_owned())
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Value {
+        Value::Text(value)
+    }
+}
+
+impl From<&[u8]> for Value {
+    fn from(value: &[u8]) -> Value {
+        Value::Blob(value.to_owned())
     }
 }
 


### PR DESCRIPTION
This small PR adds a `try_params` macro, which works similarly to `params!`, except it returns a Result and is based on `TryInto` instead of `Into`.

I also evaluated how compatible with rusqlite we can/should be, and here are my conclusions:
1. rusqlite implements `Params` as a trait, while in our code it's a clonable struct
2. rusqlite params are based on a `ToSql` trait, as well as `&dyn ToSql` for passing parameters
3. our params are just Value instances passed by value
4. rusqlite does intricate lifetime management of the parameters, while we're more into "pass and clone everything as is to avoid being generic over lifetimes

To sum up, I *haven't* just migrated to rusqlite code in this PR, because rusqlite params are more in line with their lifetime management -> e.g. `query` returns a `Rows<'a>`, and the public interfaces are generally lifetime-bound. On the other hand, our params are just a structure, that can be copied over if necessary, which has a DX advantage - less fights with the borrow checker at the price of more memory copying and allocations.

Happy to discuss what should our final approach be!