### PR TITLE
libsql/core: Local sync API

### DIFF
--- a/crates/bindings/c/src/lib.rs
+++ b/crates/bindings/c/src/lib.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn libsql_open_sync(
             return 3;
         }
     };
-    match RT.block_on(libsql::Database::open_with_sync(
+    match RT.block_on(libsql::Database::open_with_remote_sync(
         db_path.to_string(),
         primary_url,
         auth_token,

--- a/crates/core/examples/example_v2.rs
+++ b/crates/core/examples/example_v2.rs
@@ -8,7 +8,7 @@ async fn main() {
             "".to_string()
         });
 
-        Database::open_with_sync("db.sqld", url, token)
+        Database::open_with_remote_sync("db.sqld", url, token)
             .await
             .unwrap()
     } else {

--- a/crates/core/examples/local_sync.rs
+++ b/crates/core/examples/local_sync.rs
@@ -5,7 +5,7 @@ use libsql_replication::{Frames, TempSnapshot};
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let db = Database::open_with_sync("test.db", "http://localhost:8080", "")
+    let db = Database::open_with_local_sync("test.db")
         .await
         .unwrap();
     let conn = db.connect().unwrap();

--- a/crates/core/examples/replica.rs
+++ b/crates/core/examples/replica.rs
@@ -10,7 +10,7 @@ async fn main() {
 
     let auth_token = std::env::var("TURSO_AUTH_TOKEN").expect("Expected a TURSO_AUTH_TOKEN");
 
-    let db = Database::open_with_sync(
+    let db = Database::open_with_remote_sync(
         db_file.path().to_str().unwrap(),
         "http://localhost:8080",
         auth_token,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -31,7 +31,7 @@
 //! use libsql::{Database, Opts};
 //! use libsql_replication::{Frame, Frames, Replicator};
 //!
-//! let mut db = Database::open_with_sync("/tmp/test.db", "http://localhost:8080", "").await.unwrap();
+//! let mut db = Database::open_with_local_sync("/tmp/test.db").await.unwrap();
 //!
 //! let frames = Frames::Vec(vec![]);
 //! db.sync_frames(frames).unwrap();

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -44,8 +44,21 @@ impl Database {
         })
     }
 
+    /// Open a local database file with the ability to sync from snapshots from local filesystem.
     #[cfg(feature = "replication")]
-    pub async fn open_with_sync(
+    pub async fn open_with_local_sync(
+        db_path: impl Into<String>,
+    ) -> Result<Database> {
+        let opts = crate::Opts::with_sync();
+        let db = crate::v1::Database::open_with_opts(db_path, opts).await?;
+        Ok(Database {
+            db_type: DbType::Sync { db },
+        })
+    }
+
+    /// Open a local database file with the ability to sync from a remote database.
+    #[cfg(feature = "replication")]
+    pub async fn open_with_remote_sync(
         db_path: impl Into<String>,
         url: impl Into<String>,
         token: impl Into<String>,


### PR DESCRIPTION
This brings back a proper local sync API, which does not require callers to specify an URL and auth token.