### PR TITLE
crates/replication: do not wait for replication in execute()

### DIFF
--- a/crates/core/examples/local_sync.rs
+++ b/crates/core/examples/local_sync.rs
@@ -5,9 +5,7 @@ use libsql_replication::{Frames, TempSnapshot};
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let db = Database::open_with_local_sync("test.db")
-        .await
-        .unwrap();
+    let db = Database::open_with_local_sync("test.db").await.unwrap();
     let conn = db.connect().unwrap();
 
     let args = std::env::args().collect::<Vec<String>>();

--- a/crates/core/examples/remote_sync.rs
+++ b/crates/core/examples/remote_sync.rs
@@ -1,6 +1,6 @@
 // Example of using a remote sync server with libsql.
 
-use libsql::{Database, params};
+use libsql::{params, Database};
 
 #[tokio::main]
 async fn main() {
@@ -10,7 +10,9 @@ async fn main() {
     let db_path = match std::env::var("LIBSQL_DB_PATH") {
         Ok(path) => path,
         Err(_) => {
-            eprintln!("Please set the LIBSQL_DB_PATH environment variable to set to local database path.");
+            eprintln!(
+                "Please set the LIBSQL_DB_PATH environment variable to set to local database path."
+            );
             return;
         }
     };
@@ -19,7 +21,9 @@ async fn main() {
     let sync_url = match std::env::var("LIBSQL_SYNC_URL") {
         Ok(url) => url,
         Err(_) => {
-            eprintln!("Please set the LIBSQL_SYNC_URL environment variable to set to remote sync URL.");
+            eprintln!(
+                "Please set the LIBSQL_SYNC_URL environment variable to set to remote sync URL."
+            );
             return;
         }
     };
@@ -56,20 +60,26 @@ async fn main() {
         Ok(_) => {
             println!("You entered: {}", input);
             let params = params![input.as_str()];
-            conn.execute("INSERT INTO guest_book_entries (text) VALUES (?)", params).await.unwrap();
+            conn.execute("INSERT INTO guest_book_entries (text) VALUES (?)", params)
+                .await
+                .unwrap();
         }
         Err(error) => {
             eprintln!("Error reading input: {}", error);
         }
     }
-    let mut results = conn.query("SELECT * FROM guest_book_entries", ()).await.unwrap();
+    db.sync().await.unwrap();
+    let mut results = conn
+        .query("SELECT * FROM guest_book_entries", ())
+        .await
+        .unwrap();
     println!("Guest book entries:");
     loop {
         match results.next().unwrap() {
             Some(row) => {
                 let text: String = row.get(0).unwrap();
                 println!("  {}", text);
-            },
+            }
             None => break,
         };
     }

--- a/crates/core/examples/remote_sync.rs
+++ b/crates/core/examples/remote_sync.rs
@@ -1,0 +1,76 @@
+// Example of using a remote sync server with libsql.
+
+use libsql::{Database, params};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    // The local database path where the data will be stored.
+    let db_path = match std::env::var("LIBSQL_DB_PATH") {
+        Ok(path) => path,
+        Err(_) => {
+            eprintln!("Please set the LIBSQL_DB_PATH environment variable to set to local database path.");
+            return;
+        }
+    };
+
+    // The remote sync URL to use.
+    let sync_url = match std::env::var("LIBSQL_SYNC_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("Please set the LIBSQL_SYNC_URL environment variable to set to remote sync URL.");
+            return;
+        }
+    };
+
+    // The authentication token to use.
+    let auth_token = std::env::var("LIBSQL_AUTH_TOKEN").unwrap_or("".to_string());
+
+    let db = match Database::open_with_remote_sync(db_path, sync_url, auth_token).await {
+        Ok(db) => db,
+        Err(error) => {
+            eprintln!("Error connecting to remote sync server: {}", error);
+            return;
+        }
+    };
+    let conn = db.connect().unwrap();
+
+    print!("Syncing with remote database...");
+    db.sync().await.unwrap();
+    println!(" done");
+
+    conn.execute(
+        r#"
+        CREATE TABLE IF NOT EXISTS guest_book_entries (
+            text TEXT
+        )"#,
+        (),
+    )
+    .await
+    .unwrap();
+
+    let mut input = String::new();
+    println!("Please write your entry to the guestbook:");
+    match std::io::stdin().read_line(&mut input) {
+        Ok(_) => {
+            println!("You entered: {}", input);
+            let params = params![input.as_str()];
+            conn.execute("INSERT INTO guest_book_entries (text) VALUES (?)", params).await.unwrap();
+        }
+        Err(error) => {
+            eprintln!("Error reading input: {}", error);
+        }
+    }
+    let mut results = conn.query("SELECT * FROM guest_book_entries", ()).await.unwrap();
+    println!("Guest book entries:");
+    loop {
+        match results.next().unwrap() {
+            Some(row) => {
+                let text: String = row.get(0).unwrap();
+                println!("  {}", text);
+            },
+            None => break,
+        };
+    }
+}

--- a/crates/core/src/v1/database.rs
+++ b/crates/core/src/v1/database.rs
@@ -116,7 +116,7 @@ impl Database {
     }
 
     #[cfg(feature = "replication")]
-    pub async fn sync(&self) -> Result<usize> {
+    pub async fn sync_oneshot(&self) -> Result<usize> {
         if let Some(ctx) = &self.replication_ctx {
             ctx.replicator
                 .sync_from_http()
@@ -128,6 +128,21 @@ impl Database {
                     .to_string(),
             ))
         }
+    }
+
+    #[cfg(feature = "replication")]
+    pub async fn sync(&self) -> Result<usize> {
+        let mut synced = 0;
+        loop {
+            let n = self.sync_oneshot().await?;
+            tracing::trace!("Synced {n} frames");
+            if n == 0 {
+                break;
+            } else {
+                synced += n;
+            }
+        }
+        Ok(synced)
     }
 
     #[cfg(feature = "replication")]

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -46,9 +46,7 @@ impl Database {
 
     /// Open a local database file with the ability to sync from snapshots from local filesystem.
     #[cfg(feature = "replication")]
-    pub async fn open_with_local_sync(
-        db_path: impl Into<String>,
-    ) -> Result<Database> {
+    pub async fn open_with_local_sync(db_path: impl Into<String>) -> Result<Database> {
         let opts = crate::Opts::with_sync();
         let db = crate::v1::Database::open_with_opts(db_path, opts).await?;
         Ok(Database {

--- a/crates/libsql-sys/src/statement.rs
+++ b/crates/libsql-sys/src/statement.rs
@@ -26,8 +26,13 @@ impl Drop for Statement {
 
 impl Statement {
     pub fn finalize(&self) {
-        if !self.finalized.swap(true, std::sync::atomic::Ordering::SeqCst) {
-            unsafe { crate::ffi::sqlite3_finalize(self.raw_stmt); }
+        if !self
+            .finalized
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            unsafe {
+                crate::ffi::sqlite3_finalize(self.raw_stmt);
+            }
         }
     }
 
@@ -210,7 +215,11 @@ pub unsafe fn prepare_stmt(raw: *mut crate::ffi::sqlite3, sql: &str) -> Result<S
     };
 
     match err as u32 {
-        crate::ffi::SQLITE_OK => Ok(Statement { raw_stmt, tail, finalized: AtomicBool::new(false) }),
+        crate::ffi::SQLITE_OK => Ok(Statement {
+            raw_stmt,
+            tail,
+            finalized: AtomicBool::new(false),
+        }),
         _ => Err(err.into()),
     }
 }


### PR DESCRIPTION
Waiting makes sense if we have a background fiber that continuously
replicates frames back to us. In libsql crate we don't do that,
so we effectively wait for frames to be replicated, but no replication
was ever requested, and we deadlock.
Instead, as you can see in the modified examples/remote_sync example,
users call db.sync().await() in order to be able to read their own
writes.

Depends on #366 