### PR TITLE
add open_remote_with_connector

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = "0.1"
 crossbeam-channel = "0.5"
 bincode = { version = "1", optional = true }
 bitflags = "2.4.0"
+tower = "0.4"
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/crates/core/src/box_clone_service.rs
+++ b/crates/core/src/box_clone_service.rs
@@ -1,0 +1,86 @@
+//! Copied from https://docs.rs/tower/latest/tower/util/struct.BoxCloneService.html
+//! This is because in the tower version the trait object only implements `Send` which
+//! means we can't call clients from context that need `Sync` like an `async fn` that needs
+//! to be `Send` (must be sync as well to impl Send).
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::Service;
+use tower::ServiceExt;
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+pub struct BoxCloneService<T, U, E>(
+    Box<
+        dyn CloneService<T, Response = U, Error = E, Future = BoxFuture<Result<U, E>>>
+            + Send
+            + Sync,
+    >,
+);
+
+impl<T, U, E> BoxCloneService<T, U, E> {
+    /// Create a new `BoxCloneService`.
+    pub fn new<S>(inner: S) -> Self
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Sync + Send + 'static,
+        S::Future: Send + 'static,
+    {
+        let inner = inner.map_future(|f| Box::pin(f) as _);
+        BoxCloneService(Box::new(inner))
+    }
+}
+
+impl<T, U, E> Service<T> for BoxCloneService<T, U, E> {
+    type Response = U;
+    type Error = E;
+    type Future = BoxFuture<Result<U, E>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
+        self.0.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, request: T) -> Self::Future {
+        self.0.call(request)
+    }
+}
+
+impl<T, U, E> Clone for BoxCloneService<T, U, E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+trait CloneService<R>: Service<R> {
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneService<R, Response = Self::Response, Error = Self::Error, Future = Self::Future>
+            + Send
+            + Sync,
+    >;
+}
+
+impl<R, T> CloneService<R> for T
+where
+    T: Service<R> + Send + Sync + Clone + 'static,
+{
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneService<R, Response = T::Response, Error = T::Error, Future = T::Future>
+            + Send
+            + Sync,
+    > {
+        Box::new(self.clone())
+    }
+}
+
+impl<T, U, E> fmt::Debug for BoxCloneService<T, U, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BoxCloneService").finish()
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -52,6 +52,7 @@ mod v1;
 mod v2;
 
 pub mod errors;
+mod box_clone_service;
 pub use errors::Error;
 
 #[cfg(all(feature = "core", feature = "replication"))]

--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -2,7 +2,6 @@ mod pipeline;
 mod proto;
 
 use hyper::header::AUTHORIZATION;
-use hyper::service::Service;
 use libsql_sys::ValueType;
 use pipeline::{
     ClientMsg, Response, ServerMsg, StreamBatchReq, StreamExecuteReq, StreamRequest,
@@ -11,9 +10,9 @@ use pipeline::{
 use proto::{Batch, BatchResult, Col, Stmt, StmtResult};
 
 use hyper::client::HttpConnector;
-use hyper::{StatusCode, Uri};
+use hyper::StatusCode;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tower::ServiceExt;
 
 // use crate::client::Config;
 use crate::{params::Params, Column, Result};
@@ -22,7 +21,7 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use super::rows::{RowInner, RowsInner};
-use super::{Conn, Transaction};
+use super::{Conn, ConnectorService, Socket, Transaction};
 
 /// Information about the current session: the server-generated cookie
 /// and the URL that should be used for further communication.
@@ -35,8 +34,8 @@ struct Cookie {
 /// Generic HTTP client. Needs a helper function that actually sends
 /// the request.
 #[derive(Clone, Debug)]
-pub struct Client<C = HttpConnector> {
-    inner: InnerClient<C>,
+pub struct Client {
+    inner: InnerClient,
     cookies: Arc<RwLock<HashMap<u64, Cookie>>>,
     url_for_queries: String,
     auth: String,
@@ -45,18 +44,12 @@ pub struct Client<C = HttpConnector> {
 }
 
 #[derive(Clone, Debug)]
-struct InnerClient<C> {
-    inner: hyper::Client<HttpsConnector<C>, hyper::Body>,
+struct InnerClient {
+    inner: hyper::Client<HttpsConnector<ConnectorService>, hyper::Body>,
 }
 
-impl<C> InnerClient<C>
-where 
-    C: Service<Uri> + Send + Clone + Sync + 'static,
-    C::Response: hyper::client::connect::Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-    C::Future: Send + 'static,
-    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-{
-    fn new(connector: C) -> Self {
+impl InnerClient {
+    fn new(connector: ConnectorService) -> Self {
         let https = HttpsConnectorBuilder::new()
             .with_native_roots()
             .https_or_http()
@@ -111,14 +104,35 @@ pub enum HranaError {
     Api(String),
 }
 
-impl<C> Client<C>
-where 
-    C: Service<Uri> + Send + Clone + Sync + 'static,
-    C::Response: hyper::client::connect::Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-    C::Future: Send + 'static,
-    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-{
-    pub fn new_with_connector(url: impl Into<String>, token: impl Into<String>, connector: C) -> Self {
+impl Client {
+    /// Creates a database client with JWT authentication.
+    ///
+    /// # Arguments
+    /// * `url` - URL of the database endpoint
+    /// * `token` - auth token
+    pub fn new(url: impl Into<String>, token: impl Into<String>) -> Self {
+        let connector = HttpConnector::new()
+            .map_response(|s| Box::new(s) as Box<dyn Socket>)
+            .map_err(|e| Box::new(e) as Box<_>);
+        Self::new_with_connector(url, token, ConnectorService::new(connector))
+    }
+
+    pub fn from_env() -> Result<Client> {
+        let url = std::env::var("LIBSQL_CLIENT_URL").map_err(|_| {
+            HranaError::MissingEnv(
+                "LIBSQL_CLIENT_URL variable should point to your sqld database".into(),
+            )
+        })?;
+
+        let token = std::env::var("LIBSQL_CLIENT_TOKEN").unwrap_or_default();
+        Ok(Client::new(url, token))
+    }
+
+    pub(crate) fn new_with_connector(
+        url: impl Into<String>,
+        token: impl Into<String>,
+        connector: ConnectorService,
+    ) -> Self {
         let inner = InnerClient::new(connector);
 
         let token = token.into();
@@ -140,28 +154,6 @@ where
             affected_row_count: Arc::new(AtomicU64::new(0)),
             last_insert_rowid: Arc::new(AtomicI64::new(0)),
         }
-    }
-}
-
-impl Client {
-    /// Creates a database client with JWT authentication.
-    ///
-    /// # Arguments
-    /// * `url` - URL of the database endpoint
-    /// * `token` - auth token
-    pub fn new(url: impl Into<String>, token: impl Into<String>) -> Self {
-        Self::new_with_connector(url, token, HttpConnector::new())
-    }
-
-    pub fn from_env() -> Result<Client> {
-        let url = std::env::var("LIBSQL_CLIENT_URL").map_err(|_| {
-            HranaError::MissingEnv(
-                "LIBSQL_CLIENT_URL variable should point to your sqld database".into(),
-            )
-        })?;
-
-        let token = std::env::var("LIBSQL_CLIENT_TOKEN").unwrap_or_default();
-        Ok(Client::new(url, token))
     }
 }
 


### PR DESCRIPTION
add an `open_remote_with_connector` method to use libsql remote with a custom http acceptor.
