### PR TITLE
crates/core: fix local_sync example

### DIFF
--- a/crates/core/examples/local_sync.rs
+++ b/crates/core/examples/local_sync.rs
@@ -16,7 +16,11 @@ async fn main() {
     let snapshot_path = args.get(1).unwrap();
     let snapshot = TempSnapshot::from_snapshot_file(snapshot_path.as_ref()).unwrap();
 
-    db.sync_frames(Frames::Snapshot(snapshot)).unwrap();
+    tokio::task::spawn_blocking(move || {
+        db.sync_frames(Frames::Snapshot(snapshot)).unwrap();
+    })
+    .await
+    .unwrap();
 
     let mut rows = conn.query("SELECT * FROM sqlite_master", ()).await.unwrap();
     while let Ok(Some(row)) = rows.next() {

--- a/crates/core/src/v1/database.rs
+++ b/crates/core/src/v1/database.rs
@@ -1,5 +1,5 @@
-use crate::OpenFlags;
 use crate::v1::connection::Connection;
+use crate::OpenFlags;
 use crate::{Error::ConnectionFailed, Result};
 #[cfg(feature = "replication")]
 use libsql_replication::Replicator;
@@ -71,21 +71,35 @@ impl Database {
         let mut db = Database::open(&db_path, OpenFlags::default())?;
         let mut replicator =
             Replicator::new(db_path).map_err(|e| ConnectionFailed(format!("{e}")))?;
-        if let Sync::Http {
-            endpoint,
-            auth_token,
-        } = opts.sync
-        {
-            let meta = replicator
-                .init_metadata(&endpoint, &auth_token)
-                .await
-                .map_err(|e| ConnectionFailed(format!("{e}")))?;
-            *replicator.meta.lock() = Some(meta);
-            db.replication_ctx = Some(ReplicationContext {
-                replicator,
+        match opts.sync {
+            Sync::Http {
                 endpoint,
-            });
-        };
+                auth_token,
+            } => {
+                let meta = replicator
+                    .init_metadata(&endpoint, &auth_token)
+                    .await
+                    .map_err(|e| ConnectionFailed(format!("{e}")))?;
+                *replicator.meta.lock() = Some(meta);
+                db.replication_ctx = Some(ReplicationContext {
+                    replicator,
+                    endpoint,
+                });
+            }
+            Sync::Frame => {
+                // NOTICE: the snapshot file used in sync_frames() contains metadata, it will be updated there
+                *replicator.meta.lock() = Some(libsql_replication::replica::meta::WalIndexMeta {
+                    pre_commit_frame_no: 0,
+                    post_commit_frame_no: 0,
+                    generation_id: 0,
+                    database_id: 0,
+                });
+                db.replication_ctx = Some(ReplicationContext {
+                    replicator,
+                    endpoint: "".to_string(),
+                });
+            }
+        }
 
         Ok(db)
     }
@@ -106,6 +120,9 @@ impl Database {
     #[cfg(feature = "replication")]
     pub fn writer(&self) -> Result<Option<libsql_replication::Writer>> {
         if let Some(ctx) = &self.replication_ctx {
+            if ctx.endpoint.is_empty() {
+                return Ok(None);
+            }
             Ok(ctx
                 .replicator
                 .writer()

--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -14,7 +14,7 @@ bincode = "1"
 bytemuck = { version = "1.13.1", features = ["derive"] }
 bytes = { version = "1.4.0", features = ["serde"] }
 thiserror = "1.0.41"
-libsql-sys = { version = "0", path = "../libsql-sys" }
+libsql-sys = { version = "0.2.13", path = "../libsql-sys" }
 uuid = { version = "1.4.0", features = ["v4", "serde"] }
 parking_lot = "0.12.1"
 tempfile = "3.6.0"


### PR DESCRIPTION
The root cause was that in some parts of the code, it's assumed that if replication_ctx exists, then we set up HTTP replication, while sometimes we want only the local sync_frames variant to work. We *really* need to clean up the replication stuff and get rid of the separate libsql_replication crate, but meanwhile - this works.

Fixes #374