### PR TITLE
crates/core: allow initializing replication from non-0 offsets

### DIFF
--- a/crates/core/src/v1/database.rs
+++ b/crates/core/src/v1/database.rs
@@ -87,13 +87,6 @@ impl Database {
                 });
             }
             Sync::Frame => {
-                // NOTICE: the snapshot file used in sync_frames() contains metadata, it will be updated there
-                *replicator.meta.lock() = Some(libsql_replication::replica::meta::WalIndexMeta {
-                    pre_commit_frame_no: 0,
-                    post_commit_frame_no: 0,
-                    generation_id: 0,
-                    database_id: 0,
-                });
                 db.replication_ctx = Some(ReplicationContext {
                     replicator,
                     endpoint: "".to_string(),

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -166,14 +166,10 @@ impl Replicator {
                 )
             }
         } else if snapshot_header.start_frame_no != 0 {
-            tracing::warn!(
-                "Cannot initialize metadata from snapshot header with frame number {} instead of 0",
+            tracing::info!(
+                "Initializing metadata from snapshot header with frame number {}. Make sure your snapshots are applied in order",
                 snapshot_header.start_frame_no
             );
-            anyhow::bail!(
-                "Cannot initialize metadata from snapshot header with frame number {} instead of 0",
-                snapshot_header.start_frame_no
-            )
         }
         // Metadata is loaded straight from the snapshot header and overwrites any previous values
         *meta = Some(replica::meta::WalIndexMeta {


### PR DESCRIPTION
When replication is performed manually by calling sync_frames(), it was disallowed to start applying snapshots from offsets different than 0. This restriction is now lifted, and the caller is trusted to provide proper, continuous frame offsets to sync_frames(). If we decide to bring back validation, we also need to implement persisting replication metadata on-disk, so that we can validate offsets between restarts.

Fixes #374