### PR TITLE
crates/core: fix off-by-one error in validating snapshot frames

### DIFF
--- a/crates/core/examples/local_sync.rs
+++ b/crates/core/examples/local_sync.rs
@@ -6,7 +6,9 @@ use std::sync::{Arc, Mutex};
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let db = Arc::new(Mutex::new(Database::open_with_local_sync("test.db").await.unwrap()));
+    let db = Arc::new(Mutex::new(
+        Database::open_with_local_sync("test.db").await.unwrap(),
+    ));
     let conn = db.lock().unwrap().connect().unwrap();
 
     let args = std::env::args().collect::<Vec<String>>();
@@ -21,15 +23,24 @@ async fn main() {
         for snapshot_path in paths {
             let db = db.clone();
             let snapshot_path = snapshot_path.unwrap().path();
-            println!("Applying snapshot to local database: {}\n", snapshot_path.display());
+            println!(
+                "Applying snapshot to local database: {}\n",
+                snapshot_path.display()
+            );
             let snapshot = TempSnapshot::from_snapshot_file(snapshot_path.as_ref()).unwrap();
             tokio::task::spawn_blocking(move || {
-                db.lock().unwrap().sync_frames(Frames::Snapshot(snapshot)).unwrap();
+                match db.lock().unwrap().sync_frames(Frames::Snapshot(snapshot)) {
+                    Ok(_) => println!("Frames from {} applied", snapshot_path.display()),
+                    Err(e) => println!(
+                        "Syncing frames from {} failed: {e}",
+                        snapshot_path.display()
+                    ),
+                }
             })
             .await
             .unwrap();
         }
-       
+
         let mut rows = conn.query("SELECT * FROM sqlite_master", ()).await.unwrap();
         while let Ok(Some(row)) = rows.next() {
             println!(

--- a/crates/core/src/v1/database.rs
+++ b/crates/core/src/v1/database.rs
@@ -87,13 +87,6 @@ impl Database {
                 });
             }
             Sync::Frame => {
-                // NOTICE: the snapshot file used in sync_frames() contains metadata, it will be updated there
-                *replicator.meta.lock() = Some(libsql_replication::replica::meta::WalIndexMeta {
-                    pre_commit_frame_no: 0,
-                    post_commit_frame_no: 0,
-                    generation_id: 0,
-                    database_id: 0,
-                });
                 db.replication_ctx = Some(ReplicationContext {
                     replicator,
                     endpoint: "".to_string(),

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -153,16 +153,16 @@ impl Replicator {
         let mut meta = self.meta.lock();
 
         if let Some(meta) = &*meta {
-            if meta.post_commit_frame_no != snapshot_header.start_frame_no {
+            if meta.post_commit_frame_no + 1 != snapshot_header.start_frame_no {
                 tracing::warn!(
-                    "Snapshot header frame number {} does not match post-commit frame number {}",
+                    "Snapshot header frame number {} does not match expected post-commit frame number {}",
                     snapshot_header.start_frame_no,
-                    meta.post_commit_frame_no
+                    meta.post_commit_frame_no + 1
                 );
                 anyhow::bail!(
-                    "Snapshot header frame number {} does not match post-commit frame number {}",
+                    "Snapshot header frame number {} does not match expected post-commit frame number {}",
                     snapshot_header.start_frame_no,
-                    meta.post_commit_frame_no
+                    meta.post_commit_frame_no + 1
                 )
             }
         } else if snapshot_header.start_frame_no != 0 {

--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -166,14 +166,10 @@ impl Replicator {
                 )
             }
         } else if snapshot_header.start_frame_no != 0 {
-            tracing::warn!(
-                "Cannot initialize metadata from snapshot header with frame number {} instead of 0",
+            tracing::info!(
+                "Initializing metadata from snapshot header with frame number {}. Make sure your snapshots are applied in order",
                 snapshot_header.start_frame_no
             );
-            anyhow::bail!(
-                "Cannot initialize metadata from snapshot header with frame number {} instead of 0",
-                snapshot_header.start_frame_no
-            )
         }
         // Metadata is loaded straight from the snapshot header and overwrites any previous values
         *meta = Some(replica::meta::WalIndexMeta {


### PR DESCRIPTION
Instead of checking if the incoming frame number is equal to previous
post-commit frame number, we should check if the incoming frame number
is the next frame. E.g. if the last post-commit frame number is 10,
we expect replication to send frame 11 next.

Fixes #374
