### PR TITLE
crates/core: return the number of frames synced

### DIFF
--- a/crates/core/examples/local_sync.rs
+++ b/crates/core/examples/local_sync.rs
@@ -30,7 +30,7 @@ async fn main() {
             let snapshot = TempSnapshot::from_snapshot_file(snapshot_path.as_ref()).unwrap();
             tokio::task::spawn_blocking(move || {
                 match db.lock().unwrap().sync_frames(Frames::Snapshot(snapshot)) {
-                    Ok(_) => println!("Frames from {} applied", snapshot_path.display()),
+                    Ok(n) => println!("{n} frames from {} applied", snapshot_path.display()),
                     Err(e) => println!(
                         "Syncing frames from {} failed: {e}",
                         snapshot_path.display()

--- a/crates/core/src/v1/database.rs
+++ b/crates/core/src/v1/database.rs
@@ -157,7 +157,7 @@ impl Database {
     }
 
     #[cfg(feature = "replication")]
-    pub fn sync_frames(&self, frames: Frames) -> Result<()> {
+    pub fn sync_frames(&self, frames: Frames) -> Result<usize> {
         if let Some(ctx) = self.replication_ctx.as_ref() {
             ctx.replicator
                 .sync(frames)

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -146,7 +146,7 @@ impl Database {
     }
 
     #[cfg(feature = "replication")]
-    pub fn sync_frames(&self, frames: libsql_replication::Frames) -> Result<()> {
+    pub fn sync_frames(&self, frames: libsql_replication::Frames) -> Result<usize> {
         match &self.db_type {
             DbType::Sync { db } => db.sync_frames(frames),
             DbType::Memory => Err(crate::Error::SyncNotSupported("in-memory".into())),


### PR DESCRIPTION
Replicating frames from snapshot files will now return the number of successfully applied frames. If 0 is returned, it's still a success, and simply means that the frames were already applied before.