### PR TITLE
vdbe: only bump rows written on non-ephemeral tables

### DIFF
--- a/crates/libsql-sys/Cargo.toml
+++ b/crates/libsql-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-sys"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 license = "MIT"
 description = "Native bindings to libSQL"

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -5648,7 +5648,7 @@ case OP_Insert: {
 #endif
 
   assert( (pOp->p5 & OPFLAG_LASTROWID)==0 || (pOp->p5 & OPFLAG_NCHANGE)!=0 );
-  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+  if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
   if( pOp->p5 & OPFLAG_NCHANGE ){
     p->nChange++;
     if( pOp->p5 & OPFLAG_LASTROWID ) db->lastRowid = x.nKey;
@@ -5835,7 +5835,7 @@ case OP_Delete: {
 
   /* Invoke the update-hook if required. */
   if( opflags & OPFLAG_NCHANGE ){
-    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+    if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
     p->nChange++;
     if( db->xUpdateCallback && ALWAYS(pTab!=0) && HasRowid(pTab) ){
       db->xUpdateCallback(db->pUpdateArg, SQLITE_DELETE, zDb, pTab->zName,
@@ -6391,7 +6391,7 @@ case OP_IdxInsert: {        /* in2 */
   pIn2 = &aMem[pOp->p2];
   assert( (pIn2->flags & MEM_Blob) || (pOp->p5 & OPFLAG_PREFORMAT) );
   if( pOp->p5 & OPFLAG_NCHANGE ) p->nChange++;
-  p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
+  if (!pC->isEphemeral) p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_WRITTEN - LIBSQL_STMTSTATUS_BASE]++;
   assert( pC->eCurType==CURTYPE_BTREE );
   assert( pC->isTable==0 );
   rc = ExpandBlob(pIn2);

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -135,7 +135,11 @@ mod tests {
         );
         assert_eq!(
             get_read_written(&conn, "INSERT INTO test(id) SELECT id FROM test"),
-            (34, 34)
+            (34, 17)
+        );
+        assert_eq!(
+            get_read_written(&conn, "SELECT * FROM test WHERE id IN (SELECT id FROM test)"),
+            (68, 0)
         );
         assert_eq!(
             get_read_written(&conn, "INSERT INTO test VALUES (1), (2), (3), (4)"),


### PR DESCRIPTION
Ephemeral tables are created ad-hoc, often on selects, so we should not take data inserted in there as "rows written".

Tested with:
```sql
create table t(id);
insert into t values (42), (43), (44);
.stats on
select * from t where id in (select * from t);
```
, that used to return 6 rows read and 3 written, and now properly returns 6 rows read and 0 written.