### PR TITLE
libsql/sys: Impl `Sync` for `Connection`

### DIFF
--- a/crates/core/src/v1/connection.rs
+++ b/crates/core/src/v1/connection.rs
@@ -53,6 +53,7 @@ impl Connection {
                 return Err(Error::ConnectionFailed(db_path));
             }
         }
+
         Ok(Connection {
             raw,
             drop_ref: Arc::new(()),

--- a/crates/libsql-sys/src/connection.rs
+++ b/crates/libsql-sys/src/connection.rs
@@ -9,6 +9,7 @@ pub struct Connection<'a> {
 
 /// The `Connection` struct is `Send` because `sqlite3` is thread-safe.
 unsafe impl<'a> Send for Connection<'a> {}
+unsafe impl<'a> Sync for Connection<'a> {}
 
 impl<'a> Connection<'a> {
     /// returns a dummy, in-memory connection. For testing purposes only


### PR DESCRIPTION
This adds a `Sync` impl for `libsql_sys::Connection` and in addition adds a assert_eq! check to connection initialization to verify we have the correct threadsafe mode set.