### PR TITLE
btree,vdbe: account number of COUNT(*) pages read

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -10301,8 +10301,9 @@ int sqlite3BtreeUpdateMeta(Btree *p, int idx, u32 iMeta){
 ** Otherwise, if an error is encountered (i.e. an IO error or database
 ** corruption) an SQLite error code is returned.
 */
-int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
+int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry, i64 *pnPages){
   i64 nEntry = 0;                      /* Value to return in *pnEntry */
+  i64 nPages = 0;                      /* Number of visited pages */
   int rc;                              /* Return code */
 
   rc = moveToRoot(pCur);
@@ -10325,6 +10326,7 @@ int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
     pPage = pCur->pPage;
     if( pPage->leaf || !pPage->intKey ){
       nEntry += pPage->nCell;
+      nPages++;
     }
 
     /* pPage is a leaf node. This loop navigates the cursor so that it 
@@ -10342,6 +10344,7 @@ int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
         if( pCur->iPage==0 ){
           /* All pages of the b-tree have been visited. Return successfully. */
           *pnEntry = nEntry;
+          *pnPages = nPages;
           return moveToRoot(pCur);
         }
         moveToParent(pCur);

--- a/src/btree.h
+++ b/src/btree.h
@@ -365,7 +365,7 @@ int sqlite3BtreeCursorIsValid(BtCursor*);
 #endif
 int sqlite3BtreeCursorIsValidNN(BtCursor*);
 
-int sqlite3BtreeCount(sqlite3*, BtCursor*, i64*);
+int sqlite3BtreeCount(sqlite3*, BtCursor*, i64*, i64*);
 
 #ifdef SQLITE_TEST
 int sqlite3BtreeCursorInfo(BtCursor*, int*, int);

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3615,8 +3615,9 @@ case OP_Count: {         /* out2 */
     nEntry = sqlite3BtreeRowCountEst(pCrsr);
   }else{
     nEntry = 0;  /* Not needed.  Only used to silence a warning. */
-    rc = sqlite3BtreeCount(db, pCrsr, &nEntry);
-    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE] += nEntry;
+    i64 nPages = 0;
+    rc = sqlite3BtreeCount(db, pCrsr, &nEntry, &nPages);
+    p->aLibsqlCounter[LIBSQL_STMTSTATUS_ROWS_READ - LIBSQL_STMTSTATUS_BASE] += nPages;
     if( rc ) goto abort_due_to_error;
   }
   pOut = out2Prerelease(p, pOp);

--- a/test/rust_suite/src/alter_column.rs
+++ b/test/rust_suite/src/alter_column.rs
@@ -154,8 +154,7 @@ fn test_update_forbidden() {
     assert!(conn
         .execute("ALTER TABLE t3 ALTER COLUMN id TO id UNIQUE", ())
         .is_err());
-    conn.execute("CREATE TABLE t4(id int UNIQUE)", ())
-        .unwrap();
+    conn.execute("CREATE TABLE t4(id int UNIQUE)", ()).unwrap();
     assert!(conn
         .execute("ALTER TABLE t4 ALTER COLUMN id TO id", ())
         .is_err());

--- a/test/rust_suite/src/lib.rs
+++ b/test/rust_suite/src/lib.rs
@@ -101,10 +101,7 @@ mod tests {
             conn.execute("INSERT INTO test values (1)", ()).unwrap();
         }
         assert_eq!(get_read_written(&conn, "SELECT * FROM test"), (16, 0));
-        assert_eq!(
-            get_read_written(&conn, "SELECT count(*) FROM test"),
-            (16, 0)
-        );
+        assert_eq!(get_read_written(&conn, "SELECT count(*) FROM test"), (1, 0));
         assert_eq!(
             get_read_written(&conn, "SELECT min(id), max(id) FROM test where 1 = 1"),
             (16, 0)
@@ -138,13 +135,17 @@ mod tests {
             (34, 17)
         );
         assert_eq!(
-            get_read_written(&conn, "SELECT * FROM test WHERE id IN (SELECT id FROM test)"),
+            get_read_written(
+                &conn,
+                "SELECT * FROM test WHERE id IN (SELECT id FROM test)"
+            ),
             (68, 0)
         );
         assert_eq!(
             get_read_written(&conn, "INSERT INTO test VALUES (1), (2), (3), (4)"),
             (0, 4)
         );
+        assert_eq!(get_read_written(&conn, "SELECT COUNT(*) FROM test"), (1, 0));
     }
 
     #[test]


### PR DESCRIPTION
COUNT (*) is an optimized operation which scans the b-tree structure instead of individual rows to get a count of all rows in the table. Thus, it should be accounted only for b-tree pages inspected when counting "rows read".