### PR TITLE
libsql/core: Add `IntoParams` and `IntoValue`

### DIFF
--- a/crates/core/benches/benchmark.rs
+++ b/crates/core/benches/benchmark.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
-use libsql::{Database, Params};
+use libsql::Database;
 use pprof::criterion::{Output, PProfProfiler};
 use tokio::runtime;
 
@@ -57,7 +57,7 @@ fn bench(c: &mut Criterion) {
         b.to_async(&rt).iter_batched(
             || block_on(conn.prepare("SELECT 1")).unwrap(),
             |mut stmt| async move {
-                let mut rows = stmt.query(&Params::None).await.unwrap();
+                let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
                 stmt.reset();
@@ -77,7 +77,7 @@ fn bench(c: &mut Criterion) {
         b.to_async(&rt).iter_batched(
             || block_on(conn.prepare("SELECT * FROM users LIMIT 1")).unwrap(),
             |mut stmt| async move {
-                let mut rows = stmt.query(&Params::None).await.unwrap();
+                let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
                 stmt.reset();
@@ -90,7 +90,7 @@ fn bench(c: &mut Criterion) {
         b.to_async(&rt).iter_batched(
             || block_on(conn.prepare("SELECT * FROM users LIMIT 100")).unwrap(),
             |mut stmt| async move {
-                let mut rows = stmt.query(&Params::None).await.unwrap();
+                let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
                 stmt.reset();

--- a/crates/core/examples/example_v2.rs
+++ b/crates/core/examples/example_v2.rs
@@ -26,9 +26,7 @@ async fn main() {
         .await
         .unwrap();
 
-    stmt.execute(&libsql::params!["foo@example.com"])
-        .await
-        .unwrap();
+    stmt.execute(["foo@example.com"]).await.unwrap();
 
     db.sync().await.unwrap();
 
@@ -37,10 +35,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let mut rows = stmt
-        .query(&libsql::params!["foo@example.com"])
-        .await
-        .unwrap();
+    let mut rows = stmt.query(["foo@example.com"]).await.unwrap();
 
     let row = rows.next().unwrap().unwrap();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -60,7 +60,7 @@ pub use v1::database::Opts;
 #[cfg(feature = "core")]
 pub use v1::{
     params,
-    params::{params_from_iter, Params, Value, ValueRef},
+    params::{params_from_iter, Value, ValueRef},
     version, version_number, RowsFuture,
 };
 

--- a/crates/core/src/v1/connection.rs
+++ b/crates/core/src/v1/connection.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
 use crate::v1::{
-    Database, Error, Params, Result, Rows, RowsFuture, Statement, Transaction, TransactionBehavior,
+    params::Params, Database, Error, Result, Rows, RowsFuture, Statement, Transaction,
+    TransactionBehavior,
 };
 
 use libsql_sys::ffi;

--- a/crates/core/src/v1/mod.rs
+++ b/crates/core/src/v1/mod.rs
@@ -17,7 +17,6 @@ pub use connection::Connection;
 pub use database::Database;
 #[cfg(feature = "replication")]
 pub use database::Opts;
-pub use params::Params;
 pub use params::{params_from_iter, Value, ValueRef};
 pub use rows::Row;
 pub use rows::Rows;

--- a/crates/core/src/v1/rows.rs
+++ b/crates/core/src/v1/rows.rs
@@ -1,4 +1,4 @@
-use crate::v1::{Connection, Params, Statement, Value};
+use crate::v1::{params::Params, Connection, Statement, Value};
 use crate::{errors, Error, Result};
 use libsql_sys::ValueType;
 

--- a/crates/core/src/v1/statement.rs
+++ b/crates/core/src/v1/statement.rs
@@ -1,5 +1,5 @@
 use crate::v1::rows::{MappedRows, Row};
-use crate::v1::{Connection, Params, Rows, ValueRef};
+use crate::v1::{params::Params, Connection, Rows, ValueRef};
 use crate::{errors, Error, Result};
 
 use std::cell::RefCell;

--- a/crates/core/src/v1/transaction.rs
+++ b/crates/core/src/v1/transaction.rs
@@ -1,5 +1,5 @@
 use crate::v1::Connection;
-use crate::Result;
+use crate::{params::Params, Result};
 use std::ops::Deref;
 
 pub enum TransactionBehavior {
@@ -59,7 +59,7 @@ impl Transaction {
             TransactionBehavior::Immediate => "BEGIN IMMEDIATE",
             TransactionBehavior::Exclusive => "BEGIN EXCLUSIVE",
         };
-        let _ = conn.execute(begin_stmt, ())?;
+        let _ = conn.execute(begin_stmt, Params::None)?;
         Ok(Self {
             conn,
             drop_behavior: DropBehavior::Rollback,
@@ -72,7 +72,7 @@ impl Transaction {
     }
 
     fn do_commit(&self) -> Result<()> {
-        let _ = self.conn.execute("COMMIT", ())?;
+        let _ = self.conn.execute("COMMIT", Params::None)?;
         Ok(())
     }
 
@@ -82,7 +82,7 @@ impl Transaction {
     }
 
     fn do_rollback(&self) -> Result<()> {
-        let _ = self.conn.execute("ROLLBACK", ())?;
+        let _ = self.conn.execute("ROLLBACK", Params::None)?;
         Ok(())
     }
 }

--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -14,7 +14,7 @@ use hyper::StatusCode;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 
 // use crate::client::Config;
-use crate::{Column, Params, Result};
+use crate::{params::Params, Column, Result};
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -282,7 +282,7 @@ impl Client {
 impl Conn for Client {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
         let mut stmt = self.prepare(sql).await?;
-        let rows = stmt.execute(&params).await?;
+        let rows = stmt.execute(params).await?;
 
         Ok(rows as u64)
     }

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -5,7 +5,8 @@ pub mod transaction;
 
 use std::sync::Arc;
 
-use crate::v1::{Params, TransactionBehavior};
+use crate::params::IntoParams;
+use crate::v1::{params::Params, TransactionBehavior};
 use crate::Result;
 pub use hrana::{Client, HranaError};
 
@@ -182,8 +183,8 @@ pub struct Connection {
 
 // TODO(lucio): Convert to using tryinto params
 impl Connection {
-    pub async fn execute(&self, sql: &str, params: impl Into<Params>) -> Result<u64> {
-        self.conn.execute(sql, params.into()).await
+    pub async fn execute(&self, sql: &str, params: impl IntoParams) -> Result<u64> {
+        self.conn.execute(sql, params.into_params()?).await
     }
 
     pub async fn execute_batch(&self, sql: &str) -> Result<()> {
@@ -194,10 +195,10 @@ impl Connection {
         self.conn.prepare(sql).await
     }
 
-    pub async fn query(&self, sql: &str, params: impl Into<Params>) -> Result<Rows> {
+    pub async fn query(&self, sql: &str, params: impl IntoParams) -> Result<Rows> {
         let mut stmt = self.prepare(sql).await?;
 
-        stmt.query(&params.into()).await
+        stmt.query(params).await
     }
 
     /// Begin a new transaction in DEFERRED mode, which is the default.

--- a/crates/core/src/v2/statement.rs
+++ b/crates/core/src/v2/statement.rs
@@ -1,5 +1,6 @@
+use crate::params::IntoParams;
+use crate::v1::params::Params;
 pub use crate::v1::Column;
-use crate::v1::Params;
 use crate::{Error, Result};
 
 use crate::{Row, Rows};
@@ -33,21 +34,21 @@ impl Statement {
         self.inner.finalize();
     }
 
-    pub async fn execute(&mut self, params: &Params) -> Result<usize> {
-        self.inner.execute(params).await
+    pub async fn execute(&mut self, params: impl IntoParams) -> Result<usize> {
+        self.inner.execute(&params.into_params()?).await
     }
 
-    pub async fn query(&mut self, params: &Params) -> Result<Rows> {
-        self.inner.query(params).await
+    pub async fn query(&mut self, params: impl IntoParams) -> Result<Rows> {
+        self.inner.query(&params.into_params()?).await
     }
 
-    pub async fn query_map<F>(&mut self, params: &Params, map: F) -> Result<MappedRows<F>> {
+    pub async fn query_map<F>(&mut self, params: impl IntoParams, map: F) -> Result<MappedRows<F>> {
         let rows = self.query(params).await?;
 
         Ok(MappedRows { rows, map })
     }
 
-    pub async fn query_row(&mut self, params: &Params) -> Result<Row> {
+    pub async fn query_row(&mut self, params: impl IntoParams) -> Result<Row> {
         let mut rows = self.query(params).await?;
 
         let row = rows.next()?.ok_or(Error::QueryReturnedNoRows)?;


### PR DESCRIPTION
This change moves us from using `TryFrom` to convert into `Value` and `Params` to using our own internal trait. The motivation for this change is to allow us to encode the error variant directly into the trait return type rather than needing to be generic over it like how `TryFrom` has the `Error` associated type.