### PR TITLE
crates/core: impl IntoParams for tuples

### DIFF
--- a/crates/core/examples/example.rs
+++ b/crates/core/examples/example.rs
@@ -1,4 +1,4 @@
-use libsql::{params, try_params, Database};
+use libsql::Database;
 
 #[tokio::main]
 async fn main() {
@@ -18,13 +18,13 @@ async fn main() {
     .unwrap();
     conn.execute(
         "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
-        params!("a", 1, 1.0, vec![1, 2, 3]),
+        ("a", 1, 1.0, vec![1, 2, 3]),
     )
     .await
     .unwrap();
     conn.execute(
         "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
-        try_params!("b", 2_u64, 2.0, vec![4, 5, 6]).unwrap(),
+        ("b", 2_u64, 2.0, vec![4, 5, 6]),
     )
     .await
     .unwrap();

--- a/crates/core/src/v1/params.rs
+++ b/crates/core/src/v1/params.rs
@@ -92,6 +92,34 @@ impl<T: IntoValue + Clone, const N: usize> IntoParams for &[T; N] {
     }
 }
 
+// NOTICE: heavily inspired by rusqlite
+macro_rules! tuple_into_params {
+    ($count:literal : $(($field:tt $ftype:ident)),* $(,)?) => {
+        impl<$($ftype,)*> IntoParams for ($($ftype,)*) where $($ftype: IntoValue,)* {
+            fn into_params(self) -> Result<Params> {
+                let params = Params::Positional(vec![$(self.$field.into_value()?),*]);
+                Ok(params)
+            }
+        }
+    }
+}
+
+tuple_into_params!(2: (0 A), (1 B));
+tuple_into_params!(3: (0 A), (1 B), (2 C));
+tuple_into_params!(4: (0 A), (1 B), (2 C), (3 D));
+tuple_into_params!(5: (0 A), (1 B), (2 C), (3 D), (4 E));
+tuple_into_params!(6: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F));
+tuple_into_params!(7: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G));
+tuple_into_params!(8: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H));
+tuple_into_params!(9: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I));
+tuple_into_params!(10: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J));
+tuple_into_params!(11: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K));
+tuple_into_params!(12: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L));
+tuple_into_params!(13: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M));
+tuple_into_params!(14: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M), (13 N));
+tuple_into_params!(15: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M), (13 N), (14 O));
+tuple_into_params!(16: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M), (13 N), (14 O), (15 P));
+
 // TODO: Should we rename this to `ToSql` which makes less sense but
 // matches the error variant we have in `Error`. Or should we change the
 // error variant to match this breaking the few people that currently use


### PR DESCRIPTION
Heavily inspired by rusqlite. Allows passing arbitrary tuples as params, without wrapping it in a params! or try_params! macro.

Follows-up #390