### PR TITLE
libsql/core: Add `IntoParams` docs

### DIFF
--- a/crates/core/src/v1/params.rs
+++ b/crates/core/src/v1/params.rs
@@ -5,7 +5,91 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};
 
-pub trait IntoParams {
+mod sealed {
+    pub trait Sealed {}
+}
+
+use sealed::Sealed;
+
+/// Converts some type into paramters that can be passed
+/// to libsql.
+///
+/// The trait is sealed and not designed to be implemented by hand
+/// but instead provides a few ways to use it.
+///
+/// # Passing parameters to libsql
+///
+/// Many functions in this library let you pass parameters to libsql. Doing this
+/// lets you avoid any risk of SQL injection, and is simpler than escaping
+/// things manually. These functions generally contain some paramter that generically
+/// accepts some implementation this trait.
+///
+/// # Positional parameters
+///
+/// These can be supplied in a few ways:
+///
+/// - For heterogeneous parameter lists of 16 or less items a tuple syntax is supported
+///     by doing `(1, "foo")`.
+/// - For hetergeneous parameter lists of 16 or greater, the [`libsql::params!`] is supported
+///     by doing `libsql::params![1, "foo"]`.
+/// - For homogeneous paramter types (where they are all the same type), const arrays are
+///     supported by doing `[1, 2, 3]`.
+///
+/// # Example (positional)
+///
+/// ```rust,no_run
+/// # use libsql::{Connection, params};
+/// # async fn run(conn: Connection) -> libsql::Result<()> {
+/// let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (?1, ?2)").await?;
+///
+/// // Using a tuple:
+/// stmt.execute((0, "foobar")).await?;
+///
+/// // Using `libsql::params!`:
+/// stmt.execute(params![1i32, "blah"]).await?;
+///
+/// // array literal — non-references
+/// stmt.execute([2i32, 3i32]).await?;
+///
+/// // array literal — references
+/// stmt.execute(["foo", "bar"]).await?;
+///
+/// // Slice literal, references:
+/// stmt.execute([2i32, 3i32]).await?;
+///
+/// #    Ok(())
+/// # }
+/// ```
+///
+/// # Named paramters
+///
+/// - For heterogeneous parameter lists of 16 or less items a tuple syntax is supported
+///     by doing `(("key1", 1), ("key2", "foo"))`.
+/// - For hetergeneous parameter lists of 16 or greater, the [`libsql::params!`] is supported
+///     by doing `libsql::named_params!["key1": 1, "key2": "foo"]`.
+/// - For homogeneous paramter types (where they are all the same type), const arrays are
+///     supported by doing `[("key1", 1), ("key2, 2), ("key3", 3)]`.
+///
+/// # Example (named)
+///
+/// ```rust,no_run
+/// # use libsql::{Connection, named_params};
+/// # async fn run(conn: Connection) -> libsql::Result<()> {
+/// let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (:key1, :key2)").await?;
+///
+/// // Using a tuple:
+/// stmt.execute(((":key1", 0), (":key2", "foobar"))).await?;
+///
+/// // Using `libsql::named_params!`:
+/// stmt.execute(named_params! {":key1": 1i32, ":key2": "blah" }).await?;
+///
+/// // const array:
+/// stmt.execute([(":key1", 2i32), (":key2", 3i32)]).await?;
+///
+/// #   Ok(())
+/// # }
+/// ```
+pub trait IntoParams: Sealed {
     // Hide this because users should not be implementing this
     // themselves. We should consider sealing this trait.
     #[doc(hidden)]
@@ -46,18 +130,21 @@ where
     iter.into_iter().collect::<Vec<_>>()
 }
 
+impl Sealed for () {}
 impl IntoParams for () {
     fn into_params(self) -> Result<Params> {
         Ok(Params::None)
     }
 }
 
+impl Sealed for Params {}
 impl IntoParams for Params {
     fn into_params(self) -> Result<Params> {
         Ok(self)
     }
 }
 
+impl<T: IntoValue> Sealed for Vec<T> {}
 impl<T: IntoValue> IntoParams for Vec<T> {
     fn into_params(self) -> Result<Params> {
         let values = self
@@ -69,6 +156,7 @@ impl<T: IntoValue> IntoParams for Vec<T> {
     }
 }
 
+impl<T: IntoValue> Sealed for Vec<(String, T)> {}
 impl<T: IntoValue> IntoParams for Vec<(String, T)> {
     fn into_params(self) -> Result<Params> {
         let values = self
@@ -80,12 +168,27 @@ impl<T: IntoValue> IntoParams for Vec<(String, T)> {
     }
 }
 
+impl<T: IntoValue, const N: usize> Sealed for [T; N] {}
 impl<T: IntoValue, const N: usize> IntoParams for [T; N] {
     fn into_params(self) -> Result<Params> {
         self.into_iter().collect::<Vec<_>>().into_params()
     }
 }
 
+impl<T: IntoValue, const N: usize> Sealed for [(&str, T); N] {}
+impl<T: IntoValue, const N: usize> IntoParams for [(&str, T); N] {
+    fn into_params(self) -> Result<Params> {
+        self.into_iter()
+            // TODO: Pretty unfortunate that we need to allocate here when we know
+            // the str is likely 'static. Maybe we should convert our param names
+            // to be `Cow<'static, str>`?
+            .map(|(k, v)| Ok((k.to_string(), v.into_value()?)))
+            .collect::<Result<Vec<_>>>()?
+            .into_params()
+    }
+}
+
+impl<T: IntoValue + Clone, const N: usize> Sealed for &[T; N] {}
 impl<T: IntoValue + Clone, const N: usize> IntoParams for &[T; N] {
     fn into_params(self) -> Result<Params> {
         self.iter().cloned().collect::<Vec<_>>().into_params()
@@ -95,6 +198,7 @@ impl<T: IntoValue + Clone, const N: usize> IntoParams for &[T; N] {
 // NOTICE: heavily inspired by rusqlite
 macro_rules! tuple_into_params {
     ($count:literal : $(($field:tt $ftype:ident)),* $(,)?) => {
+        impl<$($ftype,)*> Sealed for ($($ftype,)*) where $($ftype: IntoValue,)* {}
         impl<$($ftype,)*> IntoParams for ($($ftype,)*) where $($ftype: IntoValue,)* {
             fn into_params(self) -> Result<Params> {
                 let params = Params::Positional(vec![$(self.$field.into_value()?),*]);
@@ -103,6 +207,34 @@ macro_rules! tuple_into_params {
         }
     }
 }
+
+macro_rules! named_tuple_into_params {
+    ($count:literal : $(($field:tt $ftype:ident)),* $(,)?) => {
+        impl<$($ftype,)*> Sealed for ($((&str, $ftype),)*) where $($ftype: IntoValue,)* {}
+        impl<$($ftype,)*> IntoParams for ($((&str, $ftype),)*) where $($ftype: IntoValue,)* {
+            fn into_params(self) -> Result<Params> {
+                let params = Params::Named(vec![$((self.$field.0.to_string(), self.$field.1.into_value()?)),*]);
+                Ok(params)
+            }
+        }
+    }
+}
+
+named_tuple_into_params!(2: (0 A), (1 B));
+named_tuple_into_params!(3: (0 A), (1 B), (2 C));
+named_tuple_into_params!(4: (0 A), (1 B), (2 C), (3 D));
+named_tuple_into_params!(5: (0 A), (1 B), (2 C), (3 D), (4 E));
+named_tuple_into_params!(6: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F));
+named_tuple_into_params!(7: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G));
+named_tuple_into_params!(8: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H));
+named_tuple_into_params!(9: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I));
+named_tuple_into_params!(10: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J));
+named_tuple_into_params!(11: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K));
+named_tuple_into_params!(12: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L));
+named_tuple_into_params!(13: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M));
+named_tuple_into_params!(14: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M), (13 N));
+named_tuple_into_params!(15: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M), (13 N), (14 O));
+named_tuple_into_params!(16: (0 A), (1 B), (2 C), (3 D), (4 E), (5 F), (6 G), (7 H), (8 I), (9 J), (10 K), (11 L), (12 M), (13 N), (14 O), (15 P));
 
 tuple_into_params!(2: (0 A), (1 B));
 tuple_into_params!(3: (0 A), (1 B), (2 C));
@@ -136,6 +268,12 @@ where
     fn into_value(self) -> Result<Value> {
         self.try_into()
             .map_err(|e| Error::ToSqlConversionFailure(e.into()))
+    }
+}
+
+impl IntoValue for Result<Value> {
+    fn into_value(self) -> Result<Value> {
+        self
     }
 }
 
@@ -540,43 +678,22 @@ impl TryFrom<libsql_replication::pb::Value> for Value {
 #[macro_export]
 macro_rules! params {
     () => {
-        $crate::Params::None
+       ()
     };
-    ($($value:expr),* $(,)?) => {
-        $crate::params::Params::Positional(vec![$($value.into()),*])
-    };
-}
+    ($($value:expr),* $(,)?) => {{
+        use $crate::params::IntoValue;
+        [$($value.into_value()),*]
 
-#[macro_export]
-macro_rules! try_params {
-    () => {
-        Ok($crate::Params::None)
-    };
-    ($($value:expr),* $(,)?) => {
-        || -> $crate::Result<$crate::params::Params> {
-            Ok($crate::params::Params::Positional(vec![$($value.try_into()?),*]))
-        }()
-    };
+    }};
 }
 
 #[macro_export]
 macro_rules! named_params {
     () => {
-        $crate::Params::None
+        ()
     };
-    ($($param_name:literal: $value:expr),* $(,)?) => {
-        $crate::params::Params::Named(vec![$(($param_name.to_string(), $crate::params::Value::from($value))),*])
-    };
-}
-
-#[macro_export]
-macro_rules! try_named_params {
-    () => {
-        Ok($crate::Params::None)
-    };
-    ($($param_name:literal: $value:expr),* $(,)?) => {
-        || -> $crate::Result<$crate::Params> {
-            Ok($crate::params::Params::Named(vec![$(($param_name.to_string(), $crate::params::Value::try_from($value)?)),*]))
-        }()
-    };
+    ($($param_name:literal: $value:expr),* $(,)?) => {{
+        use $crate::params::IntoValue;
+        [$(($param_name, $value.into_value())),*]
+    }};
 }

--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -172,6 +172,17 @@ async fn prepare_and_query() {
 async fn prepare_and_query_named_params() {
     let conn = setup().await;
 
+    conn.query("SELECT 1", named_params![]).await.unwrap();
+    conn.query("SELECT 1", params![]).await.unwrap();
+    conn.query("SELECT 1", ()).await.unwrap();
+
+    check_insert(
+        &conn,
+        "INSERT INTO users (id, name) VALUES (:a, :b)",
+        ((":a", 2), (":b", "Alice")),
+    )
+    .await;
+
     check_insert(
         &conn,
         "INSERT INTO users (id, name) VALUES (:a, :b)",


### PR DESCRIPTION
This adds doc comments explaining how a user can pass parameters through into libsql's prepared statements. This commit also seals the trait so that no external user can implement this crate allow us to modify impls down the line without breaking users.

In addition, this continues the tuple magic for named parameters as well.

Preview of the docs:
![image](https://github.com/libsql/libsql/assets/5758045/ab02b8b2-c48c-4070-b302-1c8c913569c2)
