### PR TITLE
replication: fix bumping next_offset in http sync

### DIFF
--- a/crates/replication/src/lib.rs
+++ b/crates/replication/src/lib.rs
@@ -249,9 +249,9 @@ impl Replicator {
         }?;
 
         let len = frames.len();
-        self.next_offset.fetch_add(len as u64, Ordering::Relaxed);
         self.frames_sender.send(Frames::Vec(frames)).await?;
         self.injector.step()?;
+        self.next_offset.fetch_add(len as u64, Ordering::Relaxed);
         Ok(len)
     }
 


### PR DESCRIPTION
Previous code bumped next_offset too early, and in case we failed to send and apply frames, it remained bumped. That means we'd never try to apply the frames again and end up with some of them ignored, and that's data corruption. Not a likely scenario, since it happens after the frames were fetched from the network, and it's only their local application, but still, technically risky.

Refs #350