### PR TITLE
crates/core: track transactions when delegating writes

### DIFF
--- a/crates/core/src/v1/connection.rs
+++ b/crates/core/src/v1/connection.rs
@@ -284,6 +284,13 @@ impl Connection {
     }
 
     pub fn is_autocommit(&self) -> bool {
+        #[cfg(feature = "replication")]
+        {
+            if let Some(writer) = &self.writer {
+                // is_autocommit <=> not in transaction
+                return !writer.in_tx.load(std::sync::atomic::Ordering::Relaxed);
+            }
+        }
         unsafe { ffi::sqlite3_get_autocommit(self.raw) != 0 }
     }
 


### PR DESCRIPTION
External libraries (e.g. javascript stuff) depend on is_autocommit returning if we're in transaction. With write delegation the code no longer worked, because we didn't track that information. Now we do, in a slightly hacky way, by detecting when somebody creates a transaction with BEGIN, or finalizes it with COMMIT/ROLLBACK.

This is **not sufficient** to make https://github.com/aqrln/libsql-tx-repro work -- we also need to apply some hacks/creative ways around preparing statements. This code: https://github.com/libsql/libsql-client-ts/blob/7071e0f87d7f650023efbb918b5add3dd99189e8/src/sqlite3.ts#L235-L241 relies on being able to prepare statements locally, while in write delegation we generally don't do that. It's solvable, but I haven't gotten around it yet