### PR TITLE
libsql/replication: Write delegation v2 with txn support

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -44,6 +44,9 @@ tower-http = { version = "0.4.4", features = ["trace", "util"], optional = true 
 prost = { version = "0.12", optional = true }
 http = { version = "0.2", optional = true }
 
+sqlite3-parser = { version = "0.11" }
+fallible-iterator = { version = "0.3" }
+
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/crates/core/examples/transaction.rs
+++ b/crates/core/examples/transaction.rs
@@ -1,0 +1,32 @@
+use libsql::Database;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let db_file = tempfile::NamedTempFile::new().unwrap();
+    println!("Database {}", db_file.path().display());
+
+    let auth_token = std::env::var("TURSO_AUTH_TOKEN").unwrap_or_else(|_| {
+        println!("Using empty token since TURSO_AUTH_TOKEN was not set");
+        "".to_string()
+    });
+
+    let db = Database::open_with_remote_sync(
+        db_file.path().to_str().unwrap(),
+        "http://localhost:8080",
+        auth_token,
+    )
+    .await
+    .unwrap();
+    let conn = db.connect().unwrap();
+
+    let tx = conn
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+
+    tx.execute("SELECT 1", ()).await.unwrap();
+
+    tx.commit().await.unwrap();
+}

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -31,6 +31,12 @@ pub enum Error {
     InvalidColumnIndex,
     #[error("invalid column type")]
     InvalidColumnType,
+    #[error("syntax error around L{0}:{1}: `{2}`")]
+    Sqlite3SyntaxError(u64, usize, String),
+    #[error("unsupported statement")]
+    Sqlite3UnsupportedStatement,
+    #[error("sqlite3 parser error: `{0}`")]
+    Sqlite3ParserError(crate::BoxError),
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/crates/core/src/replication/connection.rs
+++ b/crates/core/src/replication/connection.rs
@@ -1,0 +1,412 @@
+// TODO(lucio): Move this to `remote/mod.rs`
+
+use std::sync::Arc;
+
+use libsql_sys::ValueType;
+use parking_lot::Mutex;
+
+use crate::replication::pb::{execute_results::State as RemoteState, query_result::RowResult};
+use crate::rows::{RowInner, RowsInner};
+use crate::statement::Stmt;
+use crate::transaction::Tx;
+use crate::{
+    params::Params, replication::Writer, Error, Result, Statement, Transaction, TransactionBehavior,
+};
+use crate::{v2, Column, Row, Rows, Value};
+
+use crate::v2::{Conn, LibsqlConnection};
+
+use super::parser;
+use super::pb::{ExecuteResults, ResultRows};
+
+#[derive(Clone)]
+pub struct RemoteConnection {
+    pub(self) local: LibsqlConnection,
+    writer: Writer,
+    state: Arc<Mutex<State>>,
+}
+
+#[derive(Default, Debug)]
+struct State {
+    remote_state: RemoteState,
+    changes: u64,
+    last_insert_rowid: i64,
+}
+
+impl RemoteConnection {
+    pub(crate) fn new(local: LibsqlConnection, writer: Writer) -> Self {
+        let state = Arc::new(Mutex::new(State::default()));
+        Self {
+            local,
+            writer,
+            state,
+        }
+    }
+
+    fn is_state_init(&self) -> bool {
+        matches!(self.state.lock().remote_state, RemoteState::Init)
+    }
+
+    pub(self) async fn execute_program(
+        &self,
+        stmts: Vec<parser::Statement>,
+        params: Params,
+    ) -> Result<ExecuteResults> {
+        use crate::replication::pb;
+        let params: pb::query::Params = params.into();
+
+        let res = self
+            .writer
+            .execute_program(stmts, params)
+            .await
+            .map_err(|e| Error::WriteDelegation(e.into()))?;
+
+        {
+            let mut state = self.state.lock();
+            state.remote_state = RemoteState::try_from(res.state).expect("Invalid state enum");
+        }
+
+        Ok(res)
+    }
+
+    pub(self) fn update_state(&self, row: &ResultRows) {
+        let mut state = self.state.lock();
+
+        if let Some(rowid) = &row.last_insert_rowid {
+            state.last_insert_rowid = *rowid;
+        }
+
+        state.changes = row.affected_row_count;
+    }
+
+    pub(self) fn should_execute_local(&self, stmts: &[parser::Statement]) -> bool {
+        let is_read_only = stmts.iter().all(|s| s.is_read_only());
+
+        self.is_state_init() && is_read_only
+    }
+
+    // Will execute a rollback if the local conn is in TXN state
+    // and will return false if no rollback happened and the
+    // execute was valid.
+    pub(self) async fn maybe_execute_rollback(&self) -> Result<bool> {
+        if !self.local.is_autocommit() {
+            self.local.execute("ROLLBACK", Params::None).await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Conn for RemoteConnection {
+    async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
+        let stmts = parser::Statement::parse(sql).collect::<Result<Vec<_>>>()?;
+
+        if self.should_execute_local(&stmts[..]) {
+            // TODO(lucio): See if we can arc the params here to cheaply clone
+            // or convert the inner bytes type to an Arc<[u8]>
+            let changes = self.local.execute(sql, params.clone()).await?;
+
+            if !self.maybe_execute_rollback().await? {
+                return Ok(changes);
+            }
+        }
+
+        let res = self.execute_program(stmts, params).await?;
+
+        let result = res
+            .results
+            .iter()
+            .next()
+            .expect("Expected atleast one result");
+
+        let affected_row_count = match &result.row_result {
+            Some(RowResult::Row(row)) => {
+                self.update_state(&row);
+                row.affected_row_count
+            }
+            Some(RowResult::Error(e)) => todo!("error: {:?}", e),
+            None => panic!("unexpected empty result row"),
+        };
+
+        Ok(affected_row_count)
+    }
+
+    async fn execute_batch(&self, sql: &str) -> Result<()> {
+        let stmts = parser::Statement::parse(sql).collect::<Result<Vec<_>>>()?;
+
+        if self.should_execute_local(&stmts[..]) {
+            self.local.execute_batch(sql).await?;
+
+            if !self.maybe_execute_rollback().await? {
+                return Ok(());
+            }
+        }
+
+        let res = self.execute_program(stmts, Params::None).await?;
+
+        for result in res.results {
+            match &result.row_result {
+                Some(RowResult::Row(row)) => self.update_state(&row),
+                Some(RowResult::Error(e)) => todo!("error: {:?}", e),
+                None => panic!("unexpected empty result row"),
+            };
+        }
+
+        Ok(())
+    }
+
+    async fn prepare(&self, sql: &str) -> Result<Statement> {
+        let stmt = RemoteStatement::prepare(self.clone(), sql).await?;
+
+        Ok(v2::Statement {
+            inner: Box::new(stmt),
+        })
+    }
+
+    async fn transaction(&self, tx_behavior: TransactionBehavior) -> Result<Transaction> {
+        let tx = RemoteTx::begin(self.clone(), tx_behavior).await?;
+
+        Ok(v2::Transaction {
+            inner: Box::new(tx),
+            conn: v2::Connection {
+                conn: Arc::new(self.clone()),
+            },
+        })
+    }
+
+    fn is_autocommit(&self) -> bool {
+        self.is_state_init()
+    }
+
+    fn changes(&self) -> u64 {
+        self.state.lock().changes
+    }
+
+    fn last_insert_rowid(&self) -> i64 {
+        self.state.lock().last_insert_rowid
+    }
+
+    fn close(&self) {
+        self.local.close()
+    }
+}
+
+pub struct RemoteStatement {
+    conn: RemoteConnection,
+    stmts: Vec<parser::Statement>,
+    /// Set to `Some` when we should execute this locally
+    local_statement: Option<v2::Statement>,
+}
+
+impl RemoteStatement {
+    pub async fn prepare(conn: RemoteConnection, sql: &str) -> Result<Self> {
+        let stmts = parser::Statement::parse(sql).collect::<Result<Vec<_>>>()?;
+
+        let local_statement = if conn.should_execute_local(&stmts[..]) {
+            let stmt = conn.local.prepare(sql).await?;
+            Some(stmt)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            conn,
+            stmts,
+            local_statement,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Stmt for RemoteStatement {
+    fn finalize(&mut self) {}
+
+    async fn execute(&mut self, params: &Params) -> Result<usize> {
+        if let Some(stmt) = &mut self.local_statement {
+            return stmt.execute(params.clone()).await;
+        }
+
+        let res = self
+            .conn
+            .execute_program(self.stmts.clone(), params.clone())
+            .await?;
+
+        let result = res
+            .results
+            .iter()
+            .next()
+            .expect("Expected atleast one result");
+
+        let affected_row_count = match &result.row_result {
+            Some(RowResult::Row(row)) => {
+                self.conn.update_state(&row);
+                row.affected_row_count
+            }
+            Some(RowResult::Error(e)) => todo!("error: {:?}", e),
+            None => panic!("unexpected empty result row"),
+        };
+
+        Ok(affected_row_count as usize)
+    }
+
+    async fn query(&mut self, params: &Params) -> Result<Rows> {
+        if let Some(stmt) = &mut self.local_statement {
+            return stmt.query(params.clone()).await;
+        }
+
+        let res = self
+            .conn
+            .execute_program(self.stmts.clone(), params.clone())
+            .await?;
+
+        let result = res
+            .results
+            .into_iter()
+            .next()
+            .expect("Expected atleast one result");
+
+        let rows = match result.row_result {
+            Some(RowResult::Row(row)) => {
+                self.conn.update_state(&row);
+                row
+            }
+            Some(RowResult::Error(e)) => todo!("error: {:?}", e),
+            None => panic!("unexpected empty result row"),
+        };
+
+        Ok(Rows {
+            inner: Box::new(RemoteRows(rows, 0)),
+        })
+    }
+
+    fn reset(&mut self) {}
+
+    fn parameter_count(&self) -> usize {
+        todo!()
+    }
+
+    fn parameter_name(&self, _idx: i32) -> Option<&str> {
+        todo!()
+    }
+
+    fn columns(&self) -> Vec<Column> {
+        todo!()
+    }
+}
+
+pub(crate) struct RemoteRows(
+    pub(crate) crate::replication::pb::ResultRows,
+    pub(crate) usize,
+);
+
+impl RowsInner for RemoteRows {
+    fn next(&mut self) -> Result<Option<Row>> {
+        // TODO(lucio): Switch to a vecdeque and reduce allocations
+        let cursor = self.1;
+        self.1 += 1;
+        let row = self.0.rows.get(cursor);
+
+        if row.is_none() {
+            return Ok(None);
+        }
+
+        let row = row.unwrap();
+
+        let values = row
+            .values
+            .iter()
+            .map(|v| bincode::deserialize(&v.data[..]).map_err(Error::from))
+            .collect::<Result<Vec<_>>>()?;
+
+        let row = RemoteRow(values, self.0.column_descriptions.clone());
+        Ok(Some(row).map(Box::new).map(|inner| Row { inner }))
+    }
+
+    fn column_count(&self) -> i32 {
+        self.0.column_descriptions.len() as i32
+    }
+
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.0
+            .column_descriptions
+            .get(idx as usize)
+            .map(|s| s.name.as_str())
+    }
+
+    fn column_type(&self, idx: i32) -> Result<ValueType> {
+        let col = self.0.column_descriptions.get(idx as usize).unwrap();
+        col.decltype
+            .as_ref()
+            .map(|s| s.as_str())
+            .and_then(ValueType::from_str)
+            .ok_or(Error::InvalidColumnType)
+    }
+}
+
+struct RemoteRow(Vec<Value>, Vec<crate::replication::pb::Column>);
+
+impl RowInner for RemoteRow {
+    fn column_value(&self, idx: i32) -> Result<Value> {
+        self.0
+            .get(idx as usize)
+            .cloned()
+            .ok_or(Error::InvalidColumnIndex)
+    }
+
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.1.get(idx as usize).map(|s| s.name.as_str())
+    }
+
+    fn column_str(&self, idx: i32) -> Result<&str> {
+        let value = self.0.get(idx as usize).ok_or(Error::InvalidColumnIndex)?;
+
+        match &value {
+            Value::Text(s) => Ok(s.as_str()),
+            _ => Err(Error::InvalidColumnType),
+        }
+    }
+
+    fn column_type(&self, idx: i32) -> Result<ValueType> {
+        let col = self.1.get(idx as usize).unwrap();
+        col.decltype
+            .as_ref()
+            .map(|s| s.as_str())
+            .and_then(ValueType::from_str)
+            .ok_or(Error::InvalidColumnType)
+    }
+}
+
+pub(super) struct RemoteTx(pub(super) Option<RemoteConnection>);
+
+impl RemoteTx {
+    pub(crate) async fn begin(
+        conn: RemoteConnection,
+        tx_behavior: TransactionBehavior,
+    ) -> Result<Self> {
+        let begin_stmt = match tx_behavior {
+            TransactionBehavior::Deferred => "BEGIN DEFERRED",
+            TransactionBehavior::Immediate => "BEGIN IMMEDIATE",
+            TransactionBehavior::Exclusive => "BEGIN EXCLUSIVE",
+        };
+
+        let _ = conn.execute(begin_stmt, Params::None).await?;
+        Ok(Self(Some(conn)))
+    }
+}
+
+#[async_trait::async_trait]
+impl Tx for RemoteTx {
+    async fn commit(&mut self) -> Result<()> {
+        let conn = self.0.take().expect("Tx already dropped");
+        conn.execute("COMMIT", Params::None).await?;
+        Ok(())
+    }
+
+    async fn rollback(&mut self) -> Result<()> {
+        let conn = self.0.take().expect("Tx already dropped");
+        conn.execute("ROLLBACK", Params::None).await?;
+        Ok(())
+    }
+}

--- a/crates/core/src/replication/mod.rs
+++ b/crates/core/src/replication/mod.rs
@@ -1,8 +1,11 @@
 mod client;
+mod connection;
 pub mod frame;
+mod parser;
 pub mod replica;
 
 pub use client::pb;
+pub use connection::RemoteConnection;
 
 pub const WAL_PAGE_SIZE: i32 = 4096;
 // pub const WAL_MAGIC: u64 = u64::from_le_bytes(*b"SQLDWAL\0");
@@ -21,6 +24,10 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
 use client::Client;
+
+use self::parser::Statement;
+use self::pb::query::Params;
+use self::pb::{ExecuteResults, Positional, Program, ProgramReq};
 
 pub struct Replicator {
     pub(crate) frames_sender: Sender<Frames>,
@@ -274,38 +281,35 @@ impl Replicator {
 }
 
 impl Writer {
-    pub async fn execute(
+    pub async fn execute_program(
         &self,
-        sql: &str,
-        params: impl Into<pb::query::Params> + Send,
-    ) -> anyhow::Result<u64> {
-        tracing::trace!("executing remote sql statement: {sql}");
-        let (write_frame_no, rows_affected) = self.client.execute(sql, params.into()).await?;
+        steps: Vec<Statement>,
+        params: impl Into<pb::query::Params>,
+    ) -> anyhow::Result<ExecuteResults> {
+        let mut params = Some(params.into());
 
-        tracing::trace!(
-            "statement executed on remote waiting for frame_no: {}",
-            write_frame_no
-        );
-        Ok(rows_affected)
-    }
+        let steps = steps
+            .into_iter()
+            .map(|stmt| pb::Step {
+                query: Some(pb::Query {
+                    stmt: stmt.stmt,
+                    // TODO(lucio): Pass params
+                    params: Some(
+                        params
+                            .take()
+                            .unwrap_or(Params::Positional(Positional::default())),
+                    ),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .collect();
 
-    pub async fn query(
-        &self,
-        sql: &str,
-        params: impl Into<pb::query::Params> + Send,
-    ) -> anyhow::Result<pb::ResultRows> {
-        let (write_frame_no, rows) = self.client.query(sql, params.into()).await?;
-
-        tracing::trace!(
-            "statement executed on remote waiting for frame_no: {}",
-            write_frame_no
-        );
-
-        Ok(rows)
-    }
-
-    pub async fn execute_batch(&self, sql: Vec<String>) -> anyhow::Result<()> {
-        self.client.execute_batch(sql).await?;
-        Ok(())
+        self.client
+            .execute_program(ProgramReq {
+                client_id: self.client.client_id(),
+                pgm: Some(Program { steps }),
+            })
+            .await
     }
 }

--- a/crates/core/src/replication/parser.rs
+++ b/crates/core/src/replication/parser.rs
@@ -1,0 +1,237 @@
+use crate::{Error, Result};
+use fallible_iterator::FallibleIterator;
+use sqlite3_parser::ast::{Cmd, PragmaBody, QualifiedName, Stmt};
+use sqlite3_parser::lexer::sql::{Parser, ParserError};
+
+/// A group of statements to be executed together.
+#[derive(Debug, Clone)]
+pub struct Statement {
+    pub stmt: String,
+    pub kind: StmtKind,
+}
+
+impl Default for Statement {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Classify statement in categories of interest.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum StmtKind {
+    /// The begining of a transaction
+    TxnBegin,
+    /// The end of a transaction
+    TxnEnd,
+    Read,
+    Write,
+    Other,
+}
+
+fn is_temp(name: &QualifiedName) -> bool {
+    name.db_name.as_ref().map(|n| n.0.as_str()) == Some("TEMP")
+}
+
+fn is_reserved_tbl(name: &QualifiedName) -> bool {
+    let n = name.name.0.to_lowercase();
+    n == "_litestream_seq" || n == "_litestream_lock" || n == "libsql_wasm_func_table"
+}
+
+fn write_if_not_reserved(name: &QualifiedName) -> Option<StmtKind> {
+    (!is_reserved_tbl(name)).then_some(StmtKind::Write)
+}
+
+impl StmtKind {
+    fn kind(cmd: &Cmd) -> Option<Self> {
+        match cmd {
+            Cmd::Explain(Stmt::Pragma(name, body)) => Self::pragma_kind(name, body.as_ref()),
+            Cmd::Explain(_) => Some(Self::Other),
+            Cmd::ExplainQueryPlan(_) => Some(Self::Other),
+            Cmd::Stmt(Stmt::Begin { .. }) => Some(Self::TxnBegin),
+            Cmd::Stmt(Stmt::Commit { .. } | Stmt::Rollback { .. }) => Some(Self::TxnEnd),
+            Cmd::Stmt(
+                Stmt::CreateVirtualTable { tbl_name, .. }
+                | Stmt::CreateTable {
+                    tbl_name,
+                    temporary: false,
+                    ..
+                },
+            ) if !is_temp(tbl_name) => Some(Self::Write),
+            Cmd::Stmt(
+                Stmt::Insert {
+                    with: _,
+                    or_conflict: _,
+                    tbl_name,
+                    ..
+                }
+                | Stmt::Update {
+                    with: _,
+                    or_conflict: _,
+                    tbl_name,
+                    ..
+                },
+            ) => write_if_not_reserved(tbl_name),
+
+            Cmd::Stmt(Stmt::Delete {
+                with: _, tbl_name, ..
+            }) => write_if_not_reserved(tbl_name),
+            Cmd::Stmt(Stmt::DropTable {
+                if_exists: _,
+                tbl_name,
+            }) => write_if_not_reserved(tbl_name),
+            Cmd::Stmt(Stmt::AlterTable(tbl_name, _)) => write_if_not_reserved(tbl_name),
+            Cmd::Stmt(
+                Stmt::DropIndex { .. }
+                | Stmt::DropTrigger { .. }
+                | Stmt::CreateTrigger {
+                    temporary: false, ..
+                }
+                | Stmt::CreateIndex { .. },
+            ) => Some(Self::Write),
+            Cmd::Stmt(Stmt::Select { .. }) => Some(Self::Read),
+            Cmd::Stmt(Stmt::Pragma(name, body)) => Self::pragma_kind(name, body.as_ref()),
+            // Creating regular views is OK, temporary views are bound to a connection
+            // and thus disallowed in sqld.
+            Cmd::Stmt(Stmt::CreateView {
+                temporary: false, ..
+            }) => Some(Self::Write),
+            Cmd::Stmt(Stmt::DropView { .. }) => Some(Self::Write),
+            _ => None,
+        }
+    }
+
+    fn pragma_kind(name: &QualifiedName, body: Option<&PragmaBody>) -> Option<Self> {
+        let name = name.name.0.as_str();
+        match name {
+            // always ok to be served by primary or replicas - pure readonly pragmas
+            "table_list" | "index_list" | "table_info" | "table_xinfo" | "index_xinfo"
+            | "pragma_list" | "compile_options" | "database_list" | "function_list"
+            | "module_list" => Some(Self::Read),
+            // special case for `encoding` - it's effectively readonly for connections
+            // that already created a database, which is always the case for sqld
+            "encoding" => Some(Self::Read),
+            // always ok to be served by primary
+            "foreign_keys" | "foreign_key_list" | "foreign_key_check" | "collation_list"
+            | "data_version" | "freelist_count" | "integrity_check" | "legacy_file_format"
+            | "page_count" | "quick_check" | "stats" | "user_version" => Some(Self::Write),
+            // ok to be served by primary without args
+            "analysis_limit"
+            | "application_id"
+            | "auto_vacuum"
+            | "automatic_index"
+            | "busy_timeout"
+            | "cache_size"
+            | "cache_spill"
+            | "cell_size_check"
+            | "checkpoint_fullfsync"
+            | "defer_foreign_keys"
+            | "fullfsync"
+            | "hard_heap_limit"
+            | "journal_mode"
+            | "journal_size_limit"
+            | "legacy_alter_table"
+            | "locking_mode"
+            | "max_page_count"
+            | "mmap_size"
+            | "page_size"
+            | "query_only"
+            | "read_uncommitted"
+            | "recursive_triggers"
+            | "reverse_unordered_selects"
+            | "schema_version"
+            | "secure_delete"
+            | "soft_heap_limit"
+            | "synchronous"
+            | "temp_store"
+            | "threads"
+            | "trusted_schema"
+            | "wal_autocheckpoint" => {
+                match body {
+                    Some(_) => None,
+                    None => Some(Self::Write),
+                }
+            }
+            // changes the state of the connection, and can't be allowed rn:
+            "case_sensitive_like" | "ignore_check_constraints" | "incremental_vacuum"
+                // TODO: check if optimize can be safely performed
+                | "optimize"
+                | "parser_trace"
+                | "shrink_memory"
+                | "wal_checkpoint" => None,
+            _ => {
+                tracing::debug!("Unknown pragma: {name}");
+                None
+            },
+        }
+    }
+}
+
+impl Statement {
+    pub fn empty() -> Self {
+        Self {
+            stmt: String::new(),
+            // empty statement is arbitrarely made of the read kind so it is not send to a writer
+            kind: StmtKind::Read,
+        }
+    }
+
+    pub fn parse(s: &str) -> impl Iterator<Item = Result<Self>> + '_ {
+        fn parse_inner(
+            original: &str,
+            stmt_count: u64,
+            has_more_stmts: bool,
+            c: Cmd,
+        ) -> Result<Statement> {
+            let kind = StmtKind::kind(&c).ok_or_else(|| Error::Sqlite3UnsupportedStatement)?;
+
+            if stmt_count == 1 && !has_more_stmts {
+                // XXX: Temporary workaround for integration with Atlas
+                if let Cmd::Stmt(Stmt::CreateTable { .. }) = &c {
+                    return Ok(Statement {
+                        stmt: original.to_string(),
+                        kind,
+                    });
+                }
+            }
+
+            Ok(Statement {
+                stmt: c.to_string(),
+                kind,
+            })
+        }
+        // The parser needs to be boxed because it's large, and you don't want it on the stack.
+        // There's upstream work to make it smaller, but in the meantime the parser should remain
+        // on the heap:
+        // - https://github.com/gwenn/lemon-rs/issues/8
+        // - https://github.com/gwenn/lemon-rs/pull/19
+        let mut parser = Box::new(Parser::new(s.as_bytes()).peekable());
+        let mut stmt_count = 0;
+        std::iter::from_fn(move || {
+            stmt_count += 1;
+            match parser.next() {
+                Ok(Some(cmd)) => Some(parse_inner(
+                    s,
+                    stmt_count,
+                    parser.peek().map_or(true, |o| o.is_some()),
+                    cmd,
+                )),
+                Ok(None) => None,
+                Err(sqlite3_parser::lexer::sql::Error::ParserError(
+                    ParserError::SyntaxError {
+                        token_type: _,
+                        found: Some(found),
+                    },
+                    Some((line, col)),
+                )) => Some(Err(crate::Error::Sqlite3SyntaxError(line, col, found))),
+                Err(e) => Some(Err(Error::Sqlite3ParserError(e.into()))),
+            }
+        })
+    }
+
+    pub fn is_read_only(&self) -> bool {
+        matches!(
+            self.kind,
+            StmtKind::Read | StmtKind::TxnEnd | StmtKind::TxnBegin
+        )
+    }
+}

--- a/crates/core/src/v1/connection.rs
+++ b/crates/core/src/v1/connection.rs
@@ -163,63 +163,6 @@ impl Connection {
         Ok(())
     }
 
-    pub(crate) async fn execute_batch2<S>(&self, sql: S) -> Result<()>
-    where
-        S: Into<String>,
-    {
-        let sql = sql.into();
-        let mut sql = sql.as_str();
-
-        #[cfg(feature = "replication")]
-        {
-            if self.writer.is_some() {
-                let mut steps = Vec::new();
-                while !sql.is_empty() {
-                    let stmt = self.prepare(sql)?;
-                    let tail = stmt.tail();
-
-                    if tail == 0 || tail >= sql.len() {
-                        if !stmt.inner.raw_stmt.is_null() {
-                            steps.push(sql[..].to_string());
-                        }
-                        break;
-                    }
-
-                    let step = &sql[..tail];
-                    steps.push(step.to_string());
-
-                    sql = &sql[tail..];
-                }
-
-                let writer = self.writer.as_ref().unwrap();
-
-                writer
-                    .execute_batch(steps)
-                    .await
-                    .map_err(|e| Error::WriteDelegation(e.into()))?;
-                return Ok(());
-            }
-        }
-
-        while !sql.is_empty() {
-            let stmt = self.prepare(sql)?;
-
-            if !stmt.inner.raw_stmt.is_null() {
-                stmt.step()?;
-            }
-
-            let tail = stmt.tail();
-
-            if tail == 0 || tail >= sql.len() {
-                break;
-            }
-
-            sql = &sql[tail..];
-        }
-
-        Ok(())
-    }
-
     /// Execute the SQL statement synchronously.
     ///
     /// If you execute a SQL query statement (e.g. `SELECT` statement) that
@@ -261,21 +204,6 @@ impl Connection {
         self.transaction_with_behavior(TransactionBehavior::Deferred)
     }
 
-    pub(crate) async fn execute2<S, P>(&self, sql: S, params: P) -> Result<u64>
-    where
-        S: Into<String>,
-        P: TryInto<Params>,
-        P::Error: Into<crate::BoxError>,
-    {
-        let sql = sql.into();
-        let stmt = Statement::prepare(self.clone(), self.raw, &sql)?;
-
-        let params = params
-            .try_into()
-            .map_err(|e| Error::ToSqlConversionFailure(e.into()))?;
-        stmt.execute2(params).await
-    }
-
     /// Begin a new transaction in the given mode.
     pub fn transaction_with_behavior(
         &self,
@@ -294,5 +222,10 @@ impl Connection {
 
     pub fn last_insert_rowid(&self) -> i64 {
         unsafe { ffi::sqlite3_last_insert_rowid(self.raw) }
+    }
+
+    #[cfg(feature = "replication")]
+    pub fn writer(&self) -> Option<&crate::replication::Writer> {
+        self.writer.as_ref()
     }
 }

--- a/crates/core/src/v2/rows.rs
+++ b/crates/core/src/v2/rows.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result, Value};
+use crate::{Result, Value};
 
 use libsql_sys::ValueType;
 
@@ -60,7 +60,7 @@ impl RowsInner for LibsqlRows {
 }
 
 pub struct Row {
-    pub(super) inner: Box<dyn RowInner + Send + Sync>,
+    pub(crate) inner: Box<dyn RowInner + Send + Sync>,
 }
 
 impl Row {
@@ -171,7 +171,7 @@ impl FromValue for String {
     }
 }
 
-pub(super) trait RowInner {
+pub(crate) trait RowInner {
     fn column_value(&self, idx: i32) -> Result<Value>;
     fn column_str(&self, idx: i32) -> Result<&str>;
     fn column_name(&self, idx: i32) -> Option<&str>;
@@ -195,87 +195,5 @@ impl RowInner for LibsqlRow {
 
     fn column_type(&self, idx: i32) -> Result<ValueType> {
         self.0.column_type(idx)
-    }
-}
-
-pub(crate) struct LibsqlRemoteRows(
-    pub(crate) crate::replication::pb::ResultRows,
-    pub(crate) usize,
-);
-
-impl RowsInner for LibsqlRemoteRows {
-    fn next(&mut self) -> Result<Option<Row>> {
-        // TODO(lucio): Switch to a vecdeque and reduce allocations
-        let cursor = self.1;
-        self.1 += 1;
-        let row = self.0.rows.get(cursor);
-
-        if row.is_none() {
-            return Ok(None);
-        }
-
-        let row = row.unwrap();
-
-        let values = row
-            .values
-            .iter()
-            .map(|v| bincode::deserialize(&v.data[..]).map_err(Error::from))
-            .collect::<Result<Vec<_>>>()?;
-
-        let row = LibsqlRemoteRow(values, self.0.column_descriptions.clone());
-        Ok(Some(row).map(Box::new).map(|inner| Row { inner }))
-    }
-
-    fn column_count(&self) -> i32 {
-        self.0.column_descriptions.len() as i32
-    }
-
-    fn column_name(&self, idx: i32) -> Option<&str> {
-        self.0
-            .column_descriptions
-            .get(idx as usize)
-            .map(|s| s.name.as_str())
-    }
-
-    fn column_type(&self, idx: i32) -> Result<ValueType> {
-        let col = self.0.column_descriptions.get(idx as usize).unwrap();
-        col.decltype
-            .as_ref()
-            .map(|s| s.as_str())
-            .and_then(ValueType::from_str)
-            .ok_or(Error::InvalidColumnType)
-    }
-}
-
-struct LibsqlRemoteRow(Vec<Value>, Vec<crate::replication::pb::Column>);
-
-impl RowInner for LibsqlRemoteRow {
-    fn column_value(&self, idx: i32) -> Result<Value> {
-        self.0
-            .get(idx as usize)
-            .cloned()
-            .ok_or(Error::InvalidColumnIndex)
-    }
-
-    fn column_name(&self, idx: i32) -> Option<&str> {
-        self.1.get(idx as usize).map(|s| s.name.as_str())
-    }
-
-    fn column_str(&self, idx: i32) -> Result<&str> {
-        let value = self.0.get(idx as usize).ok_or(Error::InvalidColumnIndex)?;
-
-        match &value {
-            Value::Text(s) => Ok(s.as_str()),
-            _ => Err(Error::InvalidColumnType),
-        }
-    }
-
-    fn column_type(&self, idx: i32) -> Result<ValueType> {
-        let col = self.1.get(idx as usize).unwrap();
-        col.decltype
-            .as_ref()
-            .map(|s| s.as_str())
-            .and_then(ValueType::from_str)
-            .ok_or(Error::InvalidColumnType)
     }
 }

--- a/crates/core/src/v2/transaction.rs
+++ b/crates/core/src/v2/transaction.rs
@@ -7,8 +7,8 @@ use super::Connection;
 pub use crate::v1::TransactionBehavior;
 
 pub struct Transaction {
-    pub(super) inner: Box<dyn Tx + Send + Sync>,
-    pub(super) conn: Connection,
+    pub(crate) inner: Box<dyn Tx + Send + Sync>,
+    pub(crate) conn: Connection,
 }
 
 impl Transaction {
@@ -31,7 +31,7 @@ impl Deref for Transaction {
 }
 
 #[async_trait::async_trait]
-pub(super) trait Tx {
+pub(crate) trait Tx {
     async fn commit(&mut self) -> Result<()>;
     async fn rollback(&mut self) -> Result<()>;
 }


### PR DESCRIPTION
This implements write delegation in the proper way by not leveraging the
internal libsql parser but to use a separate rust one. This allows us
to not corrupt libsql connection state when we want to submit remote
executes.

What this means is there is now a `RemoteConnection` implementation that
wraps the libsql version. It will detect when sql statements are write
based and will submit those against the primary.

Closes https://github.com/libsql/libsql/issues/403