### PR TITLE
libsql/core: Fix Statement::is_read_only() for TX markers

### DIFF
--- a/crates/core/src/replication/parser.rs
+++ b/crates/core/src/replication/parser.rs
@@ -229,9 +229,6 @@ impl Statement {
     }
 
     pub fn is_read_only(&self) -> bool {
-        matches!(
-            self.kind,
-            StmtKind::Read | StmtKind::TxnEnd | StmtKind::TxnBegin
-        )
+        matches!(self.kind, StmtKind::Read)
     }
 }


### PR DESCRIPTION
Even if all SQL statements are read-only, if you start a transaction, it's safest to execute it remotely for correctness.